### PR TITLE
fix: use DisplayErrorContext for SDK errors to show full error chain

### DIFF
--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -7,6 +7,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Read an EC2 Security Group Rule (shared between ingress and egress)
@@ -27,9 +28,11 @@ impl AwsProvider {
             req = req.security_group_rule_ids(*rule_id);
         }
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to describe security group rules")
-                .with_cause(e)
-                .for_resource(id.clone())
+            ProviderError::new(sdk_error_message(
+                "Failed to describe security group rules",
+                &e,
+            ))
+            .for_resource(id.clone())
         })?;
         let rules: Vec<_> = result
             .security_group_rules()
@@ -212,8 +215,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to create ingress rule")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to create ingress rule", &e))
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -231,8 +233,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to create egress rule")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to create egress rule", &e))
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -287,9 +288,11 @@ impl AwsProvider {
             req = req.security_group_rule_ids(*rule_id);
         }
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to describe security group rules")
-                .with_cause(e)
-                .for_resource(id.clone())
+            ProviderError::new(sdk_error_message(
+                "Failed to describe security group rules",
+                &e,
+            ))
+            .for_resource(id.clone())
         })?;
 
         let rules = result.security_group_rules();
@@ -313,8 +316,7 @@ impl AwsProvider {
                 request = request.security_group_rule_ids(*rule_id);
             }
             request.send().await.map_err(|e| {
-                ProviderError::new("Failed to delete ingress rules")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete ingress rules", &e))
                     .for_resource(id.clone())
             })?;
         } else {
@@ -326,8 +328,7 @@ impl AwsProvider {
                 request = request.security_group_rule_ids(*rule_id);
             }
             request.send().await.map_err(|e| {
-                ProviderError::new("Failed to delete egress rules")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete egress rules", &e))
                     .for_resource(id.clone())
             })?;
         }

--- a/carina-provider-aws/src/ec2_tags.rs
+++ b/carina-provider-aws/src/ec2_tags.rs
@@ -6,6 +6,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ResourceId, Value};
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Extract tags from EC2 tag list into a Value::Map
@@ -68,8 +69,7 @@ impl AwsProvider {
                     req = req.tags(aws_sdk_ec2::types::Tag::builder().key(key.as_str()).build());
                 }
                 req.send().await.map_err(|e| {
-                    ProviderError::new("Failed to delete tags")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to delete tags", &e))
                         .for_resource(resource_id.clone())
                 })?;
             }
@@ -84,8 +84,7 @@ impl AwsProvider {
                     req = req.tags(tag);
                 }
                 req.send().await.map_err(|e| {
-                    ProviderError::new("Failed to tag resource")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to tag resource", &e))
                         .for_resource(resource_id.clone())
                 })?;
             }

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -7,6 +7,7 @@ use std::future::Future;
 use std::time::Duration;
 
 use aws_sdk_ec2::types::{ResourceType, Tag, TagSpecification};
+use aws_smithy_types::error::display::DisplayErrorContext;
 use tokio::time::sleep;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -61,6 +62,15 @@ pub enum PollState {
     Gone,
     /// The resource is still transitioning.
     Pending,
+}
+
+/// Format an AWS SDK error with the full error chain.
+///
+/// Uses `DisplayErrorContext` to walk the source chain, producing messages like:
+/// `ChangeResourceRecordSets failed: service error: InvalidChangeBatch: ...`
+/// instead of the unhelpful `ChangeResourceRecordSets failed: service error`.
+pub fn sdk_error_message(context: &str, err: &(impl std::error::Error + 'static)) -> String {
+    format!("{}: {}", context, DisplayErrorContext(err))
 }
 
 /// Retry an AWS SDK operation with exponential backoff on transient errors.
@@ -153,6 +163,65 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_sdk_error_message_includes_full_chain() {
+        // Simulate a chained error: outer wraps inner
+        #[derive(Debug)]
+        struct InnerError;
+        impl std::fmt::Display for InnerError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "InvalidChangeBatch: record already exists")
+            }
+        }
+        impl std::error::Error for InnerError {}
+
+        #[derive(Debug)]
+        struct OuterError(InnerError);
+        impl std::fmt::Display for OuterError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "service error")
+            }
+        }
+        impl std::error::Error for OuterError {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let err = OuterError(InnerError);
+
+        // Without DisplayErrorContext, we'd get "ChangeResourceRecordSets failed: service error"
+        let bad = format!("ChangeResourceRecordSets failed: {}", err);
+        assert_eq!(bad, "ChangeResourceRecordSets failed: service error");
+
+        // With our helper, the full chain is included
+        let good = sdk_error_message("ChangeResourceRecordSets failed", &err);
+        assert!(
+            good.contains("InvalidChangeBatch"),
+            "expected full chain, got: {}",
+            good
+        );
+    }
+
+    #[test]
+    fn test_sdk_error_message_single_error() {
+        #[derive(Debug)]
+        struct SimpleError;
+        impl std::fmt::Display for SimpleError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "something went wrong")
+            }
+        }
+        impl std::error::Error for SimpleError {}
+
+        let msg = sdk_error_message("CreateBucket failed", &SimpleError);
+        assert!(
+            msg.starts_with("CreateBucket failed: something went wrong"),
+            "expected context + message, got: {}",
+            msg
+        );
+    }
 
     #[test]
     fn test_is_retryable_error_throttling() {

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -10,6 +10,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 // ===== Generated Methods on AwsProvider =====
 
@@ -26,8 +27,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete vpc")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete vpc", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -45,8 +45,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete subnet")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete subnet", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -64,8 +63,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete route table")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete route table", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -83,8 +81,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete security group")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete security group", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -161,9 +158,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to read s3.bucket GetBucketVersioning")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to read s3.bucket GetBucketVersioning",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
         let value = output
             .status()
@@ -197,8 +196,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to put bucket versioning")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to put bucket versioning", &e))
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State};
 
 use crate::AwsProvider;
