### PR TITLE
docs: add generated docs for data sources (identitystore.user, sts.caller_identity)

### DIFF
--- a/generated-docs/aws/identitystore/user.md
+++ b/generated-docs/aws/identitystore/user.md
@@ -1,0 +1,46 @@
+---
+title: "aws.identitystore.user"
+description: "AWS IDENTITYSTORE user resource reference"
+---
+
+
+CloudFormation Type: `AWS::IdentityStore::User`
+
+This is a **data source** (read-only). Use with the `read` keyword.
+
+## Lookup Inputs
+
+### `identity_store_id`
+
+- **Required:** Yes
+
+The globally unique identifier for the identity store.
+
+### `user_id`
+
+- **Required:** No
+
+The identifier for the user. Provide either user_id or user_name.
+
+### `user_name`
+
+- **Required:** No
+
+The user's user name. Provide either user_id or user_name.
+
+## Attributes
+
+### `display_name`
+
+- **Type:** String
+- **Read-only**
+
+<p>The display name of the user.</p>
+
+### `emails`
+
+- **Type:** String
+- **Read-only**
+
+<p>The email address of the user.</p>
+

--- a/generated-docs/aws/sts/caller_identity.md
+++ b/generated-docs/aws/sts/caller_identity.md
@@ -1,0 +1,37 @@
+---
+title: "aws.sts.caller_identity"
+description: "AWS STS caller_identity resource reference"
+---
+
+
+CloudFormation Type: `AWS::STS::CallerIdentity`
+
+This is a **data source** (read-only). Use with the `read` keyword.
+
+## Attributes
+
+### `account_id`
+
+- **Type:** String
+- **Read-only**
+
+<p>The Amazon Web Services account ID number of the account that owns or contains the calling
+         entity.</p>
+
+### `arn`
+
+- **Type:** String
+- **Read-only**
+
+<p>The Amazon Web Services ARN associated with the calling entity.</p>
+
+### `user_id`
+
+- **Type:** String
+- **Read-only**
+
+<p>The unique identifier of the calling entity. The exact value depends on the type of
+         entity that is making the call. The values returned are those listed in the <b>aws:userid</b> column in the <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable">Principal
+            table</a> found on the <b>Policy Variables</b> reference
+         page in the <i>IAM User Guide</i>.</p>
+


### PR DESCRIPTION
Closes #124
Closes #103

## Summary

Verify end-to-end: both data sources now have codegen-generated schemas AND docs.

- `identitystore/user.md` — shows Lookup Inputs (identity_store_id, user_id, user_name) and Attributes (display_name, emails)
- `sts/caller_identity.md` — shows Attributes (account_id, arn, user_id)

This completes the DataSourceDef series (4/4) and the parent issue #103.

## Test plan

- [x] `generate-docs.sh` produces both docs files
- [x] Doc content verified: correct sections and attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)