### PR TITLE
chore: regenerate Cargo.lock with git source references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
+source = "git+https://github.com/carina-rs/carina#397e03fbde52ed7c8be12d4c1f91ed3d5d131a52"
 dependencies = [
  "argon2",
  "futures",
@@ -631,6 +632,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
+source = "git+https://github.com/carina-rs/carina#397e03fbde52ed7c8be12d4c1f91ed3d5d131a52"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -673,6 +675,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
+source = "git+https://github.com/carina-rs/carina#397e03fbde52ed7c8be12d4c1f91ed3d5d131a52"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
## Summary

- Add the missing \`source = "git+https://github.com/carina-rs/carina#<sha>"\` line to the \`carina-core\`, \`carina-plugin-sdk\`, and \`carina-provider-protocol\` entries in \`Cargo.lock\`. Produced by a fresh \`cargo check\` off current main, so this is just what cargo expects the lockfile to look like.
- This unbreaks the \`Codegen Check\` job on main, which was failing because the script regenerates the lockfile and \`git diff --exit-code\` caught the otherwise invisible drift.

This is the minimal fix. The durable follow-up (pinning to a specific \`rev\` / \`tag\`, or a pre-commit guard that rewrites the lockfile) is left for a later change, tracked in #100.

## Test plan

- [ ] `Codegen Check` passes on the PR run (was failing on recent main runs).
- [ ] After merge, confirm the main-branch `Codegen Check` stays green.

Closes #100