-use crate::helpers::{build_tag_specification, require_string_attr};
+use crate::helpers::{build_tag_specification, require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 Egress-Only Internet Gateway
@@ -24,9 +24,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe egress-only internet gateways")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to describe egress-only internet gateways",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         if let Some(eigw) = result.egress_only_internet_gateways().first() {
@@ -72,9 +74,11 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create egress-only internet gateway")
-                .with_cause(e)
-                .for_resource(resource.id.clone())
+            ProviderError::new(sdk_error_message(
+                "Failed to create egress-only internet gateway",
+                &e,
+            ))
+            .for_resource(resource.id.clone())
         })?;
 
         let eigw_id = result
@@ -121,9 +125,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete egress-only internet gateway")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to delete egress-only internet gateway",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
         Ok(())
     }

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -5,6 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Read an EC2 Elastic IP
@@ -31,8 +32,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe addresses")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe addresses", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -72,8 +72,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to allocate address")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to allocate address", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -125,8 +124,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to release address")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to release address", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{build_tag_specification, require_string_attr};
+use crate::helpers::{build_tag_specification, require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 Flow Log
@@ -32,8 +32,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe flow logs")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe flow logs", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -144,9 +143,11 @@ impl AwsProvider {
                     {
                         continue;
                     }
-                    return Err(ProviderError::new("Failed to create flow logs")
-                        .with_cause(e)
-                        .for_resource(resource.id.clone()));
+                    return Err(ProviderError::new(sdk_error_message(
+                        "Failed to create flow logs",
+                        &e,
+                    ))
+                    .for_resource(resource.id.clone()));
                 }
             };
 
@@ -225,8 +226,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete flow logs")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete flow logs", &e))
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/internet_gateway.rs
@@ -4,6 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Read an EC2 Internet Gateway
@@ -30,9 +31,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe internet gateways")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to describe internet gateways",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         if let Some(igw) = result.internet_gateways().first() {
@@ -77,8 +80,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to create internet gateway")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to create internet gateway", &e))
                     .for_resource(resource.id.clone())
             })?;
 
@@ -103,8 +105,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to attach internet gateway")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to attach internet gateway", &e))
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -128,8 +129,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe internet gateway")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe internet gateway", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -145,9 +145,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to detach internet gateway")
-                            .with_cause(e)
-                            .for_resource(id.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to detach internet gateway",
+                            &e,
+                        ))
+                        .for_resource(id.clone())
                     })?;
             }
         }
@@ -159,8 +161,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete internet gateway")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete internet gateway", &e))
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -7,7 +7,9 @@ use carina_core::utils::extract_enum_value;
 use aws_sdk_ec2::types::NatGatewayState;
 
 use crate::AwsProvider;
