### PR TITLE
docs: add submodule initialization instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,16 @@ git wt                       # List worktrees
 git wt -d <branch-name>      # Delete worktree (from main worktree)
 ```
 
+### Submodule Initialization
+
+This repo uses a git submodule for `carina-plugin-wit/`. After `git pull` or creating a new worktree, initialize the submodule:
+
+```bash
+git submodule update --init --recursive
+```
+
+Without this, builds will fail because `wit_bindgen::generate!` cannot find the WIT files.
+
 ## Code Style
 
 - **Commit messages**: Write in English


### PR DESCRIPTION
## Summary
- Adds a "Submodule Initialization" section to CLAUDE.md documenting the `git submodule update --init --recursive` requirement after `git pull` or worktree creation

## Test plan
- [ ] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)