### PR TITLE
feat: generate to_dsl reverse mappings in enum alias table

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -826,29 +826,70 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     }
     code.push_str("}\n");
 
+    // Collect all alias entries: explicit aliases + to_dsl reverse mappings.
+    let mut alias_entries: Vec<(String, String, String)> = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+
+    // Add explicit aliases from resource definition
+    for (attr, alias, canonical) in &res.enum_aliases {
+        if seen.insert((attr.to_string(), alias.to_string())) {
+            alias_entries.push((attr.to_string(), alias.to_string(), canonical.to_string()));
+        }
+    }
+
+    // Add to_dsl reverse mappings for values containing hyphens.
+    for (prop_name, enum_info) in &all_enums {
+        let attr_name = prop_name.to_snake_case();
+        for value in &enum_info.values {
+            if value.contains('-') {
+                let dsl_form = value.replace('-', "_");
+                if dsl_form != *value && seen.insert((attr_name.clone(), dsl_form.clone())) {
+                    alias_entries.push((attr_name.clone(), dsl_form, value.clone()));
+                }
+            }
+        }
+    }
+
     // Generate enum_alias_reverse()
     code.push_str(
         "\n/// Maps DSL alias values back to canonical AWS values for this module.\n\
          /// e.g., (\"ip_protocol\", \"all\") -> Some(\"-1\")\n\
          pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {\n",
     );
-
-    let mut match_arms: Vec<String> = Vec::new();
-    for (attr, alias, canonical) in &res.enum_aliases {
-        match_arms.push(format!(
-            "        (\"{}\", \"{}\") => Some(\"{}\")",
-            attr, alias, canonical
-        ));
-    }
-
-    if match_arms.is_empty() {
+    if alias_entries.is_empty() {
         code.push_str("    let _ = (attr_name, value);\n    None\n");
     } else {
-        match_arms.push("        _ => None".to_string());
+        let match_arms: Vec<String> = alias_entries
+            .iter()
+            .map(|(attr, alias, canonical)| {
+                format!(
+                    "        (\"{}\", \"{}\") => Some(\"{}\")",
+                    attr, alias, canonical
+                )
+            })
+            .collect();
         code.push_str(&format!(
-            "    match (attr_name, value) {{\n{}\n    }}\n",
+            "    match (attr_name, value) {{\n{},\n        _ => None\n    }}\n",
             match_arms.join(",\n")
         ));
+    }
+    code.push_str("}\n");
+
+    // Generate enum_alias_entries()
+    code.push_str(
+        "\n/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.\n\
+         pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {\n",
+    );
+    if alias_entries.is_empty() {
+        code.push_str("    &[]\n");
+    } else {
+        let entry_strs: Vec<String> = alias_entries
+            .iter()
+            .map(|(attr, alias, canonical)| {
+                format!("        (\"{}\", \"{}\", \"{}\")", attr, alias, canonical)
+            })
+            .collect();
+        code.push_str(&format!("    &[\n{}\n    ]\n", entry_strs.join(",\n")));
     }
     code.push_str("}\n");
 
@@ -1298,7 +1339,30 @@ fn generate_mod_rs(dsl_names: &[&str], output_dir: &std::path::Path) -> String {
             name, service, resource
         ));
     }