-use crate::helpers::{PollState, require_string_attr, retry_aws_operation, wait_for_ec2_state};
+use crate::helpers::{
+    PollState, require_string_attr, retry_aws_operation, sdk_error_message, wait_for_ec2_state,
+};
 
 impl AwsProvider {
     /// Read an EC2 NAT Gateway
@@ -34,8 +36,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe NAT gateways")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe NAT gateways", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -88,8 +89,7 @@ impl AwsProvider {
             let rid = rid.clone();
             async move {
                 req.send().await.map_err(|e| {
-                    ProviderError::new("Failed to create NAT gateway")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to create NAT gateway", &e))
                         .for_resource(rid)
                 })
             }
@@ -146,8 +146,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete NAT gateway")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete NAT gateway", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -174,8 +173,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to describe NAT gateway")
-                            .with_cause(e)
+                        ProviderError::new(sdk_error_message("Failed to describe NAT gateway", &e))
                             .for_resource(rid.clone())
                     })?;
                 Ok(
@@ -219,8 +217,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to describe NAT gateway")
-                            .with_cause(e)
+                        ProviderError::new(sdk_error_message("Failed to describe NAT gateway", &e))
                             .for_resource(rid.clone())
                     })?;
                 Ok(if let Some(ngw) = result.nat_gateways().first() {

--- a/carina-provider-aws/src/services/ec2/route.rs
+++ b/carina-provider-aws/src/services/ec2/route.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::require_string_attr;
+use crate::helpers::{require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 Route (routes are identified by route_table_id + destination)
@@ -30,8 +30,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe route table")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe route table", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -82,8 +81,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create route")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create route", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -136,8 +134,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new("Failed to update route")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to update route", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -167,9 +164,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete route")
-                    .with_cause(e)
-                    .for_resource(id)
+                ProviderError::new(sdk_error_message("Failed to delete route", &e)).for_resource(id)
             })?;
 
         Ok(())

--- a/carina-provider-aws/src/services/ec2/route_table.rs
+++ b/carina-provider-aws/src/services/ec2/route_table.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::require_string_attr;
+use crate::helpers::{require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 Route Table
@@ -31,8 +31,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe route tables")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe route tables", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -88,8 +87,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to create route table")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to create route table", &e))
                     .for_resource(resource.id.clone())
             })?;
 
@@ -133,8 +131,7 @@ impl AwsProvider {
                             .send()
                             .await
                             .map_err(|e| {
-                                ProviderError::new("Failed to create route")
-                                    .with_cause(e)
+                                ProviderError::new(sdk_error_message("Failed to create route", &e))
                                     .for_resource(resource.id.clone())
                             })?;
                     }

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation};
+use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 Security Group
@@ -31,8 +31,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe security groups")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe security groups", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -92,8 +91,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to create security group")
-                            .with_cause(e)
+                        ProviderError::new(sdk_error_message("Failed to create security group", &e))
                             .for_resource(rid)
                     })
             }

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::require_string_attr;
+use crate::helpers::{require_string_attr, sdk_error_message};
 use aws_sdk_ec2::types::{AttributeBooleanValue, HostnameType};
 
 impl AwsProvider {
@@ -33,8 +33,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe subnets")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe subnets", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -82,8 +81,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create subnet")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create subnet", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -141,9 +139,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to set map_public_ip_on_launch")
-                        .with_cause(e)
-                        .for_resource(id.clone())
+                    ProviderError::new(sdk_error_message(
+                        "Failed to set map_public_ip_on_launch",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
         }
 
@@ -157,9 +157,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to set assign_ipv6_address_on_creation")
-                        .with_cause(e)
-                        .for_resource(id.clone())
+                    ProviderError::new(sdk_error_message(
+                        "Failed to set assign_ipv6_address_on_creation",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
         }
 
@@ -171,8 +173,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to set enable_dns64")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to set enable_dns64", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -189,10 +190,10 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(
+                        ProviderError::new(sdk_error_message(
                             "Failed to set private_dns_name_options_on_launch.hostname_type",
-                        )
-                        .with_cause(e)
+                            &e,
+                        ))
                         .for_resource(id.clone())
                     })?;
             }
@@ -206,10 +207,10 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(
+                        ProviderError::new(sdk_error_message(
                             "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_a_record",
-                        )
-                        .with_cause(e)
+                            &e,
+                        ))
                         .for_resource(id.clone())
                     })?;
             }
@@ -223,10 +224,10 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(
+                        ProviderError::new(sdk_error_message(
                             "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_aaaa_record",
-                        )
-                        .with_cause(e)
+                            &e,
+                        ))
                         .for_resource(id.clone())
                     })?;
             }

--- a/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::require_string_attr;
+use crate::helpers::{require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 Subnet Route Table Association
@@ -37,8 +37,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe route tables")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe route tables", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -89,8 +88,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to associate route table")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to associate route table", &e))
                     .for_resource(resource.id.clone())
             })?;
 
