### PR TITLE
feat: use ValidatorType for tags validation across WASM boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f16990ffe29f635d38d828bd31635e3f8f8a38ae"
+source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
 dependencies = [
  "argon2",
  "futures",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f16990ffe29f635d38d828bd31635e3f8f8a38ae"
+source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f16990ffe29f635d38d828bd31635e3f8f8a38ae"
+source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -301,6 +301,7 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
             create_timeout_secs: c.create_timeout_secs,
             create_max_retries: c.create_max_retries,
         }),
+        validators: vec![],
     }
 }
 

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -68,9 +68,17 @@ impl CarinaProvider for AwsProcessProvider {
     }
 
     fn schemas(&self) -> Vec<proto::ResourceSchema> {
-        carina_provider_aws::schemas::all_schemas()
+        carina_provider_aws::schemas::generated::configs()
             .iter()
-            .map(convert::core_to_proto_schema)
+            .map(|config| {
+                let mut schema = convert::core_to_proto_schema(&config.schema);
+                if config.has_tags {
+                    schema
+                        .validators
+                        .push(proto::ValidatorType::TagsKeyValueCheck);
+                }
+                schema
+            })
             .collect()
     }
 
@@ -229,3 +237,44 @@ carina_plugin_sdk::export_provider!(AwsProcessProvider, http);
 
 #[cfg(target_arch = "wasm32")]
 fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_plugin_sdk::types::ValidatorType;
+
+    #[test]
+    fn schemas_include_tags_validator_for_tagged_resources() {
+        let provider = AwsProcessProvider::new();
+        let schemas = provider.schemas();
+        let bucket = schemas
+            .iter()
+            .find(|s| s.resource_type == "aws.s3.bucket")
+            .expect("s3.bucket schema should exist");
+        assert!(
+            bucket
+                .validators
+                .contains(&ValidatorType::TagsKeyValueCheck),
+            "s3.bucket should have TagsKeyValueCheck validator"
+        );
+    }
+
+    #[test]
+    fn schemas_exclude_tags_validator_for_untagged_resources() {
+        let provider = AwsProcessProvider::new();
+        let schemas = provider.schemas();
+        let configs = carina_provider_aws::schemas::generated::configs();
+        if let Some(untagged) = configs.iter().find(|c| !c.has_tags) {
+            let schema = schemas
+                .iter()
+                .find(|s| s.resource_type == format!("aws.{}", untagged.resource_type_name))
+                .expect("untagged schema should exist");
+            assert!(
+                !schema
+                    .validators
+                    .contains(&ValidatorType::TagsKeyValueCheck),
+                "untagged resource should not have TagsKeyValueCheck"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #67

## Summary

- Update `schemas()` to set `ValidatorType::TagsKeyValueCheck` on protocol schemas for resources with `has_tags=true`
- Add `validators: vec![]` initialization to `core_to_proto_schema()` for the new protocol field
- Update Cargo.lock to latest carina (which includes `ValidatorType` in `carina-provider-protocol`)

## Context

Matching implementation from carina-rs/carina-provider-awscc#83. carina-rs/carina#1645 added `ValidatorType` enum and host-side validator reconstruction. This PR completes the fix for the aws provider.

## Test plan

- [x] `cargo test -p carina-provider-aws` — all 139 tests pass
- [x] `cargo clippy -p carina-provider-aws -- -D warnings` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)