### PR TITLE
fix: add union-type to WIT and fix cross-provider WASM path

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -403,7 +403,7 @@ fi
 
 # ── Provider source injection ────────────────────────────────────────
 AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
-AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
+AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/../carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 
 # inject_provider_source: Create a temp copy of a .crn file with source/version
 # injected into provider blocks. Prints the temp file path.

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -29,7 +29,7 @@ fi
 # Use WASM provider binaries (carina CLI only supports WASM providers)
 # Build with: cargo build -p carina-provider-aws --target wasm32-wasip2 --release
 AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
-AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
+AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/../carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 
 # inject_provider_source: Create a temp copy of a .crn file with source/version
 # injected into provider blocks. Prints the temp file path.

--- a/carina-plugin-wit/wit/types.wit
+++ b/carina-plugin-wit/wit/types.wit
@@ -70,6 +70,7 @@ interface types {
         list-type(string),
         /// JSON-encoded attribute-type for the value type
         map-type(string),
+        union-type(string),
         struct-type(struct-def),
     }
 


### PR DESCRIPTION
## Summary
- Add `union-type(string)` to the `attribute-type` variant in `carina-plugin-wit/wit/types.wit` (carina-rs/carina#1491)
- Fix `AWSCC_PROVIDER_BIN` default path in `_helpers.sh` and `run-tests.sh` to look in sibling repo (`../carina-provider-awscc/`) instead of the current repo

Closes #18

## Test plan
- [ ] Verify WIT compiles correctly with `cargo build`
- [ ] Verify acceptance tests can locate the AWSCC WASM binary from sibling repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)