@@ -139,9 +137,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to replace route table association")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to replace route table association",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         let new_assoc_id = result.new_association_id().ok_or_else(|| {
@@ -177,8 +177,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to disassociate route table")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to disassociate route table", &e))
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{PollState, build_tag_specification, wait_for_ec2_state};
+use crate::helpers::{PollState, build_tag_specification, sdk_error_message, wait_for_ec2_state};
 
 impl AwsProvider {
     /// Read an EC2 Transit Gateway
@@ -25,8 +25,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe transit gateways")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe transit gateways", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -125,8 +124,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create transit gateway")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create transit gateway", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -177,8 +175,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete transit gateway")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete transit gateway", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -206,9 +203,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to describe transit gateway")
-                            .with_cause(e)
-                            .for_resource(rid.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to describe transit gateway",
+                            &e,
+                        ))
+                        .for_resource(rid.clone())
                     })?;
                 Ok(
                     if let Some(tgw) = result.transit_gateways().first()
@@ -248,9 +247,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to describe transit gateway")
-                            .with_cause(e)
-                            .for_resource(rid.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to describe transit gateway",
+                            &e,
+                        ))
+                        .for_resource(rid.clone())
                     })?;
                 Ok(if let Some(tgw) = result.transit_gateways().first() {
                     if tgw.state().map(|s| s.as_str()) == Some("deleted") {

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -4,7 +4,9 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{PollState, build_tag_specification, require_string_attr, wait_for_ec2_state};
+use crate::helpers::{
+    PollState, build_tag_specification, require_string_attr, sdk_error_message, wait_for_ec2_state,
+};
 
 impl AwsProvider {
     /// Read an EC2 Transit Gateway VPC Attachment
@@ -24,9 +26,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe transit gateway VPC attachments")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to describe transit gateway VPC attachments",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         if let Some(att) = result.transit_gateway_vpc_attachments().first() {
@@ -104,9 +108,11 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create transit gateway VPC attachment")
-                .with_cause(e)
-                .for_resource(resource.id.clone())
+            ProviderError::new(sdk_error_message(
+                "Failed to create transit gateway VPC attachment",
+                &e,
+            ))
+            .for_resource(resource.id.clone())
         })?;
 
         let att_id = result
@@ -157,9 +163,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete transit gateway VPC attachment")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to delete transit gateway VPC attachment",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         // Wait for attachment to be deleted
@@ -186,9 +194,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to describe transit gateway VPC attachment")
-                            .with_cause(e)
-                            .for_resource(rid.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to describe transit gateway VPC attachment",
+                            &e,
+                        ))
+                        .for_resource(rid.clone())
                     })?;
                 Ok(
                     if let Some(att) = result.transit_gateway_vpc_attachments().first()
@@ -228,9 +238,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to describe transit gateway VPC attachment")
-                            .with_cause(e)
-                            .for_resource(rid.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to describe transit gateway VPC attachment",
+                            &e,
+                        ))
+                        .for_resource(rid.clone())
                     })?;
                 Ok(
                     if let Some(att) = result.transit_gateway_vpc_attachments().first() {

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation};
+use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 VPC
@@ -29,8 +29,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe VPCs")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe VPCs", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -115,8 +114,7 @@ impl AwsProvider {
             let rid = rid.clone();
             async move {
                 builder.send().await.map_err(|e| {
-                    ProviderError::new("Failed to create VPC")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to create VPC", &e))
                         .for_resource(rid)
                 })
             }
@@ -144,8 +142,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to set DNS support")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to set DNS support", &e))
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -163,8 +160,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to set DNS hostnames")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to set DNS hostnames", &e))
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -197,8 +193,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to update DNS support")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to update DNS support", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -216,8 +211,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to update DNS hostnames")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to update DNS hostnames", &e))
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation};
+use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 VPC Endpoint
@@ -25,8 +25,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe VPC endpoints")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe VPC endpoints", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -124,8 +123,7 @@ impl AwsProvider {
             let rid = rid.clone();
             async move {
                 req.send().await.map_err(|e| {
-                    ProviderError::new("Failed to create VPC endpoint")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to create VPC endpoint", &e))
                         .for_resource(rid)
                 })
             }
@@ -315,8 +313,7 @@ impl AwsProvider {
 
         if has_modifications {
             req.send().await.map_err(|e| {
-                ProviderError::new("Failed to modify VPC endpoint")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to modify VPC endpoint", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -346,8 +343,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete VPC endpoint")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete VPC endpoint", &e))
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::require_string_attr;
+use crate::helpers::{require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 VPC Gateway Attachment
@@ -58,9 +58,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe internet gateways")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to describe internet gateways",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         if let Some(igw) = result.internet_gateways().first() {
@@ -104,8 +106,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe VPN gateways")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe VPN gateways", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -147,8 +148,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to attach internet gateway")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to attach internet gateway", &e))
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -164,8 +164,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to attach VPN gateway")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to attach VPN gateway", &e))
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -214,8 +213,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to detach internet gateway")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to detach internet gateway", &e))
                         .for_resource(id.clone())
                 })?;
         } else if gateway_id.starts_with("vgw-") {
@@ -226,8 +224,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to detach VPN gateway")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to detach VPN gateway", &e))
                         .for_resource(id.clone())
                 })?;
         } else {

--- a/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{build_tag_specification, require_string_attr};
+use crate::helpers::{build_tag_specification, require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 VPC Peering Connection
@@ -24,9 +24,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe VPC peering connections")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to describe VPC peering connections",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         if let Some(pcx) = result.vpc_peering_connections().first() {
@@ -94,9 +96,11 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create VPC peering connection")
-                .with_cause(e)
-                .for_resource(resource.id.clone())
+            ProviderError::new(sdk_error_message(
+                "Failed to create VPC peering connection",
+                &e,
+            ))
+            .for_resource(resource.id.clone())
         })?;
 
         let pcx_id = result
@@ -143,9 +147,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete VPC peering connection")
-                    .with_cause(e)
-                    .for_resource(id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to delete VPC peering connection",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
         Ok(())
     }

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -5,6 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value_with_values;
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Read an EC2 VPN Gateway
@@ -31,8 +32,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe VPN gateways")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe VPN gateways", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -83,8 +83,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create VPN gateway")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create VPN gateway", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -134,8 +133,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete VPN gateway")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete VPN gateway", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::require_string_attr;
+use crate::helpers::{require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read an IAM Role
@@ -62,9 +62,10 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::new("Failed to get IAM role")
-                    .with_cause(e)
-                    .for_resource(id.clone()))
+                Err(
+                    ProviderError::new(sdk_error_message("Failed to get IAM role", &e))
+                        .for_resource(id.clone()),
+                )
             }
         }
     }