-    code.push_str("    None\n}\n");
+    code.push_str("    None\n}\n\n");
+
+    // build_enum_aliases_map()
+    code.push_str(
+        "/// Build a complete enum aliases map for all resource types.\n\
+         /// Returns: resource_type -> attr_name -> alias -> canonical_value.\n\
+         /// Used by CarinaProvider::enum_aliases() for the WASM host cache.\n\
+         pub fn build_enum_aliases_map() -> std::collections::HashMap<String, std::collections::HashMap<String, std::collections::HashMap<String, String>>> {\n\
+         \x20   let mut map = std::collections::HashMap::new();\n",
+    );
+    for name in &sorted {
+        let (service, resource) = split_service_resource(name);
+        code.push_str(&format!(
+            "\x20   for (attr, alias, canonical) in {}::{}::enum_alias_entries() {{\n\
+             \x20       map.entry(\"{}\".to_string())\n\
+             \x20           .or_insert_with(std::collections::HashMap::new)\n\
+             \x20           .entry(attr.to_string())\n\
+             \x20           .or_insert_with(std::collections::HashMap::new)\n\
+             \x20           .insert(alias.to_string(), canonical.to_string());\n\
+             \x20   }}\n",
+            service, resource, name
+        ));
+    }
+    code.push_str("    map\n}\n");
 
     code
 }

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -134,6 +134,10 @@ impl CarinaProvider for AwsProcessProvider {
         vec!["region".to_string()]
     }
 
+    fn enum_aliases(&self) -> HashMap<String, HashMap<String, HashMap<String, String>>> {
+        carina_provider_aws::schemas::generated::build_enum_aliases_map()
+    }
+
     fn read(
         &self,
         id: &proto::ResourceId,

--- a/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
@@ -57,3 +57,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/eip.rs
@@ -75,3 +75,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -133,6 +133,25 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("log_destination_type", "cloud_watch_logs") => Some("cloud-watch-logs"),
+        ("log_destination_type", "kinesis_data_firehose") => Some("kinesis-data-firehose"),
+        _ => None,
+    }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[
+        (
+            "log_destination_type",
+            "cloud_watch_logs",
+            "cloud-watch-logs",
+        ),
+        (
+            "log_destination_type",
+            "kinesis_data_firehose",
+            "kinesis-data-firehose",
+        ),
+    ]
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
@@ -45,3 +45,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
@@ -115,3 +115,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/route.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route.rs
@@ -55,3 +55,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
@@ -52,3 +52,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
@@ -65,3 +65,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -170,6 +170,12 @@ pub fn enum_valid_values() -> (
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
         ("ip_protocol", "all") => Some("-1"),
+        ("ip_protocol", "_1") => Some("-1"),
         _ => None,
     }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[("ip_protocol", "all", "-1"), ("ip_protocol", "_1", "-1")]
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -156,6 +156,12 @@ pub fn enum_valid_values() -> (
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
         ("ip_protocol", "all") => Some("-1"),
+        ("ip_protocol", "_1") => Some("-1"),
         _ => None,
     }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[("ip_protocol", "all", "-1"), ("ip_protocol", "_1", "-1")]
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -185,6 +185,17 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("hostname_type", "ip_name") => Some("ip-name"),
+        ("hostname_type", "resource_name") => Some("resource-name"),
+        _ => None,
+    }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[
+        ("hostname_type", "ip_name", "ip-name"),
+        ("hostname_type", "resource_name", "resource-name"),
+    ]
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet_route_table_association.rs
@@ -52,3 +52,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
@@ -141,3 +141,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -119,3 +119,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -105,3 +105,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -127,3 +127,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_gateway_attachment.rs
@@ -57,3 +57,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -65,3 +65,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
@@ -71,3 +71,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -98,3 +98,7 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/identitystore/user.rs
+++ b/carina-provider-aws/src/schemas/generated/identitystore/user.rs
@@ -95,3 +95,7 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-aws/src/schemas/generated/logs/log_group.rs
@@ -104,3 +104,7 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -184,3 +184,196 @@ pub fn get_enum_alias_reverse(
     }
     None
 }
