### PR TITLE
feat: serialize Custom types through WASM protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
+source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "argon2",
  "futures",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
+source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
+source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -178,6 +178,17 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
         ProtoAttributeType::Union { members } => {
             CoreAttributeType::Union(members.iter().map(proto_to_core_attribute_type).collect())
         }
+        ProtoAttributeType::Custom {
+            name,
+            base,
+            namespace,
+        } => CoreAttributeType::Custom {
+            name: name.clone(),
+            base: Box::new(proto_to_core_attribute_type(base)),
+            validate: |_| Ok(()),
+            namespace: namespace.clone(),
+            to_dsl: None,
+        },
     }
 }
 
@@ -258,8 +269,16 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             name: name.clone(),
             fields: fields.iter().map(core_to_proto_struct_field).collect(),
         },
-        // Custom -> base type: function pointers can't cross process boundary
-        CoreAttributeType::Custom { base, .. } => core_to_proto_attribute_type(base),
+        CoreAttributeType::Custom {
+            name,
+            base,
+            namespace,
+            ..
+        } => ProtoAttributeType::Custom {
+            name: name.clone(),
+            base: Box::new(core_to_proto_attribute_type(base)),
+            namespace: namespace.clone(),
+        },
         CoreAttributeType::Union(members) => ProtoAttributeType::Union {
             members: members.iter().map(core_to_proto_attribute_type).collect(),
         },

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -344,7 +344,11 @@ pub(crate) fn convert_protocol_value(value: &str) -> String {
     let raw = convert_enum_value(value);
 
     // Handle special case: "all" means "-1" (all protocols)
-    if raw == "all" { "-1".to_string() } else { raw }
+    if raw == "all" {
+        "-1".to_string()
+    } else {
+        raw.to_string()
+    }
 }
 
 #[cfg(test)]

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -181,7 +181,7 @@ impl AwsProvider {
         // Each private_dns_name_options_on_launch field must be a separate API call.
         if let Some(Value::Map(fields)) = attributes.get("private_dns_name_options_on_launch") {
             if let Some(Value::String(ht)) = fields.get("hostname_type") {
-                let hostname_val = convert_enum_value(ht);
+                let hostname_val = convert_enum_value(ht).replace('_', "-");
                 self.ec2_client
                     .modify_subnet_attribute()
                     .subnet_id(subnet_id)

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -86,7 +86,7 @@ impl AwsProvider {
         let region = match resource.get_attr("region") {
             Some(Value::String(s)) => {
                 // Convert from aws.Region.ap_northeast_1 format to ap-northeast-1 format
-                convert_enum_value(s)
+                convert_enum_value(s).to_string()
             }
             _ => self.region.clone(),
         };
@@ -120,7 +120,7 @@ impl AwsProvider {
         if let Some(Value::String(val)) = resource.get_attr("acl") {
             use aws_sdk_s3::types::BucketCannedAcl;
             let normalized = convert_enum_value(val);
-            req = req.acl(BucketCannedAcl::from(normalized.as_str()));
+            req = req.acl(BucketCannedAcl::from(normalized));
         }
         if let Some(Value::String(val)) = resource.get_attr("grant_full_control") {
             req = req.grant_full_control(val);
@@ -571,7 +571,7 @@ impl AwsProvider {
 
         if let Some(val) = acl {
             let normalized = convert_enum_value(val);
-            req = req.acl(BucketCannedAcl::from(normalized.as_str()));
+            req = req.acl(BucketCannedAcl::from(normalized));
         }
         if let Some(val) = grant_full_control {
             req = req.grant_full_control(val);

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -555,17 +555,19 @@ fn test_subnet_hostname_type_dsl_to_aws_sdk() {
     use carina_core::utils::convert_enum_value;
 
     // DSL uses underscores: aws.ec2.subnet.HostnameType.ip_name
-    // convert_enum_value for 5-part identifiers converts underscores to hyphens
+    // convert_enum_value extracts the value, then underscore→hyphen for AWS SDK
     let dsl_value = "aws.ec2.subnet.HostnameType.ip_name";
-    let converted = convert_enum_value(dsl_value);
-    assert_eq!(converted, "ip-name");
-    let hostname_type = HostnameType::from(converted.as_str());
+    let extracted = convert_enum_value(dsl_value);
+    assert_eq!(extracted, "ip_name");
+    let aws_value = extracted.replace('_', "-");
+    let hostname_type = HostnameType::from(aws_value.as_str());
     assert_eq!(hostname_type, HostnameType::IpName);
 
     let dsl_value2 = "aws.ec2.subnet.HostnameType.resource_name";
-    let converted2 = convert_enum_value(dsl_value2);
-    assert_eq!(converted2, "resource-name");
-    let hostname_type2 = HostnameType::from(converted2.as_str());
+    let extracted2 = convert_enum_value(dsl_value2);
+    assert_eq!(extracted2, "resource_name");
+    let aws_value2 = extracted2.replace('_', "-");
+    let hostname_type2 = HostnameType::from(aws_value2.as_str());
     assert_eq!(hostname_type2, HostnameType::ResourceName);
 }
 
@@ -598,7 +600,7 @@ fn test_subnet_dns_options_fields_parsed_separately() {
     // Each field should be independently extractable for separate API calls
     if let Some(Value::String(ht)) = fields.get("hostname_type") {
         let hostname_val = convert_enum_value(ht);
-        assert_eq!(hostname_val, "ip-name");
+        assert_eq!(hostname_val, "ip_name");
     } else {
         panic!("hostname_type should be present and a String");
     }


### PR DESCRIPTION
Closes #90

- core_to_proto_attribute_type: Custom → ProtoAttributeType::Custom
- proto_to_core_attribute_type: handle new Custom variant
- Fix convert_enum_value &str return type across codebase
- Fix underscore→hyphen for hostname types and enum values

🤖 Generated with [Claude Code](https://claude.com/claude-code)