@@ -117,7 +118,7 @@ impl AwsProvider {
                         .value(val)
                         .build()
                         .map_err(|e| {
-                            ProviderError::new(format!("Failed to build tag: {}", e))
+                            ProviderError::new(sdk_error_message("Failed to build tag", &e))
                                 .for_resource(resource.id.clone())
                         })?;
                     req = req.tags(tag);
@@ -126,8 +127,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create IAM role")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create IAM role", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -167,8 +167,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to update assume role policy")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to update assume role policy", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -189,8 +188,7 @@ impl AwsProvider {
 
         if needs_update {
             req.send().await.map_err(|e| {
-                ProviderError::new("Failed to update IAM role")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to update IAM role", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -219,8 +217,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete IAM role")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete IAM role", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -256,8 +253,7 @@ impl AwsProvider {
                 req = req.tag_keys(key);
             }
             req.send().await.map_err(|e| {
-                ProviderError::new("Failed to untag IAM role")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to untag IAM role", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -276,7 +272,7 @@ impl AwsProvider {
                         .value(val)
                         .build()
                         .map_err(|e| {
-                            ProviderError::new(format!("Failed to build tag: {}", e))
+                            ProviderError::new(sdk_error_message("Failed to build tag", &e))
                                 .for_resource(id.clone())
                         })?;
                     tags_to_add.push(tag);
@@ -290,8 +286,7 @@ impl AwsProvider {
                 req = req.tags(tag);
             }
             req.send().await.map_err(|e| {
-                ProviderError::new("Failed to tag IAM role")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to tag IAM role", &e))
                     .for_resource(id.clone())
             })?;
         }

--- a/carina-provider-aws/src/services/identitystore/user.rs
+++ b/carina-provider-aws/src/services/identitystore/user.rs
@@ -11,6 +11,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, State, Value};
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Read `identitystore.user` given a `Resource` with user-supplied
@@ -38,10 +39,10 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!(
-                    "Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'"
+                ProviderError::new(sdk_error_message(
+                    &format!("Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'"),
+                    &e,
                 ))
-                .with_cause(e)
                 .for_resource(resource.id.clone())
             })?;
 
@@ -76,9 +77,11 @@ async fn resolve_user_id(
         .attribute_value(aws_smithy_types::Document::String(user_name.to_string()))
         .build()
         .map_err(|e| {
-            ProviderError::new("Failed to build userName lookup request")
-                .with_cause(e)
-                .for_resource(resource.id.clone())
+            ProviderError::new(sdk_error_message(
+                "Failed to build userName lookup request",
+                &e,
+            ))
+            .for_resource(resource.id.clone())
         })?;
 
     let alt = AlternateIdentifier::UniqueAttribute(unique_attribute);
@@ -90,10 +93,10 @@ async fn resolve_user_id(
         .send()
         .await
         .map_err(|e| {
-            ProviderError::new(format!(
-                "Failed to look up user_id for user_name '{user_name}' in store '{identity_store_id}'"
+            ProviderError::new(sdk_error_message(
+                &format!("Failed to look up user_id for user_name '{user_name}' in store '{identity_store_id}'"),
+                &e,
             ))
-            .with_cause(e)
             .for_resource(resource.id.clone())
         })?;
 

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::require_string_attr;
+use crate::helpers::{require_string_attr, sdk_error_message};
 
 impl AwsProvider {
     /// Read a CloudWatch Logs Log Group
@@ -25,8 +25,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to describe log groups")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to describe log groups", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -126,8 +125,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create log group")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create log group", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -140,8 +138,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to set retention policy")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to set retention policy", &e))
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -168,8 +165,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to set retention policy")
-                            .with_cause(e)
+                        ProviderError::new(sdk_error_message("Failed to set retention policy", &e))
                             .for_resource(id.clone())
                     })?;
             }
@@ -182,9 +178,11 @@ impl AwsProvider {
                         .send()
                         .await
                         .map_err(|e| {
-                            ProviderError::new("Failed to delete retention policy")
-                                .with_cause(e)
-                                .for_resource(id.clone())
+                            ProviderError::new(sdk_error_message(
+                                "Failed to delete retention policy",
+                                &e,
+                            ))
+                            .for_resource(id.clone())
                         })?;
                 }
             }
@@ -200,8 +198,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to associate KMS key")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to associate KMS key", &e))
                         .for_resource(id.clone())
                 })?;
         } else if from.attributes.contains_key("kms_key_id") {
@@ -211,8 +208,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to disassociate KMS key")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to disassociate KMS key", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -241,8 +237,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete log group")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete log group", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -282,8 +277,7 @@ impl AwsProvider {
                 req = req.tags(key);
             }
             req.send().await.map_err(|e| {
-                ProviderError::new("Failed to untag log group")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to untag log group", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -311,8 +305,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to tag log group")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to tag log group", &e))
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{PollState, require_string_attr, wait_for_ec2_state};
+use crate::helpers::{PollState, require_string_attr, sdk_error_message, wait_for_ec2_state};
 
 impl AwsProvider {
     /// Extract attributes from an Organizations Account object
@@ -131,9 +131,10 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::new("Failed to describe account")
-                    .with_cause(e)
-                    .for_resource(id.clone()))
+                Err(
+                    ProviderError::new(sdk_error_message("Failed to describe account", &e))
+                        .for_resource(id.clone()),
+                )
             }
         }
     }
