### PR TITLE
fix: add attribute field to ResourceValidationFailed for tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
+source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
 dependencies = [
  "argon2",
  "futures",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
+source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
+source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -147,6 +147,7 @@ pub fn validate_tags_map(
         if has_key && has_value {
             return Err(vec![carina_core::schema::TypeError::ResourceValidationFailed {
                 message: "tags map contains both 'key' and 'value' as keys, which looks like a Key/Value pair list. Use flat map syntax instead: tags = { Name = '...' }".to_string(),
+                attribute: Some("tags".to_string()),
             }]);
         }
     }


### PR DESCRIPTION
Closes #69

## Summary

Add `attribute: Some("tags".to_string())` to `ResourceValidationFailed` in `validate_tags_map`, required by carina-rs/carina#1647.

## Test plan

- [x] `cargo test -p carina-provider-aws` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)