### PR TITLE
ci: add WIT drift check against upstream carina

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,21 @@ jobs:
           name: carina-provider-aws.wasm
           path: target/wasm32-wasip2/release/carina-provider-aws.wasm
 
+  wit-check:
+    name: WIT Drift Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check vendored WIT against upstream carina
+        run: |
+          for f in provider.wit types.wit world.wit; do
+            curl -fsSL "https://raw.githubusercontent.com/carina-rs/carina/main/carina-plugin-wit/wit/$f" -o "/tmp/upstream-$f"
+            diff "carina-plugin-wit/wit/$f" "/tmp/upstream-$f" || {
+              echo "::error::vendored $f is out of sync with carina main — copy the upstream file and commit"
+              exit 1
+            }
+          done
+
   codegen-check:
     name: Codegen Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #84

## Summary
- Adds a `wit-check` CI job that compares vendored `provider.wit`, `types.wit`, and `world.wit` against upstream carina main
- Fails with a clear error message if any file is out of sync

## Test plan
- [ ] CI passes on this PR (WIT files are currently in sync)
- [ ] Verify the job catches drift by temporarily modifying a local WIT file

🤖 Generated with [Claude Code](https://claude.com/claude-code)