### PR TITLE
chore: wire read_data_source through WASM plugin bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#896ee8e5ec9c5c55bc8f5f0e92773d863bbb6d2b"
+source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
 dependencies = [
  "argon2",
  "futures",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#896ee8e5ec9c5c55bc8f5f0e92773d863bbb6d2b"
+source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#896ee8e5ec9c5c55bc8f5f0e92773d863bbb6d2b"
+source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-plugin-wit/wit/provider.wit
+++ b/carina-plugin-wit/wit/provider.wit
@@ -18,6 +18,14 @@ interface provider {
     initialize: func(attrs: list<tuple<string, value>>) -> result<_, string>;
 
     read: func(id: resource-id, identifier: option<string>) -> result<state, string>;
+
+    /// Read a data source resource. Receives the full `resource-def` so
+    /// providers can see user-supplied input attributes (e.g. the
+    /// `user_name` for `aws.identitystore.user`). Zero-input data sources
+    /// should still route through `read` on the host side — callers
+    /// dispatch on `resource.is_data_source()` before picking this path.
+    read-data-source: func(res: resource-def) -> result<state, string>;
+
     create: func(res: resource-def) -> result<state, string>;
     update: func(id: resource-id, identifier: string, current: state, to: resource-def) -> result<state, string>;
 

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -149,6 +149,20 @@ impl CarinaProvider for AwsProcessProvider {
         }
     }
 
+    fn read_data_source(
+        &self,
+        resource: &proto::Resource,
+    ) -> Result<proto::State, proto::ProviderError> {
+        let core_resource = convert::proto_to_core_resource(resource);
+        let result = self
+            .runtime
+            .block_on(self.provider().read_data_source(&core_resource));
+        match result {
+            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Err(e) => Err(Self::convert_error(e)),
+        }
+    }
+
     fn create(&self, resource: &proto::Resource) -> Result<proto::State, proto::ProviderError> {
         let core_resource = convert::proto_to_core_resource(resource);
         let result = self


### PR DESCRIPTION
## Summary

- Bumps carina-core / carina-plugin-sdk / carina-provider-protocol git deps to pick up carina-rs/carina#1678, which plumbed `Provider::read_data_source` through the WIT interface, SDK trait, and plugin host.
- Syncs the vendored `carina-plugin-wit/wit/provider.wit` with the upstream WIT so the local `wit_bindgen::generate!` invocation in `export_provider!` sees the new Guest trait member.
- Adds a `read_data_source` delegator to `AwsProcessProvider` in `carina-provider-aws/src/main.rs` that forwards to the native `AwsProvider::read_data_source` override (already merged in #82).

Together these three changes finish the end-to-end wiring for `aws.identitystore.user` (and any future input-taking data source) under the WASM plugin loader.

## Why each piece is necessary

1. **Cargo.lock bump** — without it, CI rerun picks up the old pinned SDK revision, which doesn't know about `read_data_source`.
2. **Vendored WIT sync** — `wit_bindgen::generate!` reads the WIT at compile time using the path `../carina-plugin-wit/wit` (relative to the crate using the macro). That path resolves into this repo's vendored copy, not the upstream carina repo. Without updating it, the WASM build fails with:
   ```
   error[E0407]: method `read_data_source` is not a member of trait `exports::carina::provider::provider::Guest`
    --> carina-provider-aws/src/main.rs:262:1
   ```
3. **`AwsProcessProvider` delegator** — the SDK's new `CarinaProvider::read_data_source` has a default impl that errors on non-`_` input attributes. Without overriding it in `AwsProcessProvider`, the default runs and the WASM-loaded aws provider rejects `aws.identitystore.user` despite the native `AwsProvider` having the correct override. The delegator mirrors the existing `read`/`create`/`update`/`delete` forwarders in the same file.

## Test plan

- [x] `cargo update -p carina-core -p carina-plugin-sdk -p carina-provider-protocol` → Cargo.lock now points at the upstream merge commit for carina-rs/carina#1678
- [x] `cargo build -p carina-provider-aws` (native)
- [x] `cargo test -p carina-provider-aws` — 142 + 4 passed
- [x] `cargo clippy -p carina-provider-aws --all-targets -- -D warnings`
- [x] `cargo fmt -p carina-provider-aws -- --check`
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — the one that previously failed with E0407 now succeeds
- [ ] End-to-end against a real Identity Store via `carina init --upgrade` + `carina plan` against `aws.identitystore.user { identity_store_id = '...', user_name = '...' }`

Refs carina-rs/carina#1677
Refs carina-rs/carina-provider-aws#80

🤖 Generated with [Claude Code](https://claude.com/claude-code)