### PR TITLE
feat: validate tags map keys to detect Key/Value pair list structure

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -132,6 +132,27 @@ pub fn tags_type() -> AttributeType {
     AttributeType::Map(Box::new(AttributeType::String))
 }
 
+/// Validate that a tags map does not use Key/Value pair list structure.
+///
+/// Detects when a tags map contains both `key` and `value` as keys (case-insensitive),
+/// which indicates the user wrote a Key/Value pair list instead of a flat map:
+///   Wrong: `tags = { key = 'Name', value = '...' }`
+///   Right: `tags = { Name = '...' }`
+pub fn validate_tags_map(
+    attributes: &std::collections::HashMap<String, Value>,
+) -> Result<(), Vec<carina_core::schema::TypeError>> {
+    if let Some(Value::Map(map)) = attributes.get("tags") {
+        let has_key = map.keys().any(|k| k.eq_ignore_ascii_case("key"));
+        let has_value = map.keys().any(|k| k.eq_ignore_ascii_case("value"));
+        if has_key && has_value {
+            return Err(vec![carina_core::schema::TypeError::ResourceValidationFailed {
+                message: "tags map contains both 'key' and 'value' as keys, which looks like a Key/Value pair list. Use flat map syntax instead: tags = { Name = '...' }".to_string(),
+            }]);
+        }
+    }
+    Ok(())
+}
+
 // ========== Resource ID validators ==========
 
 /// Validate a generic AWS resource ID format: `{prefix}-{hex}` where hex is 8+ hex digits.

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -575,6 +575,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
 
     if needs_tags_type {
         code.push_str("use super::tags_type;\n");
+        code.push_str("use super::validate_tags_map;\n");
     }
     if has_ranged_ints {
         code.push_str("use carina_core::resource::Value;\n");
@@ -767,6 +768,11 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
              \x20               .with_provider_name(\"Tags\"),\n\
              \x20       )\n",
         );
+    }
+
+    // Tags validator
+    if res.has_tags {
+        code.push_str("\x20       .with_validator(validate_tags_map)\n");
     }
 
     // Close schema and config

--- a/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
 /// Returns the schema config for ec2.egress_only_internet_gateway (Smithy: com.amazonaws.ec2)
@@ -37,7 +38,8 @@ pub fn ec2_egress_only_internet_gateway_config() -> AwsSchemaConfig {
                 AttributeSchema::new("tags", tags_type())
                     .with_description("The tags for the resource.")
                     .with_provider_name("Tags"),
-            ),
+            )
+            .with_validator(validate_tags_map),
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/eip.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_DOMAIN: &[&str] = &["standard", "vpc"];
@@ -56,6 +57,7 @@ pub fn ec2_eip_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_LOG_DESTINATION_TYPE: &[&str] = &["cloud-watch-logs", "kinesis-data-firehose", "s3"];
@@ -110,6 +111,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
 /// Returns the schema config for ec2.internet_gateway (Smithy: com.amazonaws.ec2)
@@ -25,7 +26,8 @@ pub fn ec2_internet_gateway_config() -> AwsSchemaConfig {
                 AttributeSchema::new("tags", tags_type())
                     .with_description("The tags for the resource.")
                     .with_provider_name("Tags"),
-            ),
+            )
+            .with_validator(validate_tags_map),
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
 const VALID_AVAILABILITY_MODE: &[&str] = &["regional", "zonal"];
@@ -90,6 +91,7 @@ pub fn ec2_nat_gateway_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
 /// Returns the schema config for ec2.route_table (Smithy: com.amazonaws.ec2)
@@ -32,7 +33,8 @@ pub fn ec2_route_table_config() -> AwsSchemaConfig {
                 AttributeSchema::new("tags", tags_type())
                     .with_description("The tags for the resource.")
                     .with_provider_name("Tags"),
-            ),
+            )
+            .with_validator(validate_tags_map),
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 /// Returns the schema config for ec2.security_group (Smithy: com.amazonaws.ec2)
@@ -46,6 +47,7 @@ pub fn ec2_security_group_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
@@ -169,6 +170,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
 const VALID_AUTO_ACCEPT_SHARED_ATTACHMENTS: &[&str] = &["disable", "enable"];
@@ -99,6 +100,7 @@ pub fn ec2_transit_gateway_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_APPLIANCE_MODE_SUPPORT: &[&str] = &["disable", "enable"];
@@ -89,6 +90,7 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
@@ -86,6 +87,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
@@ -105,6 +106,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
 /// Returns the schema config for ec2.vpc_peering_connection (Smithy: com.amazonaws.ec2)
@@ -46,6 +47,7 @@ pub fn ec2_vpc_peering_connection_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_TYPE: &[&str] = &["ipsec.1"];
@@ -52,6 +53,7 @@ pub fn ec2_vpn_gateway_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_IAM_USER_ACCESS_TO_BILLING: &[&str] = &["ALLOW", "DENY"];
@@ -98,6 +99,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -6,6 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
+use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_ACL: &[&str] = &[
@@ -115,6 +116,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
                 .with_description("The tags for the resource.")
                 .with_provider_name("Tags"),
         )
+        .with_validator(validate_tags_map)
     }
 }
 


### PR DESCRIPTION
Closes #59

## Summary

- Add `validate_tags_map()` to `carina-aws-types` — detects Key/Value pair list pattern in tags maps
- Update codegen to add `.with_validator(validate_tags_map)` on all resources with `has_tags: true`
- Regenerate all schemas

## Diff review

All generated file changes are:
- `+use super::validate_tags_map;` (import)
- `+.with_validator(validate_tags_map)` (validator)

No attribute changes, no schema structure changes.

## Test plan

- [x] `cargo test` — all 230 tests pass
- [x] Pre-commit checks pass
- [x] Diff reviewed: only validator additions, no unexpected changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)