### PR TITLE
feat: add aws.identitystore.user data source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-identitystore"
+version = "1.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ba5baaf9f102f9a65d2670e453eb964df3851269b0458c99d62034d8d84d82"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-organizations"
 version = "1.113.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,7 +616,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
+source = "git+https://github.com/carina-rs/carina#896ee8e5ec9c5c55bc8f5f0e92773d863bbb6d2b"
 dependencies = [
  "argon2",
  "futures",
@@ -608,7 +632,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
+source = "git+https://github.com/carina-rs/carina#896ee8e5ec9c5c55bc8f5f0e92773d863bbb6d2b"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -628,10 +652,12 @@ dependencies = [
  "aws-sdk-cloudwatchlogs",
  "aws-sdk-ec2",
  "aws-sdk-iam",
+ "aws-sdk-identitystore",
  "aws-sdk-organizations",
  "aws-sdk-s3",
  "aws-sdk-sts",
  "aws-smithy-async",
+ "aws-smithy-types",
  "carina-aws-types",
  "carina-core",
  "carina-plugin-sdk",
@@ -649,7 +675,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
+source = "git+https://github.com/carina-rs/carina#896ee8e5ec9c5c55bc8f5f0e92773d863bbb6d2b"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -25,12 +25,14 @@ carina-plugin-sdk = { git = "https://github.com/carina-rs/carina" }
 carina-provider-protocol = { git = "https://github.com/carina-rs/carina" }
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
+aws-smithy-types = { version = "1" }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-cloudwatchlogs = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-ec2 = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-iam = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-organizations = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-version-latest"] }
+aws-sdk-identitystore = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -21,6 +21,7 @@ use aws_config::Region;
 use aws_sdk_cloudwatchlogs::Client as CloudWatchLogsClient;
 use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_iam::Client as IamClient;
+use aws_sdk_identitystore::Client as IdentityStoreClient;
 use aws_sdk_organizations::Client as OrganizationsClient;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sts::Client as StsClient;
@@ -33,6 +34,7 @@ pub struct AwsProvider {
     logs_client: CloudWatchLogsClient,
     sts_client: StsClient,
     organizations_client: OrganizationsClient,
+    identitystore_client: IdentityStoreClient,
     region: String,
 }
 
@@ -48,6 +50,7 @@ impl AwsProvider {
             logs_client: CloudWatchLogsClient::new(&config),
             sts_client: StsClient::new(&config),
             organizations_client: OrganizationsClient::new(&config),
+            identitystore_client: IdentityStoreClient::new(&config),
             region: region.to_string(),
         }
     }
@@ -71,6 +74,7 @@ impl AwsProvider {
     }
 
     /// Create with specific clients (for testing)
+    #[allow(clippy::too_many_arguments)]
     pub fn with_clients(
         s3_client: S3Client,
         ec2_client: Ec2Client,
@@ -78,6 +82,7 @@ impl AwsProvider {
         logs_client: CloudWatchLogsClient,
         sts_client: StsClient,
         organizations_client: OrganizationsClient,
+        identitystore_client: IdentityStoreClient,
         region: String,
     ) -> Self {
         Self {
@@ -87,6 +92,7 @@ impl AwsProvider {
             logs_client,
             sts_client,
             organizations_client,
+            identitystore_client,
             region,
         }
     }

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -97,6 +97,45 @@ impl Provider for AwsProvider {
         })
     }
 
+    fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        let resource = resource.clone();
+        Box::pin(async move {
+            let mut state = match resource.id.resource_type.as_str() {
+                "identitystore.user" => self.read_identitystore_user(&resource).await?,
+                _ => {
+                    // Fallback for data sources this provider doesn't dispatch
+                    // explicitly. Route zero-input cases (e.g. `sts.caller_identity`)
+                    // through the regular read path so existing dispatch handles
+                    // them. Refuse to drop user-supplied inputs silently — if a
+                    // future data source has inputs but no override here, fail
+                    // loud instead of calling `read(&id, None)` and losing them
+                    // (matches the trait-default safety rail in `Provider::read_data_source`).
+                    let user_input_count = resource
+                        .attributes
+                        .keys()
+                        .filter(|k| !k.starts_with('_'))
+                        .count();
+                    if user_input_count > 0 {
+                        return Err(ProviderError::new(format!(
+                            "aws provider does not implement read_data_source for '{}' \
+                             but the resource has {user_input_count} user-supplied input \
+                             attribute(s); refusing to drop them",
+                            resource.id.resource_type
+                        ))
+                        .for_resource(resource.id.clone()));
+                    }
+                    self.read(&resource.id, None).await?
+                }
+            };
+
+            if state.exists {
+                normalize_state_enums(&resource.id.resource_type, &mut state.attributes);
+            }
+
+            Ok(state)
+        })
+    }
+
     fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
         let resource = resource.clone();
         Box::pin(async move {

--- a/carina-provider-aws/src/schemas/generated/identitystore/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/identitystore/mod.rs
@@ -1,0 +1,11 @@
+//! Hand-written — not generated from Smithy
+//!
+//! The codegen pipeline's `ResourceDef` doesn't model "data source with
+//! user-supplied lookup inputs", so `identitystore.user` is maintained
+//! manually. The codegen script preserves this module as an orphan (see
+//! carina-rs/carina-provider-aws commit 3f77a33).
+
+// Re-export parent types so resource modules can use `super::` to access them.
+pub use super::*;
+
+pub mod user;

--- a/carina-provider-aws/src/schemas/generated/identitystore/user.rs
+++ b/carina-provider-aws/src/schemas/generated/identitystore/user.rs
@@ -1,0 +1,97 @@
+//! user schema definition for AWS Identity Store
+//!
+//! Hand-written because this data source takes user-supplied lookup inputs
+//! (`identity_store_id` + one of `user_name` / `user_id`) that don't fit the
+//! codegen's `ResourceDef` model. See `services/identitystore/user.rs` for
+//! the read implementation that dispatches between `GetUserId` and
+//! `DescribeUser` depending on which input the user provided.
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+
+/// Returns the schema config for identitystore.user
+pub fn identitystore_user_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::IdentityStore::User",
+        resource_type_name: "identitystore.user",
+        has_tags: false,
+        schema: ResourceSchema::new("aws.identitystore.user")
+            .as_data_source()
+            .attribute(
+                AttributeSchema::new("identity_store_id", AttributeType::String)
+                    .required()
+                    .with_description("The globally unique identifier for the identity store.")
+                    .with_provider_name("IdentityStoreId"),
+            )
+            .attribute(
+                AttributeSchema::new("user_name", AttributeType::String)
+                    .with_description(
+                        "A unique string used to identify the user (typically an email). \
+                         One of `user_name` or `user_id` must be provided.",
+                    )
+                    .with_provider_name("UserName"),
+            )
+            .attribute(
+                AttributeSchema::new("user_id", AttributeType::String)
+                    .with_description(
+                        "The identifier for the user. One of `user_name` or `user_id` must \
+                         be provided. Populated on read when `user_name` is used for lookup.",
+                    )
+                    .with_provider_name("UserId"),
+            )
+            .attribute(
+                AttributeSchema::new("display_name", AttributeType::String)
+                    .with_description("The name that is typically displayed when the user is referenced. (read-only)")
+                    .with_provider_name("DisplayName"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "name",
+                    AttributeType::Struct {
+                        name: "Name".to_string(),
+                        fields: vec![
+                            StructField::new("formatted", AttributeType::String)
+                                .with_description("The full name of the user, formatted for display.")
+                                .with_provider_name("Formatted"),
+                            StructField::new("family_name", AttributeType::String)
+                                .with_description("The family name of the user.")
+                                .with_provider_name("FamilyName"),
+                            StructField::new("given_name", AttributeType::String)
+                                .with_description("The given name of the user.")
+                                .with_provider_name("GivenName"),
+                            StructField::new("middle_name", AttributeType::String)
+                                .with_description("The middle name of the user.")
+                                .with_provider_name("MiddleName"),
+                            StructField::new("honorific_prefix", AttributeType::String)
+                                .with_description("The honorific prefix of the user.")
+                                .with_provider_name("HonorificPrefix"),
+                            StructField::new("honorific_suffix", AttributeType::String)
+                                .with_description("The honorific suffix of the user.")
+                                .with_provider_name("HonorificSuffix"),
+                        ],
+                    },
+                )
+                .with_description("An object containing the user's name components. (read-only)")
+                .with_provider_name("Name"),
+            )
+            .attribute(
+                AttributeSchema::new("emails", AttributeType::list(AttributeType::String))
+                    .with_description("The email addresses of the user. (read-only)")
+                    .with_provider_name("Emails"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("identitystore.user", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -9,6 +9,7 @@ pub use super::types::*;
 
 pub mod ec2;
 pub mod iam;
+pub mod identitystore;
 pub mod logs;
 pub mod organizations;
 pub mod s3;
@@ -37,6 +38,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         ec2::vpc_peering_connection::ec2_vpc_peering_connection_config(),
         ec2::vpn_gateway::ec2_vpn_gateway_config(),
         iam::role::iam_role_config(),
+        identitystore::user::identitystore_user_config(),
         logs::log_group::logs_log_group_config(),
         organizations::account::organizations_account_config(),
         organizations::organization::organizations_organization_config(),
@@ -75,6 +77,7 @@ pub fn get_enum_valid_values(
         ec2::vpc_peering_connection::enum_valid_values(),
         ec2::vpn_gateway::enum_valid_values(),
         iam::role::enum_valid_values(),
+        identitystore::user::enum_valid_values(),
         logs::log_group::enum_valid_values(),
         organizations::account::enum_valid_values(),
         organizations::organization::enum_valid_values(),
@@ -160,6 +163,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "iam.role" {
         return iam::role::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "identitystore.user" {
+        return identitystore::user::enum_alias_reverse(attr_name, value);
     }
     if resource_type == "logs.log_group" {
         return logs::log_group::enum_alias_reverse(attr_name, value);

--- a/carina-provider-aws/src/services/identitystore/mod.rs
+++ b/carina-provider-aws/src/services/identitystore/mod.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/carina-provider-aws/src/services/identitystore/user.rs
+++ b/carina-provider-aws/src/services/identitystore/user.rs
@@ -1,0 +1,333 @@
+//! Data source read for `aws.identitystore.user`.
+//!
+//! Looks a user up by `user_name` (via `GetUserId` → `DescribeUser`) or by
+//! `user_id` (via `DescribeUser` directly). One of the two must be set.
+//! `identity_store_id` is always required.
+
+use std::collections::HashMap;
+
+use aws_sdk_identitystore::types::{AlternateIdentifier, UniqueAttribute};
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, State, Value};
+
+use crate::AwsProvider;
+
+impl AwsProvider {
+    /// Read `identitystore.user` given a `Resource` with user-supplied
+    /// lookup inputs.
+    pub(crate) async fn read_identitystore_user(
+        &self,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let identity_store_id = resource
+            .get_attr("identity_store_id")
+            .and_then(value_as_str)
+            .ok_or_else(|| {
+                ProviderError::new("identitystore.user requires `identity_store_id`")
+                    .for_resource(resource.id.clone())
+            })?;
+
+        let user_id =
+            resolve_user_id(&self.identitystore_client, identity_store_id, resource).await?;
+
+        let describe = self
+            .identitystore_client
+            .describe_user()
+            .identity_store_id(identity_store_id)
+            .user_id(&user_id)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(format!(
+                    "Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'"
+                ))
+                .with_cause(e)
+                .for_resource(resource.id.clone())
+            })?;
+
+        let attributes = extract_identitystore_user(&describe);
+        Ok(State::existing(resource.id.clone(), attributes))
+    }
+}
+
+/// Resolve a Carina `Resource` to the Identity Store `UserId` used by the
+/// subsequent `DescribeUser` call. If the user supplied `user_id` directly
+/// we use it as-is; otherwise we look it up by `user_name` via `GetUserId`.
+///
+/// All returned errors are already tagged with `resource.id`.
+async fn resolve_user_id(
+    client: &aws_sdk_identitystore::Client,
+    identity_store_id: &str,
+    resource: &Resource,
+) -> Result<String, ProviderError> {
+    if let Some(user_id) = resource.get_attr("user_id").and_then(value_as_str) {
+        return Ok(user_id.to_string());
+    }
+    let user_name = resource
+        .get_attr("user_name")
+        .and_then(value_as_str)
+        .ok_or_else(|| {
+            ProviderError::new("identitystore.user requires either `user_id` or `user_name`")
+                .for_resource(resource.id.clone())
+        })?;
+
+    let unique_attribute = UniqueAttribute::builder()
+        .attribute_path("userName")
+        .attribute_value(aws_smithy_types::Document::String(user_name.to_string()))
+        .build()
+        .map_err(|e| {
+            ProviderError::new("Failed to build userName lookup request")
+                .with_cause(e)
+                .for_resource(resource.id.clone())
+        })?;
+
+    let alt = AlternateIdentifier::UniqueAttribute(unique_attribute);
+
+    let resp = client
+        .get_user_id()
+        .identity_store_id(identity_store_id)
+        .alternate_identifier(alt)
+        .send()
+        .await
+        .map_err(|e| {
+            ProviderError::new(format!(
+                "Failed to look up user_id for user_name '{user_name}' in store '{identity_store_id}'"
+            ))
+            .with_cause(e)
+            .for_resource(resource.id.clone())
+        })?;
+
+    Ok(resp.user_id().to_string())
+}
+
+/// Pure projection of a `DescribeUserOutput` into the DSL-visible attribute
+/// map for `identitystore.user`. Extracted from the read path so it can be
+/// unit-tested without hitting the AWS SDK.
+pub(crate) fn extract_identitystore_user(
+    resp: &aws_sdk_identitystore::operation::describe_user::DescribeUserOutput,
+) -> HashMap<String, Value> {
+    let mut attributes = HashMap::new();
+
+    attributes.insert(
+        "user_id".to_string(),
+        Value::String(resp.user_id().to_string()),
+    );
+    attributes.insert(
+        "identity_store_id".to_string(),
+        Value::String(resp.identity_store_id().to_string()),
+    );
+    if let Some(user_name) = resp.user_name() {
+        attributes.insert(
+            "user_name".to_string(),
+            Value::String(user_name.to_string()),
+        );
+    }
+    if let Some(display_name) = resp.display_name() {
+        attributes.insert(
+            "display_name".to_string(),
+            Value::String(display_name.to_string()),
+        );
+    }
+    if let Some(name) = resp.name() {
+        let mut name_fields: HashMap<String, Value> = HashMap::new();
+        if let Some(v) = name.formatted() {
+            name_fields.insert("formatted".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = name.family_name() {
+            name_fields.insert("family_name".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = name.given_name() {
+            name_fields.insert("given_name".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = name.middle_name() {
+            name_fields.insert("middle_name".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = name.honorific_prefix() {
+            name_fields.insert("honorific_prefix".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = name.honorific_suffix() {
+            name_fields.insert("honorific_suffix".to_string(), Value::String(v.to_string()));
+        }
+        if !name_fields.is_empty() {
+            attributes.insert("name".to_string(), Value::Map(name_fields));
+        }
+    }
+    let email_values: Vec<Value> = resp
+        .emails()
+        .iter()
+        .filter_map(|e: &aws_sdk_identitystore::types::Email| {
+            e.value().map(|v| Value::String(v.to_string()))
+        })
+        .collect();
+    if !email_values.is_empty() {
+        attributes.insert("emails".to_string(), Value::List(email_values));
+    }
+
+    attributes
+}
+
+fn value_as_str(v: &Value) -> Option<&str> {
+    if let Value::String(s) = v {
+        Some(s.as_str())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_identitystore::operation::describe_user::DescribeUserOutput;
+    use aws_sdk_identitystore::types::{Email, Name};
+
+    fn name_block() -> Name {
+        Name::builder()
+            .formatted("Gosuke Miyashita")
+            .family_name("Miyashita")
+            .given_name("Gosuke")
+            .build()
+    }
+
+    fn primary_email() -> Email {
+        Email::builder().value("gosukenator@gmail.com").build()
+    }
+
+    fn describe_user_full() -> DescribeUserOutput {
+        DescribeUserOutput::builder()
+            .user_id("37846ac8-4021-705b-1bf2-26861723348f")
+            .identity_store_id("d-9567916d09")
+            .user_name("gosukenator@gmail.com")
+            .display_name("Gosuke Miyashita")
+            .name(name_block())
+            .emails(primary_email())
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn extract_populates_required_fields() {
+        let resp = describe_user_full();
+        let attrs = extract_identitystore_user(&resp);
+
+        assert_eq!(
+            attrs.get("user_id"),
+            Some(&Value::String(
+                "37846ac8-4021-705b-1bf2-26861723348f".to_string()
+            ))
+        );
+        assert_eq!(
+            attrs.get("identity_store_id"),
+            Some(&Value::String("d-9567916d09".to_string()))
+        );
+        assert_eq!(
+            attrs.get("user_name"),
+            Some(&Value::String("gosukenator@gmail.com".to_string()))
+        );
+        assert_eq!(
+            attrs.get("display_name"),
+            Some(&Value::String("Gosuke Miyashita".to_string()))
+        );
+    }
+
+    #[test]
+    fn extract_populates_name_struct() {
+        let resp = describe_user_full();
+        let attrs = extract_identitystore_user(&resp);
+
+        let Some(Value::Map(name)) = attrs.get("name") else {
+            panic!("expected name map, got {:?}", attrs.get("name"));
+        };
+        assert_eq!(
+            name.get("formatted"),
+            Some(&Value::String("Gosuke Miyashita".to_string()))
+        );
+        assert_eq!(
+            name.get("family_name"),
+            Some(&Value::String("Miyashita".to_string()))
+        );
+        assert_eq!(
+            name.get("given_name"),
+            Some(&Value::String("Gosuke".to_string()))
+        );
+        // Unset optional fields must not appear in the map.
+        assert!(!name.contains_key("middle_name"));
+        assert!(!name.contains_key("honorific_prefix"));
+    }
+
+    #[test]
+    fn extract_populates_emails_list() {
+        let resp = describe_user_full();
+        let attrs = extract_identitystore_user(&resp);
+
+        let Some(Value::List(emails)) = attrs.get("emails") else {
+            panic!("expected emails list, got {:?}", attrs.get("emails"));
+        };
+        assert_eq!(emails.len(), 1);
+        assert_eq!(
+            emails[0],
+            Value::String("gosukenator@gmail.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_omits_optional_fields_when_absent() {
+        // Minimal response: only required fields (user_id, identity_store_id).
+        let resp = DescribeUserOutput::builder()
+            .user_id("uid-min")
+            .identity_store_id("d-min")
+            .build()
+            .unwrap();
+        let attrs = extract_identitystore_user(&resp);
+
+        assert_eq!(
+            attrs.get("user_id"),
+            Some(&Value::String("uid-min".to_string()))
+        );
+        assert_eq!(
+            attrs.get("identity_store_id"),
+            Some(&Value::String("d-min".to_string()))
+        );
+        assert!(!attrs.contains_key("user_name"));
+        assert!(!attrs.contains_key("display_name"));
+        assert!(!attrs.contains_key("name"));
+        assert!(!attrs.contains_key("emails"));
+    }
+
+    #[test]
+    fn extract_populates_partial_name_struct() {
+        // Only `given_name` is set — the `name` map must still be emitted
+        // (non-empty) and must contain only the fields that were present.
+        let resp = DescribeUserOutput::builder()
+            .user_id("uid")
+            .identity_store_id("d")
+            .name(Name::builder().given_name("Gosuke").build())
+            .build()
+            .unwrap();
+        let attrs = extract_identitystore_user(&resp);
+
+        let Some(Value::Map(name)) = attrs.get("name") else {
+            panic!("expected name map, got {:?}", attrs.get("name"));
+        };
+        assert_eq!(name.len(), 1);
+        assert_eq!(
+            name.get("given_name"),
+            Some(&Value::String("Gosuke".to_string()))
+        );
+        assert!(!name.contains_key("formatted"));
+        assert!(!name.contains_key("family_name"));
+    }
+
+    #[test]
+    fn extract_omits_empty_emails_list() {
+        // DescribeUserOutput with empty emails should not add an empty list
+        // attribute — that's just noise downstream.
+        let resp = DescribeUserOutput::builder()
+            .user_id("uid")
+            .identity_store_id("d")
+            .set_emails(Some(vec![]))
+            .build()
+            .unwrap();
+        let attrs = extract_identitystore_user(&resp);
+        assert!(!attrs.contains_key("emails"));
+    }
+}

--- a/carina-provider-aws/src/services/mod.rs
+++ b/carina-provider-aws/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod ec2;
 pub mod iam;
+pub mod identitystore;
 pub mod logs;
 pub mod organizations;
 pub mod s3;


### PR DESCRIPTION
## Summary

- Adds `aws.identitystore.user` — the first input-taking data source in the AWS provider. Looks up an Identity Center user by `user_name` (via `GetUserId` then `DescribeUser`) or by `user_id` (direct `DescribeUser`).
- First consumer of `Provider::read_data_source` (enabler merged upstream in carina-rs/carina#1674). The AWS provider's override dispatches `identitystore.user` and falls through to the regular read path for zero-input data sources like `sts.caller_identity`, while preserving the enabler's safety rail for unknown input-taking data sources.
- Schema is hand-written, not codegen-generated, because the `ResourceDef` model doesn't describe a data source with user-supplied lookup inputs.

## Why

`AWS::IdentityStore::User` is not supported by CloudFormation, so the awscc provider can't manage or read Identity Center users. Without this data source, DSL configurations referencing Identity Center have to hardcode opaque UUIDs:

\`\`\`crn
awscc.identitystore.group_membership {
  member_id = { user_id = '37846ac8-4021-705b-1bf2-26861723348f' }  // hardcoded
}
\`\`\`

which is fragile (impossible to move configs between identity stores, requires rewriting on user recreation, unreadable). With this PR:

\`\`\`crn
let mizzy = read aws.identitystore.user {
  identity_store_id = 'd-9567916d09'
  user_name         = 'gosukenator@gmail.com'
}

awscc.identitystore.group_membership {
  member_id = { user_id = mizzy.user_id }
}
\`\`\`

## How

1. **Cargo.toml** — adds `aws-sdk-identitystore` and `aws-smithy-types` (the latter for the `Document::String` wrapping that `GetUserId`'s `AlternateIdentifier` payload needs).
2. **`lib.rs`** — `AwsProvider` gains an `identitystore_client` field. `with_clients` (test-only) now has 8 args so it carries `#[allow(clippy::too_many_arguments)]`.
3. **`schemas/generated/identitystore/user.rs`** (new, hand-written) — schema config with `identity_store_id` (required), `user_name` + `user_id` (optional, one must be provided, enforced at read time), plus read-only outputs `display_name`, `name` struct, `emails`. The `schemas/generated/mod.rs` is updated to register it. The codegen's orphan-preservation logic (commit 3f77a33) leaves this file alone on regen — verified by running `./scripts/generate-schemas-smithy.sh` locally and checking the resulting diff.
4. **`services/identitystore/user.rs`** (new) — hand-written read implementation. Splits into:
   - `read_identitystore_user(&resource)` — orchestrates the lookup and wraps errors with the resource id.
   - `resolve_user_id(client, identity_store_id, resource)` — fast path for `user_id` (1 SDK call), lookup path for `user_name` via `GetUserId` (2 SDK calls).
   - `extract_identitystore_user(resp)` — **pure function** projecting `DescribeUserOutput` to `HashMap<String, Value>`. Extracted for unit testing.
5. **`provider.rs`** — `Provider::read_data_source` override dispatches `identitystore.user` and preserves the enabler's safety rail: unknown data sources with user-supplied input attributes return an error rather than silently dropping them.

## Test plan

- [x] `cargo test -p carina-provider-aws` — **142 + 4 passed** (6 new tests for `extract_identitystore_user`)
- [x] `cargo clippy -p carina-provider-aws --all-targets -- -D warnings`
- [x] `cargo fmt -p carina-provider-aws -- --check`
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`
- [x] `./scripts/generate-schemas-smithy.sh` — verified no drift (hand-written identitystore files are preserved)
- [x] Unit tests per #80 spec — extract function only. Acceptance tests omitted per the issue because they require a live Identity Store and would have permanent side effects on the SSO login directory.
- [ ] End-to-end manual verification against a real Identity Store (tracker: user to run once merged).

## Follow-up

- Richer `emails` modelling: SDK returns `List<Email { value, type, primary }>`; this PR extracts only `value` as `List<String>`. Consumers that need the `type`/`primary` flags will want the full struct modelled.
- Consolidate `value_as_str` helper: local helper at `services/identitystore/user.rs:169` duplicates a pattern in `services/organizations/account.rs:303`. Candidate for promotion to `carina_core::resource::Value::as_str()`.

Closes #80
Depends on: carina-rs/carina#1674 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)