### PR TITLE
fix: strip DSL enum namespace from record_set type attribute

### DIFF
--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -24,6 +24,17 @@ pub fn require_string_attr(resource: &Resource, attr_name: &str) -> ProviderResu
     }
 }
 
+/// Extract a required enum attribute from a resource, stripping the DSL namespace prefix.
+///
+/// StringEnum attributes arrive as namespaced identifiers
+/// (e.g., `aws.route53.record_set.Type.A`). This extracts just the variant (`A`).
+/// Using `require_string_attr` instead will pass the full namespaced path to
+/// the AWS API, causing failures that are hard to diagnose.
+pub fn require_enum_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
+    let raw = require_string_attr(resource, attr_name)?;
+    Ok(carina_core::utils::extract_enum_value(&raw).to_string())
+}
+
 /// Build an EC2 `TagSpecification` from DSL tags for a given resource type.
 ///
 /// Returns `None` if the resource has no `tags` attribute.
@@ -163,6 +174,35 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_test_resource(attrs: Vec<(&str, &str)>) -> Resource {
+        use carina_core::resource::Expr;
+        let mut resource = Resource::new("route53.record_set", "test");
+        for (k, v) in attrs {
+            resource
+                .attributes
+                .insert(k.to_string(), Expr(Value::String(v.to_string())));
+        }
+        resource
+    }
+
+    #[test]
+    fn test_require_enum_attr_strips_namespace() {
+        let resource = make_test_resource(vec![("type", "aws.route53.record_set.Type.A")]);
+        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "A");
+    }
+
+    #[test]
+    fn test_require_enum_attr_plain_value() {
+        let resource = make_test_resource(vec![("type", "AAAA")]);
+        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "AAAA");
+    }
+
+    #[test]
+    fn test_require_enum_attr_missing() {
+        let resource = make_test_resource(vec![]);
+        assert!(require_enum_attr(&resource, "type").is_err());
+    }
 
     #[test]
     fn test_sdk_error_message_includes_full_chain() {

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -13,7 +13,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::helpers::{require_enum_attr, require_string_attr, sdk_error_message};
 
 /// Composite identifier format: `hosted_zone_id|name|type`
 fn make_identifier(hosted_zone_id: &str, name: &str, record_type: &str) -> String {
@@ -100,7 +100,7 @@ fn build_alias_target_from_map(
 /// Build an AWS SDK ResourceRecordSet from carina resource attributes.
 fn build_record_set(resource: &Resource) -> ProviderResult<ResourceRecordSet> {
     let name = require_string_attr(resource, "name")?;
-    let record_type = require_string_attr(resource, "type")?;
+    let record_type = require_enum_attr(resource, "type")?;
 
     let mut builder = ResourceRecordSet::builder()
         .name(normalize_dns_name(&name))
@@ -265,7 +265,7 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let hosted_zone_id = require_string_attr(&resource, "hosted_zone_id")?;
         let name = require_string_attr(&resource, "name")?;
-        let record_type = require_string_attr(&resource, "type")?;
+        let record_type = require_enum_attr(&resource, "type")?;
 
         let record_set = build_record_set(&resource)?;
         change_record_set(
@@ -290,7 +290,7 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let hosted_zone_id = require_string_attr(&to, "hosted_zone_id")?;
         let name = require_string_attr(&to, "name")?;
-        let record_type = require_string_attr(&to, "type")?;
+        let record_type = require_enum_attr(&to, "type")?;
 
         let record_set = build_record_set(&to)?;
         change_record_set(


### PR DESCRIPTION
Closes #111

## Summary

- Add `require_enum_attr()` helper to `helpers.rs` that combines `require_string_attr` + `extract_enum_value`, preventing future enum namespace stripping omissions
- Fix `record_set.rs`: use `require_enum_attr` for the `type` attribute in `build_record_set`, `create`, and `update`
- Before: `aws.route53.record_set.Type.A` passed to API → `InvalidInput`
- After: `A` passed to API → success

## Test plan

- [x] 3 unit tests for `require_enum_attr` (namespaced, plain, missing)
- [x] `cargo test` — all 160 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)