@@ -171,7 +172,7 @@ impl AwsProvider {
                         .value(val)
                         .build()
                         .map_err(|e| {
-                            ProviderError::new(format!("Failed to build tag: {}", e))
+                            ProviderError::new(sdk_error_message("Failed to build tag", &e))
                                 .for_resource(resource.id.clone())
                         })?;
                     req = req.tags(tag);
@@ -180,8 +181,7 @@ impl AwsProvider {
         }
 
         let response = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create account")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create account", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -207,9 +207,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to describe create account status")
-                            .with_cause(e)
-                            .for_resource(resource_id.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to describe create account status",
+                            &e,
+                        ))
+                        .for_resource(resource_id.clone())
                     })?;
                 if let Some(status) = result.create_account_status() {
                     match status.state() {
@@ -239,9 +241,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to get final create account status")
-                    .with_cause(e)
-                    .for_resource(resource.id.clone())
+                ProviderError::new(sdk_error_message(
+                    "Failed to get final create account status",
+                    &e,
+                ))
+                .for_resource(resource.id.clone())
             })?;
 
         let account_id = final_status
@@ -262,9 +266,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to list parents for new account")
-                        .with_cause(e)
-                        .for_resource(resource.id.clone())
+                    ProviderError::new(sdk_error_message(
+                        "Failed to list parents for new account",
+                        &e,
+                    ))
+                    .for_resource(resource.id.clone())
                 })?;
 
             if let Some(current_parent) = parents_response.parents().first()
@@ -279,9 +285,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to move account to parent")
-                            .with_cause(e)
-                            .for_resource(resource.id.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to move account to parent",
+                            &e,
+                        ))
+                        .for_resource(resource.id.clone())
                     })?;
             }
         }
@@ -319,8 +327,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to move account")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to move account", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -349,8 +356,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to close account")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to close account", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -388,8 +394,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to untag account")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to untag account", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -408,7 +413,7 @@ impl AwsProvider {
                         .value(val)
                         .build()
                         .map_err(|e| {
-                            ProviderError::new(format!("Failed to build tag: {}", e))
+                            ProviderError::new(sdk_error_message("Failed to build tag", &e))
                                 .for_resource(id.clone())
                         })?;
                     tags_to_add.push(tag);
@@ -424,8 +429,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to tag account")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to tag account", &e))
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -5,6 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Extract attributes from an Organizations Organization object
@@ -87,9 +88,10 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::new("Failed to describe organization")
-                    .with_cause(e)
-                    .for_resource(id.clone()))
+                Err(
+                    ProviderError::new(sdk_error_message("Failed to describe organization", &e))
+                        .for_resource(id.clone()),
+                )
             }
         }
     }
@@ -109,8 +111,7 @@ impl AwsProvider {
         }
 
         let response = req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create organization")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create organization", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -142,8 +143,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete organization")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete organization", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -13,7 +13,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::require_string_attr;
