### PR TITLE
feat: update AttributeType::Map to struct variant with key field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,6 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f210a535bcb822a3a29adc2685fed67427a02f9f"
 dependencies = [
  "argon2",
  "futures",
@@ -632,7 +631,6 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f210a535bcb822a3a29adc2685fed67427a02f9f"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -675,7 +673,6 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f210a535bcb822a3a29adc2685fed67427a02f9f"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -129,7 +129,7 @@ pub fn region_completions(prefix: &str) -> Vec<CompletionValue> {
 
 /// Tags type for AWS resources (map of string values)
 pub fn tags_type() -> AttributeType {
-    AttributeType::Map(Box::new(AttributeType::String))
+    AttributeType::map(AttributeType::String)
 }
 
 /// Validate that a tags map does not use Key/Value pair list structure.
@@ -1187,9 +1187,7 @@ fn iam_policy_statement() -> AttributeType {
                 .with_provider_name("NotPrincipal"),
             StructField::new(
                 "condition",
-                AttributeType::Map(Box::new(AttributeType::Map(Box::new(
-                    string_or_list_of_strings(),
-                )))),
+                AttributeType::map(AttributeType::map(string_or_list_of_strings())),
             )
             .with_provider_name("Condition"),
         ],

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1009,7 +1009,7 @@ fn resolve_type(
             }
         }
         Some(ShapeKind::Map) => (
-            "AttributeType::Map(Box::new(AttributeType::String))".to_string(),
+            "AttributeType::map(AttributeType::String)".to_string(),
             None,
         ),
         Some(ShapeKind::Structure) => {

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -168,9 +168,10 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             inner: Box::new(proto_to_core_attribute_type(inner)),
             ordered: *ordered,
         },
-        ProtoAttributeType::Map { inner } => {
-            CoreAttributeType::Map(Box::new(proto_to_core_attribute_type(inner)))
-        }
+        ProtoAttributeType::Map { inner, key } => CoreAttributeType::Map {
+            key: Box::new(proto_to_core_attribute_type(key)),
+            value: Box::new(proto_to_core_attribute_type(inner)),
+        },
         ProtoAttributeType::Struct { name, fields } => CoreAttributeType::Struct {
             name: name.clone(),
             fields: fields.iter().map(proto_to_core_struct_field).collect(),
@@ -262,8 +263,9 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             inner: Box::new(core_to_proto_attribute_type(inner)),
             ordered: *ordered,
         },
-        CoreAttributeType::Map(inner) => ProtoAttributeType::Map {
+        CoreAttributeType::Map { key, value: inner } => ProtoAttributeType::Map {
             inner: Box::new(core_to_proto_attribute_type(inner)),
+            key: Box::new(core_to_proto_attribute_type(key)),
         },
         CoreAttributeType::Struct { name, fields } => ProtoAttributeType::Struct {
             name: name.clone(),


### PR DESCRIPTION
## Summary
- Update `AttributeType::Map` usage from tuple variant `Map(Box<AttributeType>)` to struct variant `Map { key, value }` to match carina-core changes
- Use `AttributeType::map()` constructor for string-keyed maps in `carina-aws-types` and codegen output
- Update `proto_to_core` and `core_to_proto` conversion functions to handle the new `key` field

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (257 tests)
- [x] `cargo clippy -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)