### PR TITLE
fix: gitignore downloaded smithy model fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 generated-docs/
+carina-provider-aws/tests/fixtures/smithy/


### PR DESCRIPTION
## Summary

- Add `carina-provider-aws/tests/fixtures/smithy/` to `.gitignore`
- These files are downloaded by `scripts/download-smithy-models.sh` and should not be tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)