+use crate::helpers::{require_string_attr, sdk_error_message};
 
 /// Composite identifier format: `hosted_zone_id|name|type`
 fn make_identifier(hosted_zone_id: &str, name: &str, record_type: &str) -> String {
@@ -92,7 +92,8 @@ fn build_alias_target_from_map(
         .evaluate_target_health(evaluate)
         .build()
         .map_err(|e| {
-            ProviderError::new(format!("Invalid alias_target: {}", e)).for_resource(id.clone())
+            ProviderError::new(sdk_error_message("Invalid alias_target", &e))
+                .for_resource(id.clone())
         })
 }
 
@@ -118,7 +119,7 @@ fn build_record_set(resource: &Resource) -> ProviderResult<ResourceRecordSet> {
     }
 
     builder.build().map_err(|e| {
-        ProviderError::new(format!("Failed to build ResourceRecordSet: {}", e))
+        ProviderError::new(sdk_error_message("Failed to build ResourceRecordSet", &e))
             .for_resource(resource.id.clone())
     })
 }
@@ -136,14 +137,15 @@ async fn change_record_set(
         .resource_record_set(record_set)
         .build()
         .map_err(|e| {
-            ProviderError::new(format!("Failed to build change: {}", e)).for_resource(id.clone())
+            ProviderError::new(sdk_error_message("Failed to build change", &e))
+                .for_resource(id.clone())
         })?;
 
     let batch = ChangeBatch::builder()
         .changes(change)
         .build()
         .map_err(|e| {
-            ProviderError::new(format!("Failed to build change batch: {}", e))
+            ProviderError::new(sdk_error_message("Failed to build change batch", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -154,7 +156,7 @@ async fn change_record_set(
         .send()
         .await
         .map_err(|e| {
-            ProviderError::new(format!("ChangeResourceRecordSets failed: {}", e))
+            ProviderError::new(sdk_error_message("ChangeResourceRecordSets failed", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -238,7 +240,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to list record sets: {}", e))
+                ProviderError::new(sdk_error_message("Failed to list record sets", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -342,8 +344,11 @@ impl AwsProvider {
         }
 
         let record_set = builder.build().map_err(|e| {
-            ProviderError::new(format!("Failed to build record set for deletion: {}", e))
-                .for_resource(id.clone())
+            ProviderError::new(sdk_error_message(
+                "Failed to build record set for deletion",
+                &e,
+            ))
+            .for_resource(id.clone())
         })?;
 
         change_record_set(

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -5,6 +5,7 @@ use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value}
 use carina_core::utils::{convert_enum_value, extract_enum_value};
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Read an S3 bucket
@@ -63,9 +64,11 @@ impl AwsProvider {
                         name
                     ))
                     .for_resource(id.clone())),
-                    HeadBucketErrorKind::Other => Err(ProviderError::new("Failed to read bucket")
-                        .with_cause(err)
-                        .for_resource(id.clone())),
+                    HeadBucketErrorKind::Other => Err(ProviderError::new(sdk_error_message(
+                        "Failed to read bucket",
+                        &err,
+                    ))
+                    .for_resource(id.clone())),
                 }
             }
         }
@@ -139,8 +142,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new("Failed to create bucket")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to create bucket", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -187,8 +189,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to delete bucket tags")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to delete bucket tags", &e))
                         .for_resource(id.clone())
                 })?;
         } else {
@@ -216,8 +217,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to delete bucket")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to delete bucket", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -242,8 +242,7 @@ impl AwsProvider {
             }
 
             let response = req.send().await.map_err(|e| {
-                ProviderError::new("Failed to list object versions")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to list object versions", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -257,9 +256,11 @@ impl AwsProvider {
                         oid = oid.version_id(vid);
                     }
                     objects_to_delete.push(oid.build().map_err(|e| {
-                        ProviderError::new("Failed to build ObjectIdentifier")
-                            .with_cause(e)
-                            .for_resource(id.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to build ObjectIdentifier",
+                            &e,
+                        ))
+                        .for_resource(id.clone())
                     })?);
                 }
             }
@@ -272,9 +273,11 @@ impl AwsProvider {
                         oid = oid.version_id(vid);
                     }
                     objects_to_delete.push(oid.build().map_err(|e| {
-                        ProviderError::new("Failed to build ObjectIdentifier")
-                            .with_cause(e)
-                            .for_resource(id.clone())
+                        ProviderError::new(sdk_error_message(
+                            "Failed to build ObjectIdentifier",
+                            &e,
+                        ))
+                        .for_resource(id.clone())
                     })?);
                 }
             }
@@ -286,8 +289,7 @@ impl AwsProvider {
                     .quiet(true)
                     .build()
                     .map_err(|e| {
-                        ProviderError::new("Failed to build Delete request")
-                            .with_cause(e)
+                        ProviderError::new(sdk_error_message("Failed to build Delete request", &e))
                             .for_resource(id.clone())
                     })?;
 
@@ -298,8 +300,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new("Failed to delete objects")
-                            .with_cause(e)
+                        ProviderError::new(sdk_error_message("Failed to delete objects", &e))
                             .for_resource(id.clone())
                     })?;
             }
