### PR TITLE
fix: populate name field in StringEnum protocol conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#bd7da981b38e8c9ca48613f6b0eefd394f00e926"
+source = "git+https://github.com/carina-rs/carina#f16990ffe29f635d38d828bd31635e3f8f8a38ae"
 dependencies = [
  "argon2",
  "futures",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#bd7da981b38e8c9ca48613f6b0eefd394f00e926"
+source = "git+https://github.com/carina-rs/carina#f16990ffe29f635d38d828bd31635e3f8f8a38ae"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#bd7da981b38e8c9ca48613f6b0eefd394f00e926"
+source = "git+https://github.com/carina-rs/carina#f16990ffe29f635d38d828bd31635e3f8f8a38ae"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -154,8 +154,8 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
         ProtoAttributeType::Int => CoreAttributeType::Int,
         ProtoAttributeType::Float => CoreAttributeType::Float,
         ProtoAttributeType::Bool => CoreAttributeType::Bool,
-        ProtoAttributeType::StringEnum { values } => CoreAttributeType::StringEnum {
-            name: String::new(),
+        ProtoAttributeType::StringEnum { values, name } => CoreAttributeType::StringEnum {
+            name: name.clone(),
             values: values.clone(),
             namespace: None,
             to_dsl: None,
@@ -233,8 +233,9 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Int => ProtoAttributeType::Int,
         CoreAttributeType::Float => ProtoAttributeType::Float,
         CoreAttributeType::Bool => ProtoAttributeType::Bool,
-        CoreAttributeType::StringEnum { values, .. } => ProtoAttributeType::StringEnum {
+        CoreAttributeType::StringEnum { values, name, .. } => ProtoAttributeType::StringEnum {
             values: values.clone(),
+            name: name.clone(),
         },
         CoreAttributeType::List { inner, ordered } => ProtoAttributeType::List {
             inner: Box::new(core_to_proto_attribute_type(inner)),
@@ -300,5 +301,39 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
             create_timeout_secs: c.create_timeout_secs,
             create_max_retries: c.create_max_retries,
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_enum_name_roundtrip() {
+        let core_type = CoreAttributeType::StringEnum {
+            name: "VersioningStatus".to_string(),
+            values: vec!["Enabled".to_string(), "Suspended".to_string()],
+            namespace: Some("aws.s3.bucket".to_string()),
+            to_dsl: None,
+        };
+        let proto_type = core_to_proto_attribute_type(&core_type);
+        match &proto_type {
+            ProtoAttributeType::StringEnum { values, name } => {
+                assert_eq!(name, "VersioningStatus");
+                assert_eq!(
+                    values,
+                    &vec!["Enabled".to_string(), "Suspended".to_string()]
+                );
+            }
+            _ => panic!("Expected StringEnum"),
+        }
+        let roundtrip = proto_to_core_attribute_type(&proto_type);
+        match roundtrip {
+            CoreAttributeType::StringEnum { name, values, .. } => {
+                assert_eq!(name, "VersioningStatus");
+                assert_eq!(values, vec!["Enabled", "Suspended"]);
+            }
+            _ => panic!("Expected StringEnum"),
+        }
     }
 }


### PR DESCRIPTION
Closes #62

## Summary

- Pass `name` field through `StringEnum` in both `core_to_proto` and `proto_to_core` conversions in `convert.rs`
- Update `Cargo.lock` to latest carina git dependency (which added `name` to protocol's `StringEnum`)
- Add roundtrip test verifying name preservation through both conversion directions

## Context

carina-rs/carina#1635 added a `name` field to the protocol's `StringEnum` for DSL-format LSP completions. The provider was not populating this field during conversion, so WASM-based providers fell back to quoted string completions.

## Test plan

- [x] `cargo test -p carina-provider-aws` — all 137 tests pass
- [x] `cargo clippy -p carina-provider-aws -- -D warnings` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)