### PR TITLE
feat: implement validate_custom_type for AWS provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,6 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "argon2",
  "futures",
@@ -632,7 +631,6 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -675,7 +673,6 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -138,6 +138,19 @@ impl CarinaProvider for AwsProcessProvider {
         carina_provider_aws::schemas::generated::build_enum_aliases_map()
     }
 
+    fn validate_custom_type(&self, type_name: &str, value: &str) -> Result<(), String> {
+        use carina_provider_aws::schemas::types::aws_validators;
+        use std::sync::OnceLock;
+        type ValidatorMap = HashMap<String, Box<dyn Fn(&str) -> Result<(), String> + Send + Sync>>;
+        static VALIDATORS: OnceLock<ValidatorMap> = OnceLock::new();
+        let validators = VALIDATORS.get_or_init(aws_validators);
+        if let Some(validator) = validators.get(type_name) {
+            validator(value)
+        } else {
+            Ok(())
+        }
+    }
+
     fn read(
         &self,
         id: &proto::ResourceId,
@@ -321,6 +334,72 @@ mod tests {
                 .iter()
                 .any(|s| s.resource_type == "aws.logs.log_group"),
             "aws.logs.log_group schema should be registered"
+        );
+    }
+
+    #[test]
+    fn validate_custom_type_accepts_valid_vpc_id() {
+        let provider = AwsProcessProvider::new();
+        assert!(
+            provider
+                .validate_custom_type("vpc_id", "vpc-12345678")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_custom_type_rejects_invalid_vpc_id() {
+        let provider = AwsProcessProvider::new();
+        assert!(
+            provider
+                .validate_custom_type("vpc_id", "subnet-12345678")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn validate_custom_type_accepts_valid_arn() {
+        let provider = AwsProcessProvider::new();
+        assert!(
+            provider
+                .validate_custom_type("arn", "arn:aws:s3:::my-bucket")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_custom_type_rejects_invalid_arn() {
+        let provider = AwsProcessProvider::new();
+        assert!(provider.validate_custom_type("arn", "not-an-arn").is_err());
+    }
+
+    #[test]
+    fn validate_custom_type_passes_unknown_type() {
+        let provider = AwsProcessProvider::new();
+        assert!(
+            provider
+                .validate_custom_type("unknown_type", "any-value")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_custom_type_accepts_valid_iam_role_arn() {
+        let provider = AwsProcessProvider::new();
+        assert!(
+            provider
+                .validate_custom_type("iam_role_arn", "arn:aws:iam::123456789012:role/my-role")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_custom_type_rejects_iam_policy_arn_for_role() {
+        let provider = AwsProcessProvider::new();
+        assert!(
+            provider
+                .validate_custom_type("iam_role_arn", "arn:aws:iam::123456789012:policy/my-policy")
+                .is_err()
         );
     }
 }

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -5,6 +5,8 @@
 
 pub use carina_aws_types::*;
 
+use std::collections::HashMap;
+
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeType, ResourceSchema};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
@@ -124,6 +126,81 @@ pub fn s3_grantee() -> AttributeType {
 }
 
 // iam_policy_document() is provided by `pub use carina_aws_types::*` above
+
+/// Type alias for custom type validator functions.
+pub type CustomValidatorFn = Box<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
+
+/// Register AWS type validators declaratively.
+///
+/// Generates a `HashMap<String, CustomValidatorFn>` from three categories:
+/// - `simple`: single-arg validators (`name => function`)
+/// - `prefixed`: prefixed resource ID validators (`name => prefix`)
+/// - `service_arn`: arbitrary closure validators (`name => closure_expr`)
+macro_rules! register_validators {
+    (
+        simple { $( $s_name:ident => $s_fn:expr ),* $(,)? }
+        prefixed { $( $p_name:ident => $p_prefix:expr ),* $(,)? }
+        service_arn { $( $a_name:ident => $a_expr:expr ),* $(,)? }
+    ) => {{
+        let mut m: HashMap<String, CustomValidatorFn> = HashMap::new();
+        $( m.insert(stringify!($s_name).to_string(), Box::new(|s: &str| ($s_fn)(s))); )*
+        $( m.insert(stringify!($p_name).to_string(), Box::new(|s: &str| validate_prefixed_resource_id(s, $p_prefix))); )*
+        $( m.insert(stringify!($a_name).to_string(), Box::new($a_expr)); )*
+        m
+    }};
+}
+
+/// Return all AWS type validators for use in `validate_custom_type`.
+///
+/// These validators are keyed by type name (matching the names used in schema
+/// `AttributeType::Custom` definitions) and wrap the validation functions from
+/// `carina-aws-types`.
+pub fn aws_validators() -> HashMap<String, CustomValidatorFn> {
+    register_validators! {
+        simple {
+            arn => validate_arn,
+            availability_zone => validate_availability_zone,
+            aws_resource_id => validate_aws_resource_id,
+            iam_role_id => validate_iam_role_id,
+            aws_account_id => validate_aws_account_id,
+            kms_key_id => validate_kms_key_id,
+            ipam_pool_id => validate_ipam_pool_id,
+            availability_zone_id => validate_availability_zone_id,
+        }
+        prefixed {
+            vpc_id => "vpc",
+            subnet_id => "subnet",
+            security_group_id => "sg",
+            internet_gateway_id => "igw",
+            route_table_id => "rtb",
+            nat_gateway_id => "nat",
+            transit_gateway_id => "tgw",
+            vpn_gateway_id => "vgw",
+            network_interface_id => "eni",
+            allocation_id => "eipalloc",
+            vpc_endpoint_id => "vpce",
+            vpc_peering_connection_id => "pcx",
+            instance_id => "i",
+            prefix_list_id => "pl",
+            carrier_gateway_id => "cagw",
+            local_gateway_id => "lgw",
+            network_acl_id => "acl",
+            transit_gateway_attachment_id => "tgw-attach",
+            flow_log_id => "fl",
+            ipam_id => "ipam",
+            subnet_route_table_association_id => "rtbassoc",
+            security_group_rule_id => "sgr",
+            vpc_cidr_block_association_id => "vpc-cidr-assoc",
+            tgw_route_table_id => "tgw-rtb",
+            egress_only_internet_gateway_id => "eigw",
+        }
+        service_arn {
+            iam_role_arn => |s: &str| validate_service_arn(s, "iam", Some("role/")),
+            iam_policy_arn => |s: &str| validate_service_arn(s, "iam", Some("policy/")),
+            kms_key_arn => |s: &str| validate_kms_key_id(s),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -359,5 +436,101 @@ mod tests {
                 .validate(&Value::String("Location.ap_northeast_1".to_string()))
                 .is_err()
         );
+    }
+
+    // aws_validators tests
+
+    #[test]
+    fn aws_validators_all_registered() {
+        let validators = aws_validators();
+
+        let expected_simple = [
+            "arn",
+            "availability_zone",
+            "aws_resource_id",
+            "iam_role_id",
+            "aws_account_id",
+            "kms_key_id",
+            "ipam_pool_id",
+            "availability_zone_id",
+        ];
+
+        let expected_prefixed = [
+            "vpc_id",
+            "subnet_id",
+            "security_group_id",
+            "internet_gateway_id",
+            "route_table_id",
+            "nat_gateway_id",
+            "transit_gateway_id",
+            "vpn_gateway_id",
+            "network_interface_id",
+            "allocation_id",
+            "vpc_endpoint_id",
+            "vpc_peering_connection_id",
+            "instance_id",
+            "prefix_list_id",
+            "carrier_gateway_id",
+            "local_gateway_id",
+            "network_acl_id",
+            "transit_gateway_attachment_id",
+            "flow_log_id",
+            "ipam_id",
+            "subnet_route_table_association_id",
+            "security_group_rule_id",
+            "vpc_cidr_block_association_id",
+            "tgw_route_table_id",
+            "egress_only_internet_gateway_id",
+        ];
+
+        let expected_arn = ["iam_role_arn", "iam_policy_arn", "kms_key_arn"];
+
+        let mut all_expected: Vec<&str> = Vec::new();
+        all_expected.extend_from_slice(&expected_simple);
+        all_expected.extend_from_slice(&expected_prefixed);
+        all_expected.extend_from_slice(&expected_arn);
+
+        for name in &all_expected {
+            assert!(
+                validators.contains_key(*name),
+                "Missing validator: {}",
+                name
+            );
+        }
+
+        assert_eq!(
+            validators.len(),
+            all_expected.len(),
+            "Validator count mismatch: expected {}, got {}. Extra keys: {:?}",
+            all_expected.len(),
+            validators.len(),
+            validators
+                .keys()
+                .filter(|k| !all_expected.contains(&k.as_str()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn aws_validators_produce_correct_results() {
+        let validators = aws_validators();
+
+        // Test a prefixed resource ID validator
+        let vpc_validator = validators.get("vpc_id").unwrap();
+        assert!(vpc_validator("vpc-12345678").is_ok());
+        assert!(vpc_validator("subnet-12345678").is_err());
+
+        // Test a single-arg validator
+        let arn_validator = validators.get("arn").unwrap();
+        assert!(arn_validator("arn:aws:s3:::my-bucket").is_ok());
+        assert!(arn_validator("not-an-arn").is_err());
+
+        // Test a service ARN validator
+        let iam_role_arn_validator = validators.get("iam_role_arn").unwrap();
+        assert!(iam_role_arn_validator("arn:aws:iam::123456789012:role/my-role").is_ok());
+        assert!(iam_role_arn_validator("arn:aws:s3:::my-bucket").is_err());
+
+        // Test unknown type returns no validator (not an error)
+        assert!(!validators.contains_key("unknown_type"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `aws_validators()` function in `schemas/types.rs` using the same `register_validators!` macro pattern as the AWSCC provider
- Implement `CarinaProvider::validate_custom_type` on `AwsProcessProvider` with `OnceLock`-cached validator HashMap for efficient repeated lookups
- Update `carina-plugin-wit` submodule to include the `validate-custom-type` WIT definition

Covers all shared validators from `carina-aws-types`: ARN, prefixed resource IDs (vpc_id, subnet_id, sg, igw, etc.), service ARNs (iam_role_arn, iam_policy_arn), and standalone validators (kms_key_id, availability_zone, etc.).

Refs carina-rs/carina#1722

## Test plan
- [x] `cargo test -p carina-provider-aws` -- all 155 tests pass
- [x] `cargo clippy -p carina-provider-aws -- -D warnings` -- clean
- [ ] CI passes