@@ -339,11 +340,11 @@ impl AwsProvider {
             }
             Err(err) => {
                 if !is_s3_not_configured_error(&err, "OwnershipControlsNotFoundError") {
-                    return Err(
-                        ProviderError::new("Failed to read bucket ownership controls")
-                            .with_cause(err)
-                            .for_resource(id.clone()),
-                    );
+                    return Err(ProviderError::new(sdk_error_message(
+                        "Failed to read bucket ownership controls",
+                        &err,
+                    ))
+                    .for_resource(id.clone()));
                 }
             }
         }
@@ -364,16 +365,17 @@ impl AwsProvider {
                 .object_ownership(ObjectOwnership::from(normalized))
                 .build()
                 .map_err(|e| {
-                    ProviderError::new("Failed to build ownership controls rule")
-                        .with_cause(e)
-                        .for_resource(id.clone())
+                    ProviderError::new(sdk_error_message(
+                        "Failed to build ownership controls rule",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
             let controls = OwnershipControls::builder()
                 .rules(rule)
                 .build()
                 .map_err(|e| {
-                    ProviderError::new("Failed to build ownership controls")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to build ownership controls", &e))
                         .for_resource(id.clone())
                 })?;
             self.s3_client
@@ -383,9 +385,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to put bucket ownership controls")
-                        .with_cause(e)
-                        .for_resource(id.clone())
+                    ProviderError::new(sdk_error_message(
+                        "Failed to put bucket ownership controls",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
         }
         Ok(())
@@ -422,11 +426,11 @@ impl AwsProvider {
                         Value::Bool(false),
                     );
                 } else {
-                    return Err(
-                        ProviderError::new("Failed to read object lock configuration")
-                            .with_cause(err)
-                            .for_resource(id.clone()),
-                    );
+                    return Err(ProviderError::new(sdk_error_message(
+                        "Failed to read object lock configuration",
+                        &err,
+                    ))
+                    .for_resource(id.clone()));
                 }
             }
         }
@@ -447,8 +451,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to read bucket ACL")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to read bucket ACL", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -590,8 +593,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new("Failed to put bucket ACL")
-                .with_cause(e)
+            ProviderError::new(sdk_error_message("Failed to put bucket ACL", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -626,9 +628,11 @@ impl AwsProvider {
             }
             Err(err) => {
                 if !is_s3_not_configured_error(&err, "NoSuchTagSet") {
-                    return Err(ProviderError::new("Failed to read bucket tagging")
-                        .with_cause(err)
-                        .for_resource(id.clone()));
+                    return Err(ProviderError::new(sdk_error_message(
+                        "Failed to read bucket tagging",
+                        &err,
+                    ))
+                    .for_resource(id.clone()));
                 }
             }
         }
@@ -659,8 +663,7 @@ impl AwsProvider {
                 .set_tag_set(Some(tags))
                 .build()
                 .map_err(|e| {
-                    ProviderError::new("Failed to build tagging")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to build tagging", &e))
                         .for_resource(id.clone())
                 })?;
 
@@ -671,8 +674,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new("Failed to put bucket tags")
-                        .with_cause(e)
+                    ProviderError::new(sdk_error_message("Failed to put bucket tags", &e))
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/sts/caller_identity.rs
+++ b/carina-provider-aws/src/services/sts/caller_identity.rs
@@ -4,6 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ResourceId, State, Value};
 
 use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Read STS caller identity (data source)
@@ -17,8 +18,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new("Failed to get STS caller identity")
-                    .with_cause(e)
+                ProviderError::new(sdk_error_message("Failed to get STS caller identity", &e))
                     .for_resource(id.clone())
             })?;
 


### PR DESCRIPTION
Closes #107

## Summary

- Add `sdk_error_message()` helper to `helpers.rs` using `DisplayErrorContext` from `aws_smithy_types` to walk the full error source chain
- Convert all 140 `.with_cause(e)` and `format!("...: {}", e)` SDK error sites across 29 files to use the new helper
- Before: `ChangeResourceRecordSets failed: service error`
- After: `ChangeResourceRecordSets failed: service error: InvalidChangeBatch: Tried to create resource record set [name='carina-rs.dev.', type='A'] but it already exists`

## Test plan

- [x] Unit tests for `sdk_error_message` (chained error chain + single error)
- [x] `cargo test` — all 157 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Zero remaining `.with_cause()` calls in `carina-provider-aws/src/`

## Follow-up

- #108: Update codegen to emit `sdk_error_message` instead of `.with_cause(e)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)