### PR TITLE
fix: multi-step test scripts pass directory to carina CLI

### DIFF
--- a/acceptance-tests/create_before_destroy/run.sh
+++ b/acceptance-tests/create_before_destroy/run.sh
@@ -218,7 +218,7 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -227,7 +227,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -240,7 +240,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply replace (create_before_destroy)" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -253,7 +253,7 @@ run_test() {
     if ! assert_identifiers "assert: identifiers changed after replace" "$ids_after_step1" "$ids_after_step2" "different"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -262,7 +262,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after replace" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -272,14 +272,14 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$step1" "$step2"
+    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }

--- a/acceptance-tests/in_place_update/run.sh
+++ b/acceptance-tests/in_place_update/run.sh
@@ -216,7 +216,7 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -225,7 +225,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -238,7 +238,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply in-place update" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -251,7 +251,7 @@ run_test() {
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -260,7 +260,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -270,14 +270,14 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$step1" "$step2"
+    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -31,13 +31,14 @@ fi
 AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
 AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/../carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 
-# inject_provider_source: Create a temp copy of a .crn file with source/version
-# injected into provider blocks. Prints the temp file path.
+# inject_provider_source: Create a temp directory containing a .crn file with
+# source/version injected into provider blocks. Prints the temp directory path.
+# carina CLI expects a directory path, not a file path.
 # Args: original_crn_file
 inject_provider_source() {
     local original="$1"
-    local tmp_file
-    tmp_file=$(mktemp).crn
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
 
     sed \
         -e '/^provider aws {/a\
@@ -46,9 +47,9 @@ inject_provider_source() {
         -e '/^provider awscc {/a\
   source = "file://'"$AWSCC_PROVIDER_BIN"'"\
   version = "0.1.0"' \
-        "$original" > "$tmp_file"
+        "$original" > "$tmp_dir/main.crn"
 
-    echo "$tmp_file"
+    echo "$tmp_dir"
 }
 
 # inject_provider_source_dir: Inject source/version into all .crn files in a directory (in-place).

--- a/acceptance-tests/tag_deletion/run.sh
+++ b/acceptance-tests/tag_deletion/run.sh
@@ -167,7 +167,7 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial (two tags)" "apply" "$step1" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -176,7 +176,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -185,7 +185,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply tag removal" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -194,7 +194,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after tag removal" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -204,14 +204,14 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$step1" "$step2"
+    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }


### PR DESCRIPTION
## Summary
- Changed `inject_provider_source` in `_helpers.sh` to create a temp directory containing `main.crn` instead of returning a bare temp file path
- Updated all multi-step `run.sh` scripts to use `rm -rf` for cleanup since injected paths are now directories
- Fixes all multi-step tests: create_before_destroy, tag_deletion, in_place_update

## Background
carina CLI expects a directory path, not a file path. The multi-step test scripts were calling `inject_provider_source` which returned a temp `.crn` file path, then passing that directly to `carina apply/plan/destroy`, causing:
```
Error: expected directory, got file: /var/folders/.../tmp.xxx.crn
```

## Test plan
- [ ] Run `aws-vault exec carina-test-000 -- ./acceptance-tests/tag_deletion/run.sh` and verify it gets past the "expected directory" error
- [ ] Verify inject_provider_source returns a directory containing main.crn

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)