### PR TITLE
Add Route 53 record set management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-route53"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27aa79519d4d75164790b47ba99b8eee18a36e317f87f96bdffac12457f18a29"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,7 +640,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
+source = "git+https://github.com/carina-rs/carina#523eb18f311e9166cbc6760b77192c1c865946e3"
 dependencies = [
  "argon2",
  "futures",
@@ -632,7 +656,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
+source = "git+https://github.com/carina-rs/carina#523eb18f311e9166cbc6760b77192c1c865946e3"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -654,6 +678,7 @@ dependencies = [
  "aws-sdk-iam",
  "aws-sdk-identitystore",
  "aws-sdk-organizations",
+ "aws-sdk-route53",
  "aws-sdk-s3",
  "aws-sdk-sts",
  "aws-smithy-async",
@@ -675,7 +700,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
+source = "git+https://github.com/carina-rs/carina#523eb18f311e9166cbc6760b77192c1c865946e3"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -78,6 +78,8 @@ struct AttrInfo {
     is_create_only: bool,
     /// Whether the field is read-only
     is_read_only: bool,
+    /// Whether the field contributes to anonymous resource identity hashing
+    is_identity: bool,
     /// Description from Smithy docs
     description: Option<String>,
     /// Enum info if this attribute is an enum
@@ -136,6 +138,7 @@ fn main() -> Result<()> {
     all_resources.extend(resource_defs::s3_resources());
     all_resources.extend(resource_defs::sts_resources());
     all_resources.extend(resource_defs::organizations_resources());
+    all_resources.extend(resource_defs::route53_resources());
 
     // Filter to requested resource if specified
     let resources: Vec<&ResourceDef> = if let Some(ref name) = args.resource {
@@ -257,6 +260,9 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     // Build read-only override set
     let read_only_overrides: HashSet<&str> = res.read_only_overrides.iter().copied().collect();
 
+    // Build identity override set
+    let identity_overrides: HashSet<&str> = res.identity_overrides.iter().copied().collect();
+
     // Build extra read-only set
     let extra_read_only: HashSet<&str> = res.extra_read_only.iter().copied().collect();
 
@@ -282,6 +288,18 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             model
                 .operation_input(&create_op_id)
                 .with_context(|| format!("Cannot find create input for {}", create_op_id))?,
+        )
+    } else {
+        None
+    };
+
+    // Resolve schema structure (for resources with non-standard create APIs)
+    let schema_structure = if let Some(schema_struct_name) = res.schema_structure {
+        let schema_structure_id = format!("{}#{}", ns, schema_struct_name);
+        Some(
+            model
+                .get_structure(&schema_structure_id)
+                .with_context(|| format!("Cannot find schema structure {}", schema_structure_id))?,
         )
     } else {
         None
@@ -316,9 +334,21 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     let mut all_enums: BTreeMap<String, EnumInfo> = BTreeMap::new();
     let mut all_ranged_ints: BTreeMap<String, IntRange> = BTreeMap::new();
 
-    // Collect writable fields from create input (empty for data sources)
+    // Collect writable fields: from schema_structure if set, otherwise from create input
     let mut writable_fields: BTreeMap<String, &carina_smithy::ShapeRef> = BTreeMap::new();
-    if let Some(create_input) = &create_input {
+    if let Some(schema_struct) = &schema_structure {
+        // Use schema_structure members as writable fields.
+        // Unlike create input, don't skip the identifier — it's a user-set attribute.
+        for (name, member_ref) in &schema_struct.members {
+            if exclude.contains(name.as_str()) {
+                continue;
+            }
+            if name == "Tags" {
+                continue;
+            }
+            writable_fields.insert(name.clone(), member_ref);
+        }
+    } else if let Some(create_input) = &create_input {
         for (name, member_ref) in &create_input.members {
             if exclude.contains(name.as_str()) {
                 continue;
@@ -446,6 +476,10 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             false
         } else if extra_writable_names.contains(name.as_str()) {
             true // Extra writable fields are always create-only
+        } else if schema_structure.is_some() {
+            // For schema_structure resources, only explicit overrides are create-only.
+            // The default is writable since the update operation is hand-coded.
+            create_only_overrides.contains(name.as_str())
         } else {
             create_only_overrides.contains(name.as_str())
                 || !updatable_fields.contains(name.as_str())
@@ -471,6 +505,8 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             name,
         );
 
+        let is_identity = identity_overrides.contains(name.as_str());
+
         attrs.push(AttrInfo {
             snake_name,
             provider_name: name.clone(),
@@ -478,6 +514,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_required,
             is_create_only,
             is_read_only,
+            is_identity,
             description,
             enum_info,
         });
@@ -503,6 +540,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_required: false,
             is_create_only: true,
             is_read_only: false,
+            is_identity: identity_overrides.contains(extra.name),
             description: extra.description.map(|s| s.to_string()),
             enum_info: None,
         });
@@ -534,6 +572,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_required: false,
             is_create_only: false,
             is_read_only: true,
+            is_identity: false,
             description,
             enum_info,
         });
@@ -756,6 +795,9 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         }
         if attr.is_create_only {
             attr_code.push_str("\n\x20               .create_only()");
+        }
+        if attr.is_identity {
+            attr_code.push_str("\n\x20               .identity()");
         }
 
         if let Some(ref desc) = attr.description {
@@ -2914,6 +2956,7 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "sts.caller_identity" => "AWS::STS::CallerIdentity",
         "organizations.organization" => "AWS::Organizations::Organization",
         "organizations.account" => "AWS::Organizations::Account",
+        "route53.record_set" => "AWS::Route53::RecordSet",
         _ => panic!(
             "Unknown resource: {}. Add it to cf_type_name().",
             resource_name

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -32,6 +32,10 @@ pub struct ResourceDef {
     pub name: &'static str,
     /// Smithy service namespace (e.g., "com.amazonaws.ec2")
     pub service_namespace: &'static str,
+    /// Smithy structure to derive writable fields from, instead of the create op input.
+    /// Use for APIs where resource fields are nested (e.g., Route 53 `ResourceRecordSet`
+    /// inside `ChangeResourceRecordSets`). When None, fields come from `create_op` input.
+    pub schema_structure: Option<&'static str>,
     /// Whether delete is a single API call (delete_op + identifier).
     /// true: VPC, Subnet, Route Table, Security Group, S3 Bucket
     /// false: IGW (detach+delete), Route (no-op), SG rules (multi-rule revoke)
@@ -77,6 +81,9 @@ pub struct ResourceDef {
     /// Extra writable fields to add as create-only attributes.
     /// These are fields not present in the create operation input.
     pub extra_writable: Vec<ExtraField>,
+    /// Fields to mark as identity (contribute to anonymous resource identifier hashing).
+    /// Use for attributes that distinguish same-type resources sharing create-only values.
+    pub identity_overrides: Vec<&'static str>,
 }
 
 /// How fields are passed to an update API operation.
@@ -115,6 +122,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         ResourceDef {
             name: "ec2.vpc",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: false,
             create_op: "CreateVpc",
@@ -146,11 +154,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.subnet
         ResourceDef {
             name: "ec2.subnet",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: false,
             create_op: "CreateSubnet",
@@ -178,11 +188,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.internet_gateway
         ResourceDef {
             name: "ec2.internet_gateway",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: false,
             noop_update: true,
             create_op: "CreateInternetGateway",
@@ -201,11 +213,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.route_table
         ResourceDef {
             name: "ec2.route_table",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateRouteTable",
@@ -224,11 +238,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.route
         ResourceDef {
             name: "ec2.route",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: false,
             noop_update: false,
             create_op: "CreateRoute",
@@ -265,11 +281,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.security_group
         ResourceDef {
             name: "ec2.security_group",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateSecurityGroup",
@@ -288,11 +306,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.security_group_ingress
         ResourceDef {
             name: "ec2.security_group_ingress",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: false,
             noop_update: false,
             create_op: "AuthorizeSecurityGroupIngress",
@@ -340,11 +360,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                     description: Some("The ID of the source security group."),
                 },
             ],
+            identity_overrides: vec![],
         },
         // ec2.security_group_egress
         ResourceDef {
             name: "ec2.security_group_egress",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: false,
             noop_update: false,
             create_op: "AuthorizeSecurityGroupEgress",
@@ -392,11 +414,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                     description: Some("The ID of the destination security group."),
                 },
             ],
+            identity_overrides: vec![],
         },
         // ec2.egress_only_internet_gateway
         ResourceDef {
             name: "ec2.egress_only_internet_gateway",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateEgressOnlyInternetGateway",
@@ -415,11 +439,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.eip
         ResourceDef {
             name: "ec2.eip",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "AllocateAddress",
@@ -444,11 +470,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec!["PublicIp"],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.flow_log
         ResourceDef {
             name: "ec2.flow_log",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateFlowLogs",
@@ -476,11 +504,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.nat_gateway
         ResourceDef {
             name: "ec2.nat_gateway",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateNatGateway",
@@ -506,11 +536,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.subnet_route_table_association
         ResourceDef {
             name: "ec2.subnet_route_table_association",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "AssociateRouteTable",
@@ -529,11 +561,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.transit_gateway
         ResourceDef {
             name: "ec2.transit_gateway",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: false,
             create_op: "CreateTransitGateway",
@@ -555,11 +589,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.transit_gateway_attachment
         ResourceDef {
             name: "ec2.transit_gateway_attachment",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateTransitGatewayVpcAttachment",
@@ -578,11 +614,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.vpc_endpoint
         ResourceDef {
             name: "ec2.vpc_endpoint",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: false,
             create_op: "CreateVpcEndpoint",
@@ -611,11 +649,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.vpc_gateway_attachment
         ResourceDef {
             name: "ec2.vpc_gateway_attachment",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: false,
             noop_update: true,
             create_op: "AttachInternetGateway",
@@ -645,11 +685,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                     description: Some("The ID of the VPN gateway."),
                 },
             ],
+            identity_overrides: vec![],
         },
         // ec2.vpc_peering_connection
         ResourceDef {
             name: "ec2.vpc_peering_connection",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateVpcPeeringConnection",
@@ -668,11 +710,13 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // ec2.vpn_gateway
         ResourceDef {
             name: "ec2.vpn_gateway",
             service_namespace: "com.amazonaws.ec2",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateVpnGateway",
@@ -691,6 +735,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
     ]
 }
@@ -702,6 +747,7 @@ pub fn sts_resources() -> Vec<ResourceDef> {
         ResourceDef {
             name: "sts.caller_identity",
             service_namespace: "com.amazonaws.sts",
+            schema_structure: None,
             simple_delete: false,
             noop_update: false,
             create_op: "",
@@ -728,6 +774,7 @@ pub fn sts_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
     ]
 }
@@ -739,6 +786,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
         ResourceDef {
             name: "organizations.organization",
             service_namespace: "com.amazonaws.organizations",
+            schema_structure: None,
             simple_delete: true,
             noop_update: true,
             create_op: "CreateOrganization",
@@ -762,11 +810,13 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             ],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
         // organizations.account
         ResourceDef {
             name: "organizations.account",
             service_namespace: "com.amazonaws.organizations",
+            schema_structure: None,
             simple_delete: false,
             noop_update: true,
             create_op: "CreateAccount",
@@ -790,6 +840,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             extra_read_only: vec!["Arn", "Name", "Status", "JoinedMethod", "JoinedTimestamp"],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
         },
     ]
 }
@@ -801,6 +852,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
         ResourceDef {
             name: "s3.bucket",
             service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
             simple_delete: false, // manually implemented to support lifecycle.force_delete
             noop_update: false,
             create_op: "CreateBucket",
@@ -853,6 +905,64 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             extra_read_only: vec![],
             read_only_overrides: vec![],
             extra_writable: vec![],
+            identity_overrides: vec![],
+        },
+    ]
+}
+
+/// Returns Route 53 resource definitions.
+pub fn route53_resources() -> Vec<ResourceDef> {
+    vec![
+        // route53.record_set
+        // Uses schema_structure because ChangeResourceRecordSets wraps fields
+        // in a nested ChangeBatch, not as top-level input parameters.
+        ResourceDef {
+            name: "route53.record_set",
+            service_namespace: "com.amazonaws.route53",
+            schema_structure: Some("ResourceRecordSet"),
+            simple_delete: false,
+            noop_update: false,
+            create_op: "ChangeResourceRecordSets",
+            read_structure: Some("ResourceRecordSet"),
+            read_ops: vec![],
+            delete_op: "ChangeResourceRecordSets",
+            update_ops: vec![],
+            identifier: "Name",
+            has_tags: false,
+            type_overrides: vec![
+                // Smithy has ResourceRecords as List<Struct{Value}>, but for DSL
+                // simplicity we flatten to List<String> since each record is a
+                // single value string.
+                (
+                    "ResourceRecords",
+                    "AttributeType::list(AttributeType::String)",
+                ),
+            ],
+            exclude_fields: vec![
+                // Routing policy fields — out of scope for initial version
+                "SetIdentifier",
+                "Weight",
+                "Region",
+                "Failover",
+                "MultiValueAnswer",
+                "GeoLocation",
+                "GeoProximityLocation",
+                "HealthCheckId",
+                "TrafficPolicyInstanceId",
+                "CidrRoutingConfig",
+            ],
+            create_only_overrides: vec!["Name"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Name", "Type"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![ExtraField {
+                name: "HostedZoneId",
+                read_source: None,
+                description: Some("The ID of the hosted zone that contains this record set."),
+            }],
+            identity_overrides: vec!["Type"],
         },
     ]
 }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -33,6 +33,7 @@ aws-sdk-iam = { version = "1", default-features = false, features = ["behavior-v
 aws-sdk-organizations = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-identitystore = { version = "1", default-features = false, features = ["behavior-version-latest"] }
+aws-sdk-route53 = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -218,6 +218,7 @@ fn _proto_to_core_attribute_schema(a: &ProtoAttributeSchema) -> CoreAttributeSch
         removable: a.removable,
         block_name: a.block_name.clone(),
         write_only: a.write_only,
+        identity: a.identity,
     }
 }
 
@@ -311,6 +312,7 @@ fn core_to_proto_attribute_schema(a: &CoreAttributeSchema) -> ProtoAttributeSche
         block_name: a.block_name.clone(),
         provider_name: a.provider_name.clone(),
         removable: a.removable,
+        identity: a.identity,
     }
 }
 

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -23,6 +23,7 @@ use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_iam::Client as IamClient;
 use aws_sdk_identitystore::Client as IdentityStoreClient;
 use aws_sdk_organizations::Client as OrganizationsClient;
+use aws_sdk_route53::Client as Route53Client;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sts::Client as StsClient;
 
@@ -35,6 +36,7 @@ pub struct AwsProvider {
     sts_client: StsClient,
     organizations_client: OrganizationsClient,
     identitystore_client: IdentityStoreClient,
+    route53_client: Route53Client,
     region: String,
 }
 
@@ -51,6 +53,7 @@ impl AwsProvider {
             sts_client: StsClient::new(&config),
             organizations_client: OrganizationsClient::new(&config),
             identitystore_client: IdentityStoreClient::new(&config),
+            route53_client: Route53Client::new(&config),
             region: region.to_string(),
         }
     }
@@ -83,6 +86,7 @@ impl AwsProvider {
         sts_client: StsClient,
         organizations_client: OrganizationsClient,
         identitystore_client: IdentityStoreClient,
+        route53_client: Route53Client,
         region: String,
     ) -> Self {
         Self {
@@ -93,6 +97,7 @@ impl AwsProvider {
             sts_client,
             organizations_client,
             identitystore_client,
+            route53_client,
             region,
         }
     }

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -80,6 +80,10 @@ impl Provider for AwsProvider {
                 }
                 "iam.role" => self.read_iam_role(&id, identifier.as_deref()).await,
                 "logs.log_group" => self.read_logs_log_group(&id, identifier.as_deref()).await,
+                "route53.record_set" => {
+                    self.read_route53_record_set(&id, identifier.as_deref())
+                        .await
+                }
                 "sts.caller_identity" => self.read_sts_caller_identity(&id).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
@@ -181,6 +185,7 @@ impl Provider for AwsProvider {
                 }
                 "iam.role" => self.create_iam_role(resource).await,
                 "logs.log_group" => self.create_logs_log_group(resource).await,
+                "route53.record_set" => self.create_route53_record_set(resource).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
                     resource.id.resource_type
@@ -276,6 +281,7 @@ impl Provider for AwsProvider {
                 }
                 "iam.role" => self.update_iam_role(id, &identifier, &from, to).await,
                 "logs.log_group" => self.update_logs_log_group(id, &identifier, &from, to).await,
+                "route53.record_set" => self.update_route53_record_set(id, &identifier, to).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
                     id.resource_type
@@ -343,6 +349,7 @@ impl Provider for AwsProvider {
                 }
                 "iam.role" => self.delete_iam_role(id, &identifier).await,
                 "logs.log_group" => self.delete_logs_log_group(id, &identifier).await,
+                "route53.record_set" => self.delete_route53_record_set(id, &identifier).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
                     id.resource_type

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -12,6 +12,7 @@ pub mod iam;
 pub mod identitystore;
 pub mod logs;
 pub mod organizations;
+pub mod route53;
 pub mod s3;
 pub mod sts;
 
@@ -42,6 +43,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         logs::log_group::logs_log_group_config(),
         organizations::account::organizations_account_config(),
         organizations::organization::organizations_organization_config(),
+        route53::record_set::route53_record_set_config(),
         s3::bucket::s3_bucket_config(),
         sts::caller_identity::sts_caller_identity_config(),
     ]
@@ -81,6 +83,7 @@ pub fn get_enum_valid_values(
         logs::log_group::enum_valid_values(),
         organizations::account::enum_valid_values(),
         organizations::organization::enum_valid_values(),
+        route53::record_set::enum_valid_values(),
         s3::bucket::enum_valid_values(),
         sts::caller_identity::enum_valid_values(),
     ];
@@ -175,6 +178,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "organizations.organization" {
         return organizations::organization::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "route53.record_set" {
+        return route53::record_set::enum_alias_reverse(attr_name, value);
     }
     if resource_type == "s3.bucket" {
         return s3::bucket::enum_alias_reverse(attr_name, value);
@@ -356,6 +362,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in organizations::organization::enum_alias_entries() {
         map.entry("organizations.organization".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in route53::record_set::enum_alias_entries() {
+        map.entry("route53.record_set".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/route53/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/mod.rs
@@ -1,0 +1,4 @@
+// Re-export parent types so resource modules can use `super::` to access them.
+pub use super::*;
+
+pub mod record_set;

--- a/carina-provider-aws/src/schemas/generated/route53/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/mod.rs
@@ -1,3 +1,8 @@
+//! Auto-generated — DO NOT EDIT MANUALLY
+//!
+//! Regenerate with:
+//!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh
+
 // Re-export parent types so resource modules can use `super::` to access them.
 pub use super::*;
 

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -1,84 +1,91 @@
-//! record_set schema definition for AWS Route 53
+//! route53.record_set schema definition for AWS Cloud Control
 //!
-//! Hand-written: Route 53 RecordSet uses the ChangeResourceRecordSets API
-//! which is not available via Cloud Control, so this is SDK-direct.
+//! Auto-generated from Smithy model: com.amazonaws.route53
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
+use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
-/// Returns the schema config for route53.record_set
+const VALID_TYPE: &[&str] = &[
+    "A", "AAAA", "CAA", "CNAME", "DS", "HTTPS", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF", "SRV",
+    "SSHFP", "SVCB", "TLSA", "TXT",
+];
+
+fn validate_ttl_range(value: &Value) -> Result<(), String> {
+    if let Value::Int(n) = value {
+        if *n < 0 || *n > 2147483647 {
+            Err(format!("Value {} is out of range 0..=2147483647", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+/// Returns the schema config for route53.record_set (Smithy: com.amazonaws.route53)
 pub fn route53_record_set_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::Route53::RecordSet",
         resource_type_name: "route53.record_set",
         has_tags: false,
         schema: ResourceSchema::new("aws.route53.record_set")
-            .with_description(
-                "A DNS record in a Route 53 hosted zone. \
-                 Managed via ChangeResourceRecordSets (SDK-direct).",
-            )
-            .attribute(
-                AttributeSchema::new("hosted_zone_id", AttributeType::String)
-                    .required()
-                    .create_only()
-                    .with_description("The ID of the hosted zone that contains this record set.")
-                    .with_provider_name("HostedZoneId"),
-            )
-            .attribute(
-                AttributeSchema::new("name", AttributeType::String)
-                    .required()
-                    .create_only()
-                    .with_description(
-                        "The DNS name, e.g. 'example.com' or 'sub.example.com'. \
-                         Route 53 appends a trailing dot automatically.",
-                    )
-                    .with_provider_name("Name"),
-            )
-            .attribute(
-                AttributeSchema::new("type", AttributeType::String)
-                    .required()
-                    .identity()
-                    .with_description(
-                        "The DNS record type: A, AAAA, CNAME, MX, NS, PTR, SOA, SPF, SRV, TXT.",
-                    )
-                    .with_provider_name("Type"),
-            )
-            .attribute(
-                AttributeSchema::new("ttl", AttributeType::Int)
-                    .with_description("The time to live (TTL) in seconds.")
-                    .with_provider_name("TTL"),
-            )
-            .attribute(
-                AttributeSchema::new(
-                    "resource_records",
-                    AttributeType::list(AttributeType::String),
-                )
-                .with_description("The resource record values (e.g., IP addresses for A records).")
-                .with_provider_name("ResourceRecords"),
-            )
-            .attribute(
-                AttributeSchema::new(
-                    "alias_target",
-                    AttributeType::Struct {
-                        name: "AliasTarget".to_string(),
-                        fields: vec![
-                            StructField::new("dns_name", AttributeType::String)
-                                .required()
-                                .with_provider_name("DNSName"),
-                            StructField::new("hosted_zone_id", AttributeType::String)
-                                .required()
-                                .with_provider_name("HostedZoneId"),
-                            StructField::new("evaluate_target_health", AttributeType::Bool)
-                                .with_provider_name("EvaluateTargetHealth"),
-                        ],
-                    },
-                )
-                .with_description(
-                    "Alias target for AWS resources (ELB, CloudFront, S3, etc.). \
-                     Mutually exclusive with ttl and resource_records.",
-                )
+        .with_description("Information about the resource record set to create or delete.")
+        .attribute(
+            AttributeSchema::new("alias_target", AttributeType::Struct {
+                    name: "AliasTarget".to_string(),
+                    fields: vec![
+                    StructField::new("dns_name", AttributeType::String).required().with_description("Alias resource record sets only: The value that you specify depends on where you want to route queries: Amazon API Gateway custom regional APIs and ed...").with_provider_name("DNSName"),
+                    StructField::new("evaluate_target_health", AttributeType::Bool).required().with_description("Applies only to alias, failover alias, geolocation alias, latency alias, and weighted alias resource record sets: When EvaluateTargetHealth is true, a...").with_provider_name("EvaluateTargetHealth"),
+                    StructField::new("hosted_zone_id", AttributeType::String).required().with_description("Alias resource records sets only: The value used depends on where you want to route traffic: Amazon API Gateway custom regional APIs and edge-optimize...").with_provider_name("HostedZoneId")
+                    ],
+                })
+                .with_description("Alias resource record sets only: Information about the Amazon Web Services resource, such as a CloudFront distribution or an Amazon S3 bucket, that yo...")
                 .with_provider_name("AliasTarget"),
-            ),
+        )
+        .attribute(
+            AttributeSchema::new("name", AttributeType::String)
+                .required()
+                .create_only()
+                .with_description("For ChangeResourceRecordSets requests, the name of the record that you want to create, update, or delete. For ListResourceRecordSets responses, the na...")
+                .with_provider_name("Name"),
+        )
+        .attribute(
+            AttributeSchema::new("resource_records", AttributeType::list(AttributeType::String))
+                .with_description("Information about the resource records to act upon. If you're creating an alias resource record set, omit ResourceRecords.")
+                .with_provider_name("ResourceRecords"),
+        )
+        .attribute(
+            AttributeSchema::new("ttl", AttributeType::Custom {
+                name: "Int(0..=2147483647)".to_string(),
+                base: Box::new(AttributeType::Int),
+                validate: validate_ttl_range,
+                namespace: None,
+                to_dsl: None,
+            })
+                .with_description("The resource record cache time to live (TTL), in seconds. Note the following: If you're creating or updating an alias resource record set, omit TTL. A...")
+                .with_provider_name("TTL"),
+        )
+        .attribute(
+            AttributeSchema::new("type", AttributeType::StringEnum {
+                name: "Type".to_string(),
+                values: vec!["A".to_string(), "AAAA".to_string(), "CAA".to_string(), "CNAME".to_string(), "DS".to_string(), "HTTPS".to_string(), "MX".to_string(), "NAPTR".to_string(), "NS".to_string(), "PTR".to_string(), "SOA".to_string(), "SPF".to_string(), "SRV".to_string(), "SSHFP".to_string(), "SVCB".to_string(), "TLSA".to_string(), "TXT".to_string()],
+                namespace: Some("aws.route53.record_set".to_string()),
+                to_dsl: None,
+            })
+                .required()
+                .identity()
+                .with_description("The DNS record type. For information about different record types and how data is encoded for them, see Supported DNS Resource Record Types in the Ama...")
+                .with_provider_name("Type"),
+        )
+        .attribute(
+            AttributeSchema::new("hosted_zone_id", AttributeType::String)
+                .create_only()
+                .with_description("The ID of the hosted zone that contains this record set.")
+                .with_provider_name("HostedZoneId"),
+        )
     }
 }
 
@@ -87,10 +94,11 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("route53.record_set", &[])
+    ("route53.record_set", &[("type", VALID_TYPE)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     let _ = (attr_name, value);
     None

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -1,0 +1,102 @@
+//! record_set schema definition for AWS Route 53
+//!
+//! Hand-written: Route 53 RecordSet uses the ChangeResourceRecordSets API
+//! which is not available via Cloud Control, so this is SDK-direct.
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+
+/// Returns the schema config for route53.record_set
+pub fn route53_record_set_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::Route53::RecordSet",
+        resource_type_name: "route53.record_set",
+        has_tags: false,
+        schema: ResourceSchema::new("aws.route53.record_set")
+            .with_description(
+                "A DNS record in a Route 53 hosted zone. \
+                 Managed via ChangeResourceRecordSets (SDK-direct).",
+            )
+            .attribute(
+                AttributeSchema::new("hosted_zone_id", AttributeType::String)
+                    .required()
+                    .create_only()
+                    .with_description("The ID of the hosted zone that contains this record set.")
+                    .with_provider_name("HostedZoneId"),
+            )
+            .attribute(
+                AttributeSchema::new("name", AttributeType::String)
+                    .required()
+                    .create_only()
+                    .with_description(
+                        "The DNS name, e.g. 'example.com' or 'sub.example.com'. \
+                         Route 53 appends a trailing dot automatically.",
+                    )
+                    .with_provider_name("Name"),
+            )
+            .attribute(
+                AttributeSchema::new("type", AttributeType::String)
+                    .required()
+                    .identity()
+                    .with_description(
+                        "The DNS record type: A, AAAA, CNAME, MX, NS, PTR, SOA, SPF, SRV, TXT.",
+                    )
+                    .with_provider_name("Type"),
+            )
+            .attribute(
+                AttributeSchema::new("ttl", AttributeType::Int)
+                    .with_description("The time to live (TTL) in seconds.")
+                    .with_provider_name("TTL"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "resource_records",
+                    AttributeType::list(AttributeType::String),
+                )
+                .with_description("The resource record values (e.g., IP addresses for A records).")
+                .with_provider_name("ResourceRecords"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "alias_target",
+                    AttributeType::Struct {
+                        name: "AliasTarget".to_string(),
+                        fields: vec![
+                            StructField::new("dns_name", AttributeType::String)
+                                .required()
+                                .with_provider_name("DNSName"),
+                            StructField::new("hosted_zone_id", AttributeType::String)
+                                .required()
+                                .with_provider_name("HostedZoneId"),
+                            StructField::new("evaluate_target_health", AttributeType::Bool)
+                                .with_provider_name("EvaluateTargetHealth"),
+                        ],
+                    },
+                )
+                .with_description(
+                    "Alias target for AWS resources (ELB, CloudFront, S3, etc.). \
+                     Mutually exclusive with ttl and resource_records.",
+                )
+                .with_provider_name("AliasTarget"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("route53.record_set", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/services/mod.rs
+++ b/carina-provider-aws/src/services/mod.rs
@@ -3,5 +3,6 @@ pub mod iam;
 pub mod identitystore;
 pub mod logs;
 pub mod organizations;
+pub mod route53;
 pub mod s3;
 pub mod sts;

--- a/carina-provider-aws/src/services/route53/mod.rs
+++ b/carina-provider-aws/src/services/route53/mod.rs
@@ -1,0 +1,1 @@
+pub mod record_set;

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -1,0 +1,358 @@
+//! Route 53 RecordSet service implementation.
+//!
+//! Uses ChangeResourceRecordSets (UPSERT/DELETE) and ListResourceRecordSets
+//! for CRUD operations. Cloud Control does not support Route 53 records.
+
+use std::collections::HashMap;
+
+use aws_sdk_route53::types::{
+    AliasTarget, Change, ChangeAction, ChangeBatch, ResourceRecord, ResourceRecordSet, RrType,
+};
+
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+
+use crate::AwsProvider;
+use crate::helpers::require_string_attr;
+
+/// Composite identifier format: `hosted_zone_id|name|type`
+fn make_identifier(hosted_zone_id: &str, name: &str, record_type: &str) -> String {
+    format!("{}|{}|{}", hosted_zone_id, name, record_type)
+}
+
+fn parse_identifier(identifier: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = identifier.splitn(3, '|');
+    let zone_id = parts.next()?;
+    let name = parts.next()?;
+    let record_type = parts.next()?;
+    Some((zone_id, name, record_type))
+}
+
+/// Normalize a DNS name by ensuring it has a trailing dot (Route 53 convention).
+fn normalize_dns_name(name: &str) -> String {
+    if name.ends_with('.') {
+        name.to_string()
+    } else {
+        format!("{}.", name)
+    }
+}
+
+/// Strip the trailing dot for display/comparison with user input.
+fn strip_trailing_dot(name: &str) -> String {
+    name.strip_suffix('.').unwrap_or(name).to_string()
+}
+
+fn extract_string(value: &Value) -> Option<&str> {
+    if let Value::String(s) = value {
+        Some(s.as_str())
+    } else {
+        None
+    }
+}
+
+fn build_resource_records(records: &[Value]) -> Vec<ResourceRecord> {
+    records
+        .iter()
+        .filter_map(|v| {
+            if let Value::String(s) = v {
+                ResourceRecord::builder().value(s.clone()).build().ok()
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn build_alias_target_from_map(
+    alias: &HashMap<String, Value>,
+    id: &ResourceId,
+) -> ProviderResult<AliasTarget> {
+    let dns_name = alias
+        .get("dns_name")
+        .and_then(extract_string)
+        .unwrap_or_default();
+    let zone_id = alias
+        .get("hosted_zone_id")
+        .and_then(extract_string)
+        .unwrap_or_default();
+    let evaluate = alias
+        .get("evaluate_target_health")
+        .and_then(|v| {
+            if let Value::Bool(b) = v {
+                Some(*b)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(false);
+
+    AliasTarget::builder()
+        .dns_name(dns_name)
+        .hosted_zone_id(zone_id)
+        .evaluate_target_health(evaluate)
+        .build()
+        .map_err(|e| {
+            ProviderError::new(format!("Invalid alias_target: {}", e)).for_resource(id.clone())
+        })
+}
+
+/// Build an AWS SDK ResourceRecordSet from carina resource attributes.
+fn build_record_set(resource: &Resource) -> ProviderResult<ResourceRecordSet> {
+    let name = require_string_attr(resource, "name")?;
+    let record_type = require_string_attr(resource, "type")?;
+
+    let mut builder = ResourceRecordSet::builder()
+        .name(normalize_dns_name(&name))
+        .r#type(RrType::from(record_type.as_str()));
+
+    if let Some(Value::Int(ttl)) = resource.get_attr("ttl") {
+        builder = builder.ttl(*ttl);
+    }
+
+    if let Some(Value::List(records)) = resource.get_attr("resource_records") {
+        builder = builder.set_resource_records(Some(build_resource_records(records)));
+    }
+
+    if let Some(Value::Map(alias)) = resource.get_attr("alias_target") {
+        builder = builder.alias_target(build_alias_target_from_map(alias, &resource.id)?);
+    }
+
+    builder.build().map_err(|e| {
+        ProviderError::new(format!("Failed to build ResourceRecordSet: {}", e))
+            .for_resource(resource.id.clone())
+    })
+}
+
+/// Execute a ChangeResourceRecordSets UPSERT or DELETE.
+async fn change_record_set(
+    client: &aws_sdk_route53::Client,
+    hosted_zone_id: &str,
+    action: ChangeAction,
+    record_set: ResourceRecordSet,
+    id: &ResourceId,
+) -> ProviderResult<()> {
+    let change = Change::builder()
+        .action(action)
+        .resource_record_set(record_set)
+        .build()
+        .map_err(|e| {
+            ProviderError::new(format!("Failed to build change: {}", e)).for_resource(id.clone())
+        })?;
+
+    let batch = ChangeBatch::builder()
+        .changes(change)
+        .build()
+        .map_err(|e| {
+            ProviderError::new(format!("Failed to build change batch: {}", e))
+                .for_resource(id.clone())
+        })?;
+
+    client
+        .change_resource_record_sets()
+        .hosted_zone_id(hosted_zone_id)
+        .change_batch(batch)
+        .send()
+        .await
+        .map_err(|e| {
+            ProviderError::new(format!("ChangeResourceRecordSets failed: {}", e))
+                .for_resource(id.clone())
+        })?;
+
+    Ok(())
+}
+
+/// Extract carina attributes from an AWS SDK ResourceRecordSet.
+fn extract_attributes(hosted_zone_id: &str, rrs: &ResourceRecordSet) -> HashMap<String, Value> {
+    let mut attrs = HashMap::new();
+
+    attrs.insert(
+        "hosted_zone_id".to_string(),
+        Value::String(hosted_zone_id.to_string()),
+    );
+
+    attrs.insert(
+        "name".to_string(),
+        Value::String(strip_trailing_dot(rrs.name())),
+    );
+
+    attrs.insert(
+        "type".to_string(),
+        Value::String(rrs.r#type().as_str().to_string()),
+    );
+
+    if let Some(ttl) = rrs.ttl() {
+        attrs.insert("ttl".to_string(), Value::Int(ttl));
+    }
+
+    let records: Vec<Value> = rrs
+        .resource_records()
+        .iter()
+        .map(|r| Value::String(r.value().to_string()))
+        .collect();
+    if !records.is_empty() {
+        attrs.insert("resource_records".to_string(), Value::List(records));
+    }
+
+    if let Some(alias) = rrs.alias_target() {
+        let mut alias_map = HashMap::new();
+        alias_map.insert(
+            "dns_name".to_string(),
+            Value::String(strip_trailing_dot(alias.dns_name())),
+        );
+        alias_map.insert(
+            "hosted_zone_id".to_string(),
+            Value::String(alias.hosted_zone_id().to_string()),
+        );
+        alias_map.insert(
+            "evaluate_target_health".to_string(),
+            Value::Bool(alias.evaluate_target_health()),
+        );
+        attrs.insert("alias_target".to_string(), Value::Map(alias_map));
+    }
+
+    attrs
+}
+
+impl AwsProvider {
+    pub(crate) async fn read_route53_record_set(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(identifier) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+        let Some((zone_id, name, record_type)) = parse_identifier(identifier) else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let normalized_name = normalize_dns_name(name);
+
+        let result = self
+            .route53_client
+            .list_resource_record_sets()
+            .hosted_zone_id(zone_id)
+            .start_record_name(&normalized_name)
+            .start_record_type(RrType::from(record_type))
+            .max_items(1)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(format!("Failed to list record sets: {}", e))
+                    .for_resource(id.clone())
+            })?;
+
+        for rrs in result.resource_record_sets() {
+            let rrs_name = rrs.name();
+            let rrs_type = rrs.r#type().as_str();
+
+            if rrs_name == normalized_name && rrs_type == record_type {
+                let attrs = extract_attributes(zone_id, rrs);
+                return Ok(
+                    State::existing(id.clone(), attrs).with_identifier(identifier.to_string())
+                );
+            }
+        }
+
+        Ok(State::not_found(id.clone()))
+    }
+
+    pub(crate) async fn create_route53_record_set(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let hosted_zone_id = require_string_attr(&resource, "hosted_zone_id")?;
+        let name = require_string_attr(&resource, "name")?;
+        let record_type = require_string_attr(&resource, "type")?;
+
+        let record_set = build_record_set(&resource)?;
+        change_record_set(
+            &self.route53_client,
+            &hosted_zone_id,
+            ChangeAction::Upsert,
+            record_set,
+            &resource.id,
+        )
+        .await?;
+
+        let identifier = make_identifier(&hosted_zone_id, &name, &record_type);
+        self.read_route53_record_set(&resource.id, Some(&identifier))
+            .await
+    }
+
+    pub(crate) async fn update_route53_record_set(
+        &self,
+        id: ResourceId,
+        _identifier: &str,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        let hosted_zone_id = require_string_attr(&to, "hosted_zone_id")?;
+        let name = require_string_attr(&to, "name")?;
+        let record_type = require_string_attr(&to, "type")?;
+
+        let record_set = build_record_set(&to)?;
+        change_record_set(
+            &self.route53_client,
+            &hosted_zone_id,
+            ChangeAction::Upsert,
+            record_set,
+            &id,
+        )
+        .await?;
+
+        let identifier = make_identifier(&hosted_zone_id, &name, &record_type);
+        self.read_route53_record_set(&id, Some(&identifier)).await
+    }
+
+    pub(crate) async fn delete_route53_record_set(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let Some((zone_id, name, record_type)) = parse_identifier(identifier) else {
+            return Err(ProviderError::new(format!(
+                "Invalid record set identifier: {}",
+                identifier
+            ))
+            .for_resource(id));
+        };
+
+        // Read current state to get the exact record for deletion.
+        // Route 53 DELETE requires the record to match exactly.
+        let current = self.read_route53_record_set(&id, Some(identifier)).await?;
+        if current.attributes.is_empty() {
+            return Ok(());
+        }
+
+        let normalized_name = normalize_dns_name(name);
+        let mut builder = ResourceRecordSet::builder()
+            .name(&normalized_name)
+            .r#type(RrType::from(record_type));
+
+        if let Some(Value::Int(ttl)) = current.attributes.get("ttl") {
+            builder = builder.ttl(*ttl);
+        }
+
+        if let Some(Value::List(records)) = current.attributes.get("resource_records") {
+            builder = builder.set_resource_records(Some(build_resource_records(records)));
+        }
+
+        if let Some(Value::Map(alias)) = current.attributes.get("alias_target") {
+            builder = builder.alias_target(build_alias_target_from_map(alias, &id)?);
+        }
+
+        let record_set = builder.build().map_err(|e| {
+            ProviderError::new(format!("Failed to build record set for deletion: {}", e))
+                .for_resource(id.clone())
+        })?;
+
+        change_record_set(
+            &self.route53_client,
+            zone_id,
+            ChangeAction::Delete,
+            record_set,
+            &id,
+        )
+        .await
+    }
+}

--- a/docs/specs/2026-04-14-schema-structure-codegen.md
+++ b/docs/specs/2026-04-14-schema-structure-codegen.md
@@ -1,0 +1,79 @@
+# schema_structure: codegen support for non-standard API patterns
+
+## Goal
+
+Enable the Smithy codegen to generate resource schemas for AWS services whose create API doesn't directly expose resource fields as top-level input parameters (e.g., Route 53 `ChangeResourceRecordSets` where fields are nested inside `ChangeBatch`).
+
+## Problem
+
+The codegen currently resolves writable fields from the create operation's input structure. This works for standard CRUD APIs (EC2 `CreateVpc` → input has `CidrBlock`, `InstanceTenancy`, etc.) but fails for batch/aggregate APIs where the resource fields are in a nested structure:
+
+- Route 53: `ChangeResourceRecordSetsRequest` has `HostedZoneId` + `ChangeBatch`, actual record fields are in `ResourceRecordSet`
+- Potential future cases: DynamoDB `BatchWriteItem`, CloudWatch `PutMetricData`, etc.
+
+## Chosen Approach: `schema_structure` field
+
+Add `schema_structure: Option<&'static str>` to `ResourceDef`. When set, the codegen derives writable fields from this named Smithy structure instead of the create operation's input.
+
+### How it works
+
+1. If `schema_structure` is `Some("ResourceRecordSet")`, the codegen:
+   - Resolves `com.amazonaws.route53#ResourceRecordSet` from the Smithy model
+   - Uses its members as the writable field source (replacing the create input)
+   - Still respects `exclude_fields`, `type_overrides`, `create_only_overrides`, `identity_overrides`, `required_overrides`
+   - `extra_writable` adds fields not in the schema structure (e.g., `HostedZoneId`)
+
+2. If `schema_structure` is `None` (default), existing behavior unchanged — fields come from create input.
+
+3. `read_structure` remains separate — it's used for read-back extraction methods. For many resources, `schema_structure` and `read_structure` will be the same Smithy structure.
+
+### Changes
+
+#### `carina-codegen-aws/src/resource_defs.rs`
+- Add `schema_structure: Option<&'static str>` to `ResourceDef`
+- Add `identity_overrides: Vec<&'static str>` to `ResourceDef`
+- Add `route53_resources()` function
+
+#### `carina-codegen-aws/src/main.rs`
+- In `generate_resource()`: when `schema_structure` is set, resolve fields from it instead of `create_input`
+- Add `is_identity` to `AttrInfo` and emit `.identity()` when set
+- Register `route53_resources()` in the resource collection
+
+#### `scripts/download-smithy-models.sh`
+- Add Route 53 model download
+
+## Route 53 ResourceDef
+
+```rust
+ResourceDef {
+    name: "route53.record_set",
+    service_namespace: "com.amazonaws.route53",
+    schema_structure: Some("ResourceRecordSet"),
+    create_op: "ChangeResourceRecordSets",
+    read_structure: Some("ResourceRecordSet"),
+    identifier: "Name",
+    has_tags: false,
+    required_overrides: vec!["Name", "Type"],
+    create_only_overrides: vec!["Name"],
+    identity_overrides: vec!["Type"],
+    extra_writable: vec![
+        ExtraField {
+            name: "HostedZoneId",
+            read_source: None,
+            description: Some("The ID of the hosted zone."),
+        },
+    ],
+    exclude_fields: vec![
+        "SetIdentifier", "Weight", "Region", "Failover",
+        "MultiValueAnswer", "GeoLocation", "GeoProximityLocation",
+        "HealthCheckId", "TrafficPolicyInstanceId", "CidrRoutingConfig",
+    ],
+    ...
+}
+```
+
+## Edge cases
+
+- `extra_writable` fields with `schema_structure` should be marked `create_only` (same as current behavior)
+- `exclude_fields` removes fields from the schema structure that aren't needed in the initial version (routing policies, health checks)
+- `TTL` in Route 53 Smithy model is typed as `Long` — codegen should map to `Int`

--- a/docs/specs/2026-04-14-schema-structure-plan.md
+++ b/docs/specs/2026-04-14-schema-structure-plan.md
@@ -1,0 +1,41 @@
+# Implementation Plan: schema_structure codegen + Route 53
+
+## Task 1/4: Add `schema_structure` and `identity_overrides` to codegen
+
+**Files:**
+- `carina-codegen-aws/src/resource_defs.rs` — add fields to `ResourceDef`
+- `carina-codegen-aws/src/main.rs` — resolve fields from `schema_structure`, add `is_identity` to `AttrInfo`, emit `.identity()`
+
+**Test:** Existing codegen tests must pass. Add test for `schema_structure` field resolution.
+
+**Acceptance:** `cargo test -p carina-codegen-aws` passes, `cargo clippy` clean.
+
+## Task 2/4: Add Route 53 ResourceDef and generate schema
+
+**Files:**
+- `carina-codegen-aws/src/resource_defs.rs` — add `route53_resources()`
+- `carina-codegen-aws/src/main.rs` — register `route53_resources()`
+- `scripts/download-smithy-models.sh` — add route53 model
+- `carina-provider-aws/src/schemas/generated/route53/` — generated output
+
+**Test:** Run `generate-schemas-smithy.sh`, verify generated schema has correct attributes. Review codegen diff.
+
+**Acceptance:** Generated `route53/record_set.rs` has `hosted_zone_id`, `name`, `type` (.identity()), `ttl`, `resource_records`, `alias_target`.
+
+## Task 3/4: Replace hand-written schema with generated schema + update service impl
+
+**Files:**
+- `carina-provider-aws/src/schemas/generated/route53/record_set.rs` — replace hand-written with codegen output
+- `carina-provider-aws/src/schemas/generated/route53/mod.rs` — update if needed
+- `carina-provider-aws/src/schemas/generated/mod.rs` — update registration
+- `carina-provider-aws/src/services/route53/record_set.rs` — adapt to generated field names if they differ
+
+**Test:** `cargo build`, `cargo test`, `cargo clippy` all pass.
+
+## Task 4/4: Generate docs and create PR
+
+**Files:**
+- `generated-docs/` if applicable
+- Update existing PR #106
+
+**Acceptance:** CI passes, PR ready for review.

--- a/scripts/download-smithy-models.sh
+++ b/scripts/download-smithy-models.sh
@@ -28,5 +28,6 @@ download "ec2"           "ec2/service/2016-11-15/ec2-2016-11-15.json"
 download "s3"            "s3/service/2006-03-01/s3-2006-03-01.json"
 download "sts"           "sts/service/2011-06-15/sts-2011-06-15.json"
 download "organizations" "organizations/service/2016-11-28/organizations-2016-11-28.json"
+download "route53"       "route-53/service/2013-04-01/route-53-2013-04-01.json"
 
 echo "Done."


### PR DESCRIPTION
Closes #105

## Summary

- Add `aws.route53.record_set` resource for managing DNS records via Route 53 SDK
- Cloud Control does not support Route 53 records (`NON_PROVISIONABLE`), so this uses `ChangeResourceRecordSets` directly
- Supports basic records (A/AAAA/CNAME/MX/TXT with TTL) and alias records
- Composite identifier: `hosted_zone_id|name|type`
- UPSERT for create/update (idempotent), DELETE reads current state first
- `type` attribute marked as `.identity()` to prevent anonymous resource collisions

## DSL example

```crn
aws.route53.record_set {
  hosted_zone_id   = zone.id
  name             = "carina-rs.dev"
  type             = "A"
  ttl              = 300
  resource_records = ["185.199.108.153", "185.199.109.153"]
}
```

## Test plan

- [x] `cargo test -p carina-provider-aws` — 11 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)