### PR TITLE
style: use single quotes for literal strings in .crn files

### DIFF
--- a/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
@@ -8,12 +8,12 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.200.0.0/16"
+  cidr_block           = '10.200.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Name        = "carina-acc-test-cbd-vpc"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-vpc'
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -8,7 +8,7 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.201.0.0/16"
+  cidr_block           = '10.201.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
@@ -17,7 +17,7 @@ aws.ec2.vpc {
   }
 
   tags = {
-    Name        = "carina-acc-test-cbd-vpc"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-vpc'
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
@@ -7,13 +7,13 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 aws.ec2.egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_eip/basic.crn
+++ b/acceptance-tests/ec2_eip/basic.crn
@@ -10,6 +10,6 @@ aws.ec2.eip {
   domain = aws.ec2.eip.Domain.vpc
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_flow_log/basic.crn
+++ b/acceptance-tests/ec2_flow_log/basic.crn
@@ -8,40 +8,40 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let log_group = aws.logs.log_group {
-  log_group_name    = "/acceptance-test/vpc-flow-logs"
+  log_group_name    = '/acceptance-test/vpc-flow-logs'
   retention_in_days = 1
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let flow_log_role = aws.iam.role {
-  role_name = "acceptance-test-flow-log-role"
+  role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "vpc-flow-logs.amazonaws.com"
+        service = 'vpc-flow-logs.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -54,6 +54,6 @@ aws.ec2.flow_log {
   deliver_logs_permission_arn = flow_log_role.arn
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_internet_gateway/basic.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -18,6 +18,6 @@ aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_nat_gateway/basic.crn
+++ b/acceptance-tests/ec2_nat_gateway/basic.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -18,17 +18,17 @@ aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let subnet = aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -36,7 +36,7 @@ let eip = aws.ec2.eip {
   domain = aws.ec2.eip.Domain.vpc
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -46,6 +46,6 @@ aws.ec2.nat_gateway {
   connectivity_type = aws.ec2.nat_gateway.ConnectivityType.public
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_route/igw.crn
+++ b/acceptance-tests/ec2_route/igw.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -18,7 +18,7 @@ let igw = aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -26,12 +26,12 @@ let rt = aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw.internet_gateway_id
 }

--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -14,10 +14,10 @@ provider awscc {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -25,22 +25,22 @@ aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let subnet = aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 let nat_gw = awscc.ec2.nat_gateway {
@@ -52,12 +52,12 @@ let rt = aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw.nat_gateway_id
 }

--- a/acceptance-tests/ec2_route_table/basic.crn
+++ b/acceptance-tests/ec2_route_table/basic.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -18,6 +18,6 @@ aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -7,35 +7,35 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-sg-ipv6"
-  description = "Acceptance test - IPv6 rules"
+  group_name  = 'carina-acc-test-aws-sg-ipv6'
+  description = 'Acceptance test - IPv6 rules'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from IPv6"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from IPv6'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ipv6   = "::/0"
+  cidr_ipv6   = '::/0'
 }
 
 aws.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow all IPv6 outbound"
+  description = 'Allow all IPv6 outbound'
   ip_protocol = all
-  cidr_ipv6   = "::/0"
+  cidr_ipv6   = '::/0'
 }

--- a/acceptance-tests/ec2_security_group/with_egress.crn
+++ b/acceptance-tests/ec2_security_group/with_egress.crn
@@ -7,35 +7,35 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-sg-egress"
-  description = "Acceptance test - egress rules"
+  group_name  = 'carina-acc-test-aws-sg-egress'
+  description = 'Acceptance test - egress rules'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow HTTPS outbound"
+  description = 'Allow HTTPS outbound'
   ip_protocol = tcp
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }
 
 aws.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow all to private ranges"
+  description = 'Allow all to private ranges'
   ip_protocol = all
-  cidr_ip     = "10.0.0.0/8"
+  cidr_ip     = '10.0.0.0/8'
 }

--- a/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -7,37 +7,37 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-sg-ingress"
-  description = "Acceptance test - ingress rules"
+  group_name  = 'carina-acc-test-aws-sg-ingress'
+  description = 'Acceptance test - ingress rules'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTP"
-  ip_protocol = "tcp"
+  description = 'Allow HTTP'
+  ip_protocol = 'tcp'
   from_port   = 80
   to_port     = 80
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }
 
 aws.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }

--- a/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -10,28 +10,28 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-sg-egress"
-  description = "SG for egress rule test"
+  group_name  = 'carina-acc-test-aws-sg-egress'
+  description = 'SG for egress rule test'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow HTTPS outbound"
+  description = 'Allow HTTPS outbound'
   ip_protocol = tcp
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }

--- a/acceptance-tests/ec2_security_group_egress/dest_sg.crn
+++ b/acceptance-tests/ec2_security_group_egress/dest_sg.crn
@@ -7,37 +7,37 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let source_sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-egress-src"
-  description = "Source security group"
+  group_name  = 'carina-acc-test-aws-egress-src'
+  description = 'Source security group'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let dest_sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-egress-dst"
-  description = "Destination security group"
+  group_name  = 'carina-acc-test-aws-egress-dst'
+  description = 'Destination security group'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_egress {
   group_id                      = source_sg.group_id
-  description                   = "Allow HTTPS to destination SG"
-  ip_protocol                   = "tcp"
+  description                   = 'Allow HTTPS to destination SG'
+  ip_protocol                   = 'tcp'
   from_port                     = 443
   to_port                       = 443
   destination_security_group_id = dest_sg.group_id

--- a/acceptance-tests/ec2_security_group_egress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_egress/ipv6.crn
@@ -7,26 +7,26 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-egress-ipv6"
-  description = "SG for IPv6 egress rule test"
+  group_name  = 'carina-acc-test-aws-egress-ipv6'
+  description = 'SG for IPv6 egress rule test'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow all IPv6 outbound"
+  description = 'Allow all IPv6 outbound'
   ip_protocol = all
-  cidr_ipv6   = "::/0"
+  cidr_ipv6   = '::/0'
 }

--- a/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -7,28 +7,28 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-sg-ingress"
-  description = "SG for ingress rule test"
+  group_name  = 'carina-acc-test-aws-sg-ingress'
+  description = 'SG for ingress rule test'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from VPC'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }

--- a/acceptance-tests/ec2_security_group_ingress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_ingress/ipv6.crn
@@ -7,28 +7,28 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-ingress-ipv6"
-  description = "SG for IPv6 ingress rule test"
+  group_name  = 'carina-acc-test-aws-ingress-ipv6'
+  description = 'SG for IPv6 ingress rule test'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from IPv6"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from IPv6'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ipv6   = "::/0"
+  cidr_ipv6   = '::/0'
 }

