### PR TITLE
fix: exit code 144 in full/deep-cleanup/cleanup modes

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -178,7 +178,7 @@ if [ "$COMMAND" != "validate" ]; then
     if ! acquire_all_account_locks; then
         exit 1
     fi
-    trap 'trap "" TERM; kill 0 2>/dev/null; release_account_locks' EXIT
+    trap 'trap - INT TERM; trap "" TERM; kill 0 2>/dev/null; release_account_locks' EXIT
 fi
 
 # Validate command
@@ -534,7 +534,7 @@ if [ "$COMMAND" = "cleanup" ]; then
     echo ""
 
     WORK_DIR=$(mktemp -d)
-    trap 'trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'trap - INT TERM; trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts
     echo "Pre-authenticating AWS accounts..."
@@ -656,7 +656,7 @@ if [ "$COMMAND" = "full" ]; then
     trap cleanup_main INT TERM
 
     # Clean up temp dir and release locks on normal exit
-    trap 'trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'trap - INT TERM; trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts sequentially to avoid opening
     # multiple SSO browser tabs simultaneously
@@ -858,7 +858,7 @@ echo ""
 # (plan/apply/destroy) to prevent cross-contamination between tests (issue #839)
 if [ "$COMMAND" != "validate" ]; then
     WORK_DIR=$(mktemp -d)
-    trap 'trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'trap - INT TERM; trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 fi
 
 PASSED=0


### PR DESCRIPTION
## Summary
- Add `trap - INT TERM` before `trap "" TERM` in all EXIT traps to unregister `cleanup_main` before `kill 0` sends SIGTERM
- PR #32 fixed validate mode but full/deep-cleanup/cleanup modes still exited 144 because `cleanup_main` (the INT/TERM handler) was firing during the EXIT trap's `kill 0`, calling `exit 1` which resulted in signal 128+16=144

## Test plan
- [x] Verified `validate` mode still exits 0 (awscc repo)
- [ ] Verify `full` mode exits with correct code (requires AWS credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)