+
+/// Build a complete enum aliases map for all resource types.
+/// Returns: resource_type -> attr_name -> alias -> canonical_value.
+/// Used by CarinaProvider::enum_aliases() for the WASM host cache.
+pub fn build_enum_aliases_map() -> std::collections::HashMap<
+    String,
+    std::collections::HashMap<String, std::collections::HashMap<String, String>>,
+> {
+    let mut map = std::collections::HashMap::new();
+    for (attr, alias, canonical) in ec2::egress_only_internet_gateway::enum_alias_entries() {
+        map.entry("ec2.egress_only_internet_gateway".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::eip::enum_alias_entries() {
+        map.entry("ec2.eip".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::flow_log::enum_alias_entries() {
+        map.entry("ec2.flow_log".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::internet_gateway::enum_alias_entries() {
+        map.entry("ec2.internet_gateway".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::nat_gateway::enum_alias_entries() {
+        map.entry("ec2.nat_gateway".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::route::enum_alias_entries() {
+        map.entry("ec2.route".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::route_table::enum_alias_entries() {
+        map.entry("ec2.route_table".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::security_group::enum_alias_entries() {
+        map.entry("ec2.security_group".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::security_group_egress::enum_alias_entries() {
+        map.entry("ec2.security_group_egress".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::security_group_ingress::enum_alias_entries() {
+        map.entry("ec2.security_group_ingress".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::subnet::enum_alias_entries() {
+        map.entry("ec2.subnet".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::subnet_route_table_association::enum_alias_entries() {
+        map.entry("ec2.subnet_route_table_association".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::transit_gateway::enum_alias_entries() {
+        map.entry("ec2.transit_gateway".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::transit_gateway_attachment::enum_alias_entries() {
+        map.entry("ec2.transit_gateway_attachment".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpc::enum_alias_entries() {
+        map.entry("ec2.vpc".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpc_endpoint::enum_alias_entries() {
+        map.entry("ec2.vpc_endpoint".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpc_gateway_attachment::enum_alias_entries() {
+        map.entry("ec2.vpc_gateway_attachment".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpc_peering_connection::enum_alias_entries() {
+        map.entry("ec2.vpc_peering_connection".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpn_gateway::enum_alias_entries() {
+        map.entry("ec2.vpn_gateway".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in iam::role::enum_alias_entries() {
+        map.entry("iam.role".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in identitystore::user::enum_alias_entries() {
+        map.entry("identitystore.user".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in logs::log_group::enum_alias_entries() {
+        map.entry("logs.log_group".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in organizations::account::enum_alias_entries() {
+        map.entry("organizations.account".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in organizations::organization::enum_alias_entries() {
+        map.entry("organizations.organization".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket::enum_alias_entries() {
+        map.entry("s3.bucket".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in sts::caller_identity::enum_alias_entries() {
+        map.entry("sts.caller_identity".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    map
+}

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -127,3 +127,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -73,3 +73,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -139,6 +139,21 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("acl", "authenticated_read") => Some("authenticated-read"),
+        ("acl", "public_read") => Some("public-read"),
+        ("acl", "public_read_write") => Some("public-read-write"),
+        ("bucket_namespace", "account_regional") => Some("account-regional"),
+        _ => None,
+    }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[
+        ("acl", "authenticated_read", "authenticated-read"),
+        ("acl", "public_read", "public-read"),
+        ("acl", "public_read_write", "public-read-write"),
+        ("bucket_namespace", "account_regional", "account-regional"),
+    ]
 }

--- a/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
+++ b/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
@@ -47,3 +47,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}


### PR DESCRIPTION
Closes #85

## Summary

- Extend Smithy codegen to generate reverse alias entries for enum values containing hyphens (e.g., `cloud-watch-logs` → alias `cloud_watch_logs → cloud-watch-logs`)
- Add `enum_alias_entries()` function to each generated module
- Add `build_enum_aliases_map()` to generated `mod.rs`
- Implement `CarinaProvider::enum_aliases()` to populate the WASM host's alias cache
- Add `enum_alias_entries()` stubs to orphaned modules (iam::role, identitystore::user, logs::log_group)

This is Phase 2 of the carina-rs/carina#1675 fix. Phase 1 (carina-rs/carina#1691) removed the incorrect `replace('_', '-')` from `convert_enum_value`. This PR provides the schema-aware reverse mappings so that `resolve_value_alias` can canonicalize enum values before they reach the display layer.

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Schema regeneration with `generate-schemas-smithy.sh` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)