### PR TITLE
ci: upload WASM artifact for revision-based provider resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,7 @@ jobs:
         run: |
           cargo install --git https://github.com/mizzy/vela vela-cli --quiet
           vela optimize target/wasm32-wasip2/release/carina-provider-aws.wasm -o target/wasm32-wasip2/release/carina-provider-aws.wasm
+      - uses: actions/upload-artifact@v4
+        with:
+          name: carina-provider-aws.wasm
+          path: target/wasm32-wasip2/release/carina-provider-aws.wasm


### PR DESCRIPTION
Closes #57

## Summary

- Add `actions/upload-artifact@v4` to the `wasm-build` CI job
- Uploads the optimized WASM binary as `carina-provider-aws.wasm`
- Enables `revision = 'main'` in provider blocks to resolve the WASM binary from CI artifacts

## Test plan

- [x] CI will verify the workflow syntax and run the wasm-build job
- After merge, `revision = 'main'` should resolve the WASM artifact from CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)