### PR TITLE
fix: read provider version from Cargo.toml instead of hardcoding

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -415,6 +415,9 @@ fi
 AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
 AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/../carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 
+# Read provider version from workspace Cargo.toml to avoid hardcoding
+PROVIDER_VERSION=$(grep '^version = ' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
+
 # Validate that provider binaries are WASM components, not native binaries.
 # Native binaries are no longer supported and will cause cryptic linker errors.
 for bin_var in AWS_PROVIDER_BIN AWSCC_PROVIDER_BIN; do
@@ -438,10 +441,10 @@ inject_provider_source() {
     sed \
         -e '/^provider aws {/a\
   source = "file://'"$AWS_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
         -e '/^provider awscc {/a\
   source = "file://'"$AWSCC_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
         "$original" > "$tmp_file"
 
     echo "$tmp_file"

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -30,6 +30,7 @@ fi
 # Build with: cargo build -p carina-provider-aws --target wasm32-wasip2 --release
 AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
 AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/../carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
+PROVIDER_VERSION=$(grep '^version = ' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
 
 # inject_provider_source: Create a temp directory containing a .crn file with
 # source/version injected into provider blocks. Prints the temp directory path.
@@ -43,10 +44,10 @@ inject_provider_source() {
     sed \
         -e '/^provider aws {/a\
   source = "file://'"$AWS_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
         -e '/^provider awscc {/a\
   source = "file://'"$AWSCC_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
         "$original" > "$tmp_dir/main.crn"
 
     echo "$tmp_dir"
@@ -64,10 +65,10 @@ inject_provider_source_dir() {
         sed -i '' \
             -e '/^provider aws {/a\
   source = "file://'"$AWS_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
             -e '/^provider awscc {/a\
   source = "file://'"$AWSCC_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
             "$crn_file"
     done
 }


### PR DESCRIPTION
## Summary

- Read `PROVIDER_VERSION` from workspace `Cargo.toml` instead of hardcoding `"0.1.0"`
- Updated both `run-tests.sh` and `shared/_helpers.sh`

After bumping to v0.2.0, acceptance tests failed because `inject_provider_source()` injected `version = "0.1.0"` but the provider reported `0.2.0`, triggering version constraint rejection.

Closes #38

## Test plan

- [x] Verified `PROVIDER_VERSION` extraction produces `0.2.0`
- [x] Verified `sed` injection produces `version = "0.2.0"` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)