### PR TITLE
fix: correct examples path and preserve index.md in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,9 +30,14 @@ jobs:
 
       - name: Copy generated docs
         run: |
-          rm -rf carina-main/docs/src/content/docs/reference/providers/aws/
-          mkdir -p carina-main/docs/src/content/docs/reference/providers/aws/
-          cp -r generated-docs/aws/* carina-main/docs/src/content/docs/reference/providers/aws/
+          DEST=carina-main/docs/src/content/docs/reference/providers/aws
+          mkdir -p "$DEST"
+          # Remove only codegen-generated service directories, preserve index.md
+          for dir in generated-docs/aws/*/; do
+            service=$(basename "$dir")
+            rm -rf "$DEST/$service"
+          done
+          cp -r generated-docs/aws/* "$DEST/"
 
       - name: Create PR
         id: create-pr

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 DOCS_DIR="$PROJECT_ROOT/generated-docs/aws"
-EXAMPLES_DIR="$PROJECT_ROOT/carina-provider-aws/examples"
+EXAMPLES_DIR="$PROJECT_ROOT/examples"
 rm -rf "$DOCS_DIR"
 mkdir -p "$DOCS_DIR"
 


### PR DESCRIPTION
## Summary

- Fix `EXAMPLES_DIR` path in `generate-docs.sh` (`carina-provider-aws/examples` → `examples`)
- Update docs workflow to only delete codegen-generated service directories, preserving hand-written `index.md`

## Problem

PR carina-rs/carina#1465 was missing Example sections and deleted `index.md` because:
1. `EXAMPLES_DIR` pointed to wrong path after workspace conversion
2. `rm -rf` deleted the entire provider docs directory including hand-written `index.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)