--- a/acceptance-tests/ec2_security_group_ingress/source_sg.crn
+++ b/acceptance-tests/ec2_security_group_ingress/source_sg.crn
@@ -7,37 +7,37 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let source_sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-ingress-src"
-  description = "Source security group"
+  group_name  = 'carina-acc-test-aws-ingress-src'
+  description = 'Source security group'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let dest_sg = aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-ingress-dst"
-  description = "Destination security group"
+  group_name  = 'carina-acc-test-aws-ingress-dst'
+  description = 'Destination security group'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group_ingress {
   group_id                 = dest_sg.group_id
-  description              = "Allow HTTPS from source SG"
-  ip_protocol              = "tcp"
+  description              = 'Allow HTTPS from source SG'
+  ip_protocol              = 'tcp'
   from_port                = 443
   to_port                  = 443
   source_security_group_id = source_sg.group_id

--- a/acceptance-tests/ec2_subnet/basic.crn
+++ b/acceptance-tests/ec2_subnet/basic.crn
@@ -7,19 +7,19 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_subnet/ipv6.crn
+++ b/acceptance-tests/ec2_subnet/ipv6.crn
@@ -7,20 +7,20 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.subnet {
   vpc_id                          = vpc.vpc_id
-  cidr_block                      = "10.0.1.0/24"
+  cidr_block                      = '10.0.1.0/24'
   availability_zone               = aws.AvailabilityZone.ap_northeast_1a
   assign_ipv6_address_on_creation = false
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -7,18 +7,18 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   private_dns_name_options_on_launch = {
@@ -27,6 +27,6 @@ aws.ec2.subnet {
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_subnet_route_table_association/basic.crn
+++ b/acceptance-tests/ec2_subnet_route_table_association/basic.crn
@@ -7,20 +7,20 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let subnet = aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -28,7 +28,7 @@ let rt = aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 

--- a/acceptance-tests/ec2_transit_gateway/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway/basic.crn
@@ -7,9 +7,9 @@ provider aws {
 }
 
 aws.ec2.transit_gateway {
-  description = "Acceptance test Transit Gateway"
+  description = 'Acceptance test Transit Gateway'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -7,17 +7,17 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let subnet = aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 }
 
 let tgw = aws.ec2.transit_gateway {
-  description = "Acceptance test Transit Gateway"
+  description = 'Acceptance test Transit Gateway'
 }
 
 aws.ec2.transit_gateway_attachment {
@@ -26,6 +26,6 @@ aws.ec2.transit_gateway_attachment {
   vpc_id             = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_vpc/basic.crn
+++ b/acceptance-tests/ec2_vpc/basic.crn
@@ -7,12 +7,12 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_vpc_endpoint/basic.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/basic.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -18,17 +18,17 @@ let rt = aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.vpc_endpoint {
   vpc_id            = vpc.vpc_id
-  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = aws.ec2.vpc_endpoint.VpcEndpointType.Gateway
   route_table_ids   = [rt.route_table_id]
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_vpc_gateway_attachment/basic.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/basic.crn
@@ -7,16 +7,16 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let igw = aws.ec2.internet_gateway {
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 

--- a/acceptance-tests/ec2_vpc_peering_connection/basic.crn
+++ b/acceptance-tests/ec2_vpc_peering_connection/basic.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 let vpc1 = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let vpc2 = aws.ec2.vpc {
-  cidr_block = "10.1.0.0/16"
+  cidr_block = '10.1.0.0/16'
 }
 
 aws.ec2.vpc_peering_connection {
@@ -19,6 +19,6 @@ aws.ec2.vpc_peering_connection {
   peer_vpc_id = vpc2.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_vpn_gateway/basic.crn
+++ b/acceptance-tests/ec2_vpn_gateway/basic.crn
@@ -10,6 +10,6 @@ aws.ec2.vpn_gateway {
   type = aws.ec2.vpn_gateway.Type.ipsec.1
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/iam_role/basic.crn
+++ b/acceptance-tests/iam_role/basic.crn
@@ -7,22 +7,22 @@ provider aws {
 }
 
 aws.iam.role {
-  role_name = "carina-acceptance-test-role"
+  role_name = 'carina-acceptance-test-role'
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
       principal = {
-        service = "ec2.amazonaws.com"
+        service = 'ec2.amazonaws.com'
       }
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
-  description = "Carina acceptance test role"
-  path = "/"
+  description = 'Carina acceptance test role'
+  path = '/'
   max_session_duration = 7200
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -14,10 +14,10 @@ provider awscc {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -25,22 +25,22 @@ let igw = aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let subnet = aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {
@@ -52,12 +52,12 @@ let rt = aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "10.1.0.0/16"
+  destination_cidr_block = '10.1.0.0/16'
   gateway_id             = igw.internet_gateway_id
 }

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -14,10 +14,10 @@ provider awscc {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -25,22 +25,22 @@ aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let subnet = aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 let nat_gw = awscc.ec2.nat_gateway {
@@ -52,12 +52,12 @@ let rt = aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "10.1.0.0/16"
+  destination_cidr_block = '10.1.0.0/16'
   nat_gateway_id         = nat_gw.nat_gateway_id
 }

--- a/acceptance-tests/in_place_update/ec2_route_table_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step1.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.103.0.0/16"
+  cidr_block = '10.103.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -18,6 +18,6 @@ aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_route_table_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step2.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.103.0.0/16"
+  cidr_block = '10.103.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -18,7 +18,7 @@ aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_security_group_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step1.crn
@@ -7,19 +7,19 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.102.0.0/16"
+  cidr_block = '10.102.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-sg-update"
-  description = "carina acceptance test - in-place update"
+  group_name  = 'carina-acc-test-aws-sg-update'
+  description = 'carina acceptance test - in-place update'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_security_group_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step2.crn
@@ -7,20 +7,20 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.102.0.0/16"
+  cidr_block = '10.102.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group {
-  group_name  = "carina-acc-test-aws-sg-update"
-  description = "carina acceptance test - in-place update"
+  group_name  = 'carina-acc-test-aws-sg-update'
+  description = 'carina acceptance test - in-place update'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_subnet_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step1.crn
@@ -7,20 +7,20 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.101.0.0/16"
+  cidr_block = '10.101.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.101.1.0/24"
+  cidr_block              = '10.101.1.0/24'
   availability_zone       = aws.AvailabilityZone.ap_northeast_1a
   map_public_ip_on_launch = false
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_subnet_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step2.crn
@@ -7,20 +7,20 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.101.0.0/16"
+  cidr_block = '10.101.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.101.1.0/24"
+  cidr_block              = '10.101.1.0/24'
   availability_zone       = aws.AvailabilityZone.ap_northeast_1a
   map_public_ip_on_launch = true
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_vpc_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step1.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = false
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_vpc_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step2.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/s3_bucket_acl_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_acl_step1.crn
@@ -7,12 +7,12 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-s3-acl-update"
+  bucket = 'carina-acc-test-aws-s3-acl-update'
 
   acl              = aws.s3.bucket.ACL.private
   object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/s3_bucket_acl_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_acl_step2.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-s3-acl-update"
+  bucket = 'carina-acc-test-aws-s3-acl-update'
 
   object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-s3-update"
+  bucket = 'carina-acc-test-aws-s3-update'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-s3-update"
+  bucket = 'carina-acc-test-aws-s3-update'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Suspended
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/logs_log_group/basic.crn
+++ b/acceptance-tests/logs_log_group/basic.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 aws.logs.log_group {
-  log_group_name = "/carina/acceptance-test"
+  log_group_name = '/carina/acceptance-test'
   retention_in_days = 7
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/s3_bucket/acl_private.crn
+++ b/acceptance-tests/s3_bucket/acl_private.crn
@@ -8,12 +8,12 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-s3-acl-private"
+  bucket = 'carina-acc-test-aws-s3-acl-private'
 
   acl              = aws.s3.bucket.ACL.private
   object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/s3_bucket/basic.crn
+++ b/acceptance-tests/s3_bucket/basic.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-s3-basic-v2"
+  bucket = 'carina-acc-test-aws-s3-basic-v2'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/s3_bucket/object_ownership.crn
+++ b/acceptance-tests/s3_bucket/object_ownership.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-s3-object-ownership"
+  bucket = 'carina-acc-test-aws-s3-object-ownership'
 
   object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/s3_bucket/versioning.crn
+++ b/acceptance-tests/s3_bucket/versioning.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-s3-versioning"
+  bucket = 'carina-acc-test-aws-s3-versioning'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_route_table_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_route_table_step1.crn
@@ -8,10 +8,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.104.0.0/16"
+  cidr_block = '10.104.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -19,7 +19,7 @@ aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_route_table_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_route_table_step2.crn
@@ -9,10 +9,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.104.0.0/16"
+  cidr_block = '10.104.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
@@ -20,6 +20,6 @@ aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_route_table_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_route_table_step3.crn
@@ -10,10 +10,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.104.0.0/16"
+  cidr_block = '10.104.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 

--- a/acceptance-tests/tag_deletion/ec2_security_group_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_security_group_step1.crn
@@ -8,20 +8,20 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.106.0.0/16"
+  cidr_block = '10.106.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group {
-  group_name  = "carina-tag-deletion-test"
-  description = "Carina acceptance test for tag deletion"
+  group_name  = 'carina-tag-deletion-test'
+  description = 'Carina acceptance test for tag deletion'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_security_group_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_security_group_step2.crn
@@ -9,19 +9,19 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.106.0.0/16"
+  cidr_block = '10.106.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group {
-  group_name  = "carina-tag-deletion-test"
-  description = "Carina acceptance test for tag deletion"
+  group_name  = 'carina-tag-deletion-test'
+  description = 'Carina acceptance test for tag deletion'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_security_group_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_security_group_step3.crn
@@ -10,15 +10,15 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.106.0.0/16"
+  cidr_block = '10.106.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.security_group {
-  group_name  = "carina-tag-deletion-test"
-  description = "Carina acceptance test for tag deletion"
+  group_name  = 'carina-tag-deletion-test'
+  description = 'Carina acceptance test for tag deletion'
   vpc_id      = vpc.vpc_id
 }

--- a/acceptance-tests/tag_deletion/ec2_subnet_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step1.crn
@@ -8,20 +8,20 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.105.0.0/16"
+  cidr_block = '10.105.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.105.1.0/24"
+  cidr_block        = '10.105.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_subnet_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step2.crn
@@ -9,19 +9,19 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.105.0.0/16"
+  cidr_block = '10.105.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.105.1.0/24"
+  cidr_block        = '10.105.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_subnet_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step3.crn
@@ -10,15 +10,15 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.105.0.0/16"
+  cidr_block = '10.105.0.0/16'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }
 
 aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.105.1.0/24"
+  cidr_block        = '10.105.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 }

--- a/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
@@ -8,13 +8,13 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
@@ -9,12 +9,12 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
@@ -9,7 +9,7 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default

--- a/acceptance-tests/tag_deletion/s3_bucket_step1.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step1.crn
@@ -8,12 +8,12 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-tag-del"
+  bucket = 'carina-acc-test-aws-tag-del'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 }

--- a/acceptance-tests/tag_deletion/s3_bucket_step2.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step2.crn
@@ -10,11 +10,11 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-tag-del"
+  bucket = 'carina-acc-test-aws-tag-del'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/s3_bucket_step3.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step3.crn
@@ -9,7 +9,7 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-acc-test-aws-tag-del"
+  bucket = 'carina-acc-test-aws-tag-del'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 }

--- a/examples/ec2_internet_gateway/main.crn
+++ b/examples/ec2_internet_gateway/main.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
@@ -18,6 +18,6 @@ aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }

--- a/examples/ec2_route/main.crn
+++ b/examples/ec2_route/main.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
@@ -18,7 +18,7 @@ let igw = aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
@@ -26,12 +26,12 @@ let rt = aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw.internet_gateway_id
 }

--- a/examples/ec2_route_table/main.crn
+++ b/examples/ec2_route_table/main.crn
@@ -7,10 +7,10 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
@@ -18,6 +18,6 @@ aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }

--- a/examples/ec2_security_group/main.crn
+++ b/examples/ec2_security_group/main.crn
@@ -7,19 +7,19 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.security_group {
-  group_name  = "carina-example-sg"
-  description = "Example security group"
+  group_name  = 'carina-example-sg'
+  description = 'Example security group'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }

--- a/examples/ec2_security_group_egress/main.crn
+++ b/examples/ec2_security_group_egress/main.crn
@@ -7,28 +7,28 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-example-sg-egress"
-  description = "SG for egress rule example"
+  group_name  = 'carina-example-sg-egress'
+  description = 'SG for egress rule example'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow HTTPS outbound"
+  description = 'Allow HTTPS outbound'
   ip_protocol = tcp
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }

--- a/examples/ec2_security_group_ingress/main.crn
+++ b/examples/ec2_security_group_ingress/main.crn
@@ -7,28 +7,28 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-example-sg-ingress"
-  description = "SG for ingress rule example"
+  group_name  = 'carina-example-sg-ingress'
+  description = 'SG for ingress rule example'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC"
+  description = 'Allow HTTPS from VPC'
   ip_protocol = tcp
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }

--- a/examples/ec2_subnet/main.crn
+++ b/examples/ec2_subnet/main.crn
@@ -7,19 +7,19 @@ provider aws {
 }
 
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }

--- a/examples/ec2_vpc/main.crn
+++ b/examples/ec2_vpc/main.crn
@@ -7,12 +7,12 @@ provider aws {
 }
 
 aws.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }

--- a/examples/s3_bucket/main.crn
+++ b/examples/s3_bucket/main.crn
@@ -7,11 +7,11 @@ provider aws {
 }
 
 aws.s3.bucket {
-  bucket = "carina-example-s3-bucket"
+  bucket = 'carina-example-s3-bucket'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }


### PR DESCRIPTION
## Summary
- Replace double quotes with single quotes in all `.crn` files under `acceptance-tests/` and `examples/` directories
- 74 files updated, no functional changes (all strings are literals with no variable expansion)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)