### PR TITLE
refactor: expose provider config attribute types as data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
+source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
 dependencies = [
  "argon2",
  "futures",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
+source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
+source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-plugin-wit/wit/provider.wit
+++ b/carina-plugin-wit/wit/provider.wit
@@ -7,6 +7,13 @@ interface provider {
     /// Returns JSON-serialized Vec<ResourceSchema>
     schemas: func() -> string;
 
+    /// Returns JSON-serialized HashMap<String, AttributeType> describing
+    /// the provider block's configuration attributes (e.g., `region`).
+    /// The host validates provider config against this schema before
+    /// calling `validate-config`, so DSL format bugs in carina-core are
+    /// fixed on the host without rebuilding providers.
+    provider-config-attribute-types: func() -> string;
+
     validate-config: func(attrs: list<tuple<string, value>>) -> result<_, string>;
     initialize: func(attrs: list<tuple<string, value>>) -> result<_, string>;
 

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -154,10 +154,14 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
         ProtoAttributeType::Int => CoreAttributeType::Int,
         ProtoAttributeType::Float => CoreAttributeType::Float,
         ProtoAttributeType::Bool => CoreAttributeType::Bool,
-        ProtoAttributeType::StringEnum { values, name } => CoreAttributeType::StringEnum {
+        ProtoAttributeType::StringEnum {
+            values,
+            name,
+            namespace,
+        } => CoreAttributeType::StringEnum {
             name: name.clone(),
             values: values.clone(),
-            namespace: None,
+            namespace: namespace.clone(),
             to_dsl: None,
         },
         ProtoAttributeType::List { inner, ordered } => CoreAttributeType::List {
@@ -233,9 +237,15 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Int => ProtoAttributeType::Int,
         CoreAttributeType::Float => ProtoAttributeType::Float,
         CoreAttributeType::Bool => ProtoAttributeType::Bool,
-        CoreAttributeType::StringEnum { values, name, .. } => ProtoAttributeType::StringEnum {
+        CoreAttributeType::StringEnum {
+            values,
+            name,
+            namespace,
+            ..
+        } => ProtoAttributeType::StringEnum {
             values: values.clone(),
             name: name.clone(),
+            namespace: namespace.clone(),
         },
         CoreAttributeType::List { inner, ordered } => ProtoAttributeType::List {
             inner: Box::new(core_to_proto_attribute_type(inner)),
@@ -319,12 +329,17 @@ mod tests {
         };
         let proto_type = core_to_proto_attribute_type(&core_type);
         match &proto_type {
-            ProtoAttributeType::StringEnum { values, name } => {
+            ProtoAttributeType::StringEnum {
+                values,
+                name,
+                namespace,
+            } => {
                 assert_eq!(name, "VersioningStatus");
                 assert_eq!(
                     values,
                     &vec!["Enabled".to_string(), "Suspended".to_string()]
                 );
+                assert_eq!(namespace.as_deref(), Some("aws.s3.bucket"));
             }
             _ => panic!("Expected StringEnum"),
         }

--- a/carina-provider-aws/src/factory.rs
+++ b/carina-provider-aws/src/factory.rs
@@ -20,13 +20,29 @@ impl ProviderFactory for AwsProviderFactory {
         "AWS provider"
     }
 
-    fn validate_config(&self, attributes: &HashMap<String, Value>) -> Result<(), String> {
-        let region_type = crate::schemas::types::aws_region();
-        if let Some(region_value) = attributes.get("region") {
-            region_type
-                .validate(region_value)
-                .map_err(|e| e.to_string())?;
-        }
+    fn provider_config_attribute_types(
+        &self,
+    ) -> HashMap<String, carina_core::schema::AttributeType> {
+        let mut types = HashMap::new();
+        types.insert(
+            "region".to_string(),
+            carina_core::schema::AttributeType::StringEnum {
+                name: "Region".to_string(),
+                values: carina_aws_types::REGIONS
+                    .iter()
+                    .map(|(code, _)| code.to_string())
+                    .collect(),
+                namespace: Some("aws".to_string()),
+                to_dsl: Some(|s| s.replace('-', "_")),
+            },
+        );
+        types
+    }
+
+    fn validate_config(&self, _attributes: &HashMap<String, Value>) -> Result<(), String> {
+        // Region format/value validation is handled by the host via
+        // `provider_config_attribute_types`. No provider-specific semantic
+        // checks are needed beyond that for now.
         Ok(())
     }
 

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -82,14 +82,26 @@ impl CarinaProvider for AwsProcessProvider {
             .collect()
     }
 
-    fn validate_config(&self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
-        let core_attrs = convert::proto_to_core_value_map(attrs);
-        let region_type = carina_provider_aws::schemas::types::aws_region();
-        if let Some(region_value) = core_attrs.get("region") {
-            region_type
-                .validate(region_value)
-                .map_err(|e| e.to_string())?;
-        }
+    fn provider_config_attribute_types(&self) -> HashMap<String, proto::AttributeType> {
+        let mut types = HashMap::new();
+        types.insert(
+            "region".to_string(),
+            proto::AttributeType::StringEnum {
+                name: "Region".to_string(),
+                values: carina_aws_types::REGIONS
+                    .iter()
+                    .map(|(code, _)| code.to_string())
+                    .collect(),
+                namespace: Some("aws".to_string()),
+            },
+        );
+        types
+    }
+
+    fn validate_config(&self, _attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
+        // Region format/value validation is handled by the host via
+        // `provider_config_attribute_types`. No provider-specific semantic
+        // checks are needed beyond that for now.
         Ok(())
     }
 


### PR DESCRIPTION
Implements the new `provider_config_attribute_types` method introduced in carina-rs/carina#1653.

## Summary

The AWS provider now exposes `region` as a `StringEnum` attribute type (data) instead of embedding a `Custom` validator closure that required provider rebuilds for generic DSL format fixes in carina-core.

The host validates region format and membership against this schema before calling `validate_config`, so fixes like the strict namespace check in carina-core take effect immediately without rebuilding the provider.

## Changes

- `carina-plugin-wit/wit/provider.wit`: add `provider-config-attribute-types` WIT function
- `carina-provider-aws/src/factory.rs`: implement `provider_config_attribute_types` on `AwsProviderFactory`
- `carina-provider-aws/src/main.rs`: implement `provider_config_attribute_types` on `AwsProcessProvider`
- `carina-provider-aws/src/convert.rs`: preserve `namespace` in StringEnum proto↔core conversion

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean

Refs carina-rs/carina#1650