### PR TITLE
ci: enable auto-merge for docs PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,7 @@ jobs:
           cp -r generated-docs/aws/* carina-main/docs/src/content/docs/reference/providers/aws/
 
       - name: Create PR
+        id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
           path: carina-main
@@ -46,3 +47,10 @@ jobs:
 
             Triggered by ${{ github.event.head_commit.url }}
           commit-message: "docs: update aws provider reference"
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        run: gh pr merge --auto --merge ${{ steps.create-pr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_PR_TOKEN }}
+        working-directory: carina-main


### PR DESCRIPTION
## Summary

- Add auto-merge step to docs workflow so that generated docs PRs are automatically merged after CI passes in the main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)