### PR TITLE
Migrate to new AttributeType::Custom shape (tasks 9-11/18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#64d239647c45c6daa057a6a101495e4a6381f126"
+source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
 dependencies = [
  "argon2",
  "futures",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#64d239647c45c6daa057a6a101495e4a6381f126"
+source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -700,7 +700,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#64d239647c45c6daa057a6a101495e4a6381f126"
+source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -203,7 +203,9 @@ pub fn validate_prefixed_resource_id(id: &str, expected_prefix: &str) -> Result<
 #[allow(dead_code)]
 pub fn aws_resource_id() -> AttributeType {
     AttributeType::Custom {
-        name: "AwsResourceId".to_string(),
+        semantic_name: Some("AwsResourceId".to_string()),
+        pattern: Some("^[a-z-]+-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -221,7 +223,9 @@ pub fn aws_resource_id() -> AttributeType {
 /// VPC ID type (e.g., "vpc-1a2b3c4d")
 pub fn vpc_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpcId".to_string(),
+        semantic_name: Some("VpcId".to_string()),
+        pattern: Some("^vpc-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -239,7 +243,9 @@ pub fn vpc_id() -> AttributeType {
 /// Subnet ID type (e.g., "subnet-0123456789abcdef0")
 pub fn subnet_id() -> AttributeType {
     AttributeType::Custom {
-        name: "SubnetId".to_string(),
+        semantic_name: Some("SubnetId".to_string()),
+        pattern: Some("^subnet-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -257,7 +263,9 @@ pub fn subnet_id() -> AttributeType {
 /// Security Group ID type (e.g., "sg-12345678")
 pub fn security_group_id() -> AttributeType {
     AttributeType::Custom {
-        name: "SecurityGroupId".to_string(),
+        semantic_name: Some("SecurityGroupId".to_string()),
+        pattern: Some("^sg-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -275,7 +283,9 @@ pub fn security_group_id() -> AttributeType {
 /// Internet Gateway ID type (e.g., "igw-12345678")
 pub fn internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "InternetGatewayId".to_string(),
+        semantic_name: Some("InternetGatewayId".to_string()),
+        pattern: Some("^igw-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -293,7 +303,9 @@ pub fn internet_gateway_id() -> AttributeType {
 /// Route Table ID type (e.g., "rtb-abcdef12")
 pub fn route_table_id() -> AttributeType {
     AttributeType::Custom {
-        name: "RouteTableId".to_string(),
+        semantic_name: Some("RouteTableId".to_string()),
+        pattern: Some("^rtb-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -311,7 +323,9 @@ pub fn route_table_id() -> AttributeType {
 /// NAT Gateway ID type (e.g., "nat-12345678")
 pub fn nat_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "NatGatewayId".to_string(),
+        semantic_name: Some("NatGatewayId".to_string()),
+        pattern: Some("^nat-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -329,7 +343,9 @@ pub fn nat_gateway_id() -> AttributeType {
 /// VPC Peering Connection ID type (e.g., "pcx-12345678")
 pub fn vpc_peering_connection_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpcPeeringConnectionId".to_string(),
+        semantic_name: Some("VpcPeeringConnectionId".to_string()),
+        pattern: Some("^pcx-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -348,7 +364,9 @@ pub fn vpc_peering_connection_id() -> AttributeType {
 /// Transit Gateway ID type (e.g., "tgw-12345678")
 pub fn transit_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "TransitGatewayId".to_string(),
+        semantic_name: Some("TransitGatewayId".to_string()),
+        pattern: Some("^tgw-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -366,7 +384,9 @@ pub fn transit_gateway_id() -> AttributeType {
 /// VPC CIDR Block Association ID type (e.g., "vpc-cidr-assoc-12345678")
 pub fn vpc_cidr_block_association_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpcCidrBlockAssociationId".to_string(),
+        semantic_name: Some("VpcCidrBlockAssociationId".to_string()),
+        pattern: Some("^vpc-cidr-assoc-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -385,7 +405,9 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
 /// Transit Gateway Route Table ID type (e.g., "tgw-rtb-12345678")
 pub fn tgw_route_table_id() -> AttributeType {
     AttributeType::Custom {
-        name: "TgwRouteTableId".to_string(),
+        semantic_name: Some("TgwRouteTableId".to_string()),
+        pattern: Some("^tgw-rtb-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -403,7 +425,9 @@ pub fn tgw_route_table_id() -> AttributeType {
 /// VPN Gateway ID type (e.g., "vgw-12345678")
 pub fn vpn_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpnGatewayId".to_string(),
+        semantic_name: Some("VpnGatewayId".to_string()),
+        pattern: Some("^vgw-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -426,7 +450,9 @@ pub fn gateway_id() -> AttributeType {
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
 pub fn egress_only_internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "EgressOnlyInternetGatewayId".to_string(),
+        semantic_name: Some("EgressOnlyInternetGatewayId".to_string()),
+        pattern: Some("^eigw-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -448,7 +474,9 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
 /// VPC Endpoint ID type (e.g., "vpce-12345678")
 pub fn vpc_endpoint_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpcEndpointId".to_string(),
+        semantic_name: Some("VpcEndpointId".to_string()),
+        pattern: Some("^vpce-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -466,7 +494,9 @@ pub fn vpc_endpoint_id() -> AttributeType {
 /// Instance ID type (e.g., "i-0123456789abcdef0")
 pub fn instance_id() -> AttributeType {
     AttributeType::Custom {
-        name: "InstanceId".to_string(),
+        semantic_name: Some("InstanceId".to_string()),
+        pattern: Some("^i-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -484,7 +514,9 @@ pub fn instance_id() -> AttributeType {
 /// Network Interface ID type (e.g., "eni-0123456789abcdef0")
 pub fn network_interface_id() -> AttributeType {
     AttributeType::Custom {
-        name: "NetworkInterfaceId".to_string(),
+        semantic_name: Some("NetworkInterfaceId".to_string()),
+        pattern: Some("^eni-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -503,7 +535,9 @@ pub fn network_interface_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn allocation_id() -> AttributeType {
     AttributeType::Custom {
-        name: "AllocationId".to_string(),
+        semantic_name: Some("AllocationId".to_string()),
+        pattern: Some("^eipalloc-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -521,7 +555,9 @@ pub fn allocation_id() -> AttributeType {
 /// Prefix List ID type (e.g., "pl-0123456789abcdef0")
 pub fn prefix_list_id() -> AttributeType {
     AttributeType::Custom {
-        name: "PrefixListId".to_string(),
+        semantic_name: Some("PrefixListId".to_string()),
+        pattern: Some("^pl-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -539,7 +575,9 @@ pub fn prefix_list_id() -> AttributeType {
 /// Carrier Gateway ID type (e.g., "cagw-0123456789abcdef0")
 pub fn carrier_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "CarrierGatewayId".to_string(),
+        semantic_name: Some("CarrierGatewayId".to_string()),
+        pattern: Some("^cagw-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -557,7 +595,9 @@ pub fn carrier_gateway_id() -> AttributeType {
 /// Local Gateway ID type (e.g., "lgw-0123456789abcdef0")
 pub fn local_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "LocalGatewayId".to_string(),
+        semantic_name: Some("LocalGatewayId".to_string()),
+        pattern: Some("^lgw-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -576,7 +616,9 @@ pub fn local_gateway_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn network_acl_id() -> AttributeType {
     AttributeType::Custom {
-        name: "NetworkAclId".to_string(),
+        semantic_name: Some("NetworkAclId".to_string()),
+        pattern: Some("^acl-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -594,7 +636,9 @@ pub fn network_acl_id() -> AttributeType {
 /// Transit Gateway Attachment ID type (e.g., "tgw-attach-0123456789abcdef0")
 pub fn transit_gateway_attachment_id() -> AttributeType {
     AttributeType::Custom {
-        name: "TransitGatewayAttachmentId".to_string(),
+        semantic_name: Some("TransitGatewayAttachmentId".to_string()),
+        pattern: Some("^tgw-attach-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -613,7 +657,9 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
 /// Flow Log ID type (e.g., "fl-0123456789abcdef0")
 pub fn flow_log_id() -> AttributeType {
     AttributeType::Custom {
-        name: "FlowLogId".to_string(),
+        semantic_name: Some("FlowLogId".to_string()),
+        pattern: Some("^fl-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -631,7 +677,9 @@ pub fn flow_log_id() -> AttributeType {
 /// IPAM ID type (e.g., "ipam-0123456789abcdef0")
 pub fn ipam_id() -> AttributeType {
     AttributeType::Custom {
-        name: "IpamId".to_string(),
+        semantic_name: Some("IpamId".to_string()),
+        pattern: Some("^ipam-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -649,7 +697,9 @@ pub fn ipam_id() -> AttributeType {
 /// Subnet Route Table Association ID type (e.g., "rtbassoc-0123456789abcdef0")
 pub fn subnet_route_table_association_id() -> AttributeType {
     AttributeType::Custom {
-        name: "SubnetRouteTableAssociationId".to_string(),
+        semantic_name: Some("SubnetRouteTableAssociationId".to_string()),
+        pattern: Some("^rtbassoc-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -671,7 +721,9 @@ pub fn subnet_route_table_association_id() -> AttributeType {
 /// Security Group Rule ID type (e.g., "sgr-0123456789abcdef0")
 pub fn security_group_rule_id() -> AttributeType {
     AttributeType::Custom {
-        name: "SecurityGroupRuleId".to_string(),
+        semantic_name: Some("SecurityGroupRuleId".to_string()),
+        pattern: Some("^sgr-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -703,7 +755,9 @@ pub fn validate_iam_role_id(id: &str) -> Result<(), String> {
 /// IAM Role ID type (e.g., "AROAEXAMPLEID")
 pub fn iam_role_id() -> AttributeType {
     AttributeType::Custom {
-        name: "IamRoleId".to_string(),
+        semantic_name: Some("IamRoleId".to_string()),
+        pattern: Some("^AROA[A-Z0-9]+$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -737,7 +791,9 @@ pub fn validate_aws_account_id(id: &str) -> Result<(), String> {
 /// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
 pub fn aws_account_id() -> AttributeType {
     AttributeType::Custom {
-        name: "AwsAccountId".to_string(),
+        semantic_name: Some("AwsAccountId".to_string()),
+        pattern: Some("^\\d{12}$".to_string()),
+        length: Some((Some(12), Some(12))),
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -874,7 +930,9 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
 /// ARN type (e.g., "arn:aws:s3:::my-bucket")
 pub fn arn() -> AttributeType {
     AttributeType::Custom {
-        name: "Arn".to_string(),
+        semantic_name: Some("Arn".to_string()),
+        pattern: Some("^arn:(aws|aws-cn|aws-us-gov):[^:]+:.*$".to_string()),
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -892,7 +950,9 @@ pub fn arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_role_arn() -> AttributeType {
     AttributeType::Custom {
-        name: "IamRoleArn".to_string(),
+        semantic_name: Some("IamRoleArn".to_string()),
+        pattern: Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$".to_string()),
+        length: None,
         base: Box::new(arn()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -911,7 +971,9 @@ pub fn iam_role_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_policy_arn() -> AttributeType {
     AttributeType::Custom {
-        name: "IamPolicyArn".to_string(),
+        semantic_name: Some("IamPolicyArn".to_string()),
+        pattern: Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
+        length: None,
         base: Box::new(arn()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -930,7 +992,9 @@ pub fn iam_policy_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn kms_key_arn() -> AttributeType {
     AttributeType::Custom {
-        name: "KmsKeyArn".to_string(),
+        semantic_name: Some("KmsKeyArn".to_string()),
+        pattern: Some("^arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:key/.+$".to_string()),
+        length: None,
         base: Box::new(arn()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -998,7 +1062,9 @@ pub fn validate_kms_key_id(value: &str) -> Result<(), String> {
 #[allow(dead_code)]
 pub fn kms_key_id() -> AttributeType {
     AttributeType::Custom {
-        name: "KmsKeyId".to_string(),
+        semantic_name: Some("KmsKeyId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1032,7 +1098,9 @@ pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
 /// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
 pub fn ipam_pool_id() -> AttributeType {
     AttributeType::Custom {
-        name: "IpamPoolId".to_string(),
+        semantic_name: Some("IpamPoolId".to_string()),
+        pattern: Some("^ipam-pool-[0-9a-f]{8,}$".to_string()),
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1139,7 +1207,9 @@ pub fn validate_availability_zone_id(az_id: &str) -> Result<(), String> {
 /// Availability Zone ID type (e.g., "use1-az1", "usw2-az2", "apne1-az4")
 pub fn availability_zone_id() -> AttributeType {
     AttributeType::Custom {
-        name: "AvailabilityZoneId".to_string(),
+        semantic_name: Some("AvailabilityZoneId".to_string()),
+        pattern: Some("^[a-z]+[0-9]+-az[0-9]+$".to_string()),
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1190,7 +1260,9 @@ fn string_or_principal_struct() -> AttributeType {
 /// Only allows "Allow" or "Deny"
 fn iam_policy_effect() -> AttributeType {
     AttributeType::Custom {
-        name: "IamPolicyEffect".to_string(),
+        semantic_name: Some("IamPolicyEffect".to_string()),
+        pattern: Some("^(Allow|Deny)$".to_string()),
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1214,7 +1286,9 @@ fn iam_policy_effect() -> AttributeType {
 /// Only allows "2012-10-17" or "2008-10-17"
 fn iam_policy_version() -> AttributeType {
     AttributeType::Custom {
-        name: "IamPolicyVersion".to_string(),
+        semantic_name: Some("IamPolicyVersion".to_string()),
+        pattern: Some("^(2012-10-17|2008-10-17)$".to_string()),
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1468,6 +1542,42 @@ pub fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Custom type shape tests
+
+    #[test]
+    fn aws_account_id_carries_pattern_and_length() {
+        let t = aws_account_id();
+        if let AttributeType::Custom {
+            semantic_name,
+            pattern,
+            length,
+            ..
+        } = t
+        {
+            assert_eq!(semantic_name.as_deref(), Some("AwsAccountId"));
+            assert_eq!(pattern.as_deref(), Some(r"^\d{12}$"));
+            assert_eq!(length, Some((Some(12), Some(12))));
+        } else {
+            panic!("aws_account_id() should be AttributeType::Custom");
+        }
+    }
+
+    #[test]
+    fn vpc_id_carries_semantic_name_and_pattern() {
+        let t = vpc_id();
+        if let AttributeType::Custom {
+            semantic_name,
+            pattern,
+            ..
+        } = t
+        {
+            assert_eq!(semantic_name.as_deref(), Some("VpcId"));
+            assert!(pattern.is_some(), "VpcId should carry a pattern");
+        } else {
+            panic!("vpc_id() should be AttributeType::Custom");
+        }
+    }
 
     // ARN tests
 

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1048,17 +1048,26 @@ fn resolve_type(
                     .entry(field_name.to_string())
                     .or_insert(r);
                 let validate_fn = format!("validate_{}_range", field_name.to_snake_case());
-                let display = range_display_string(r.min, r.max);
+                let length_expr = match (r.min, r.max) {
+                    (Some(min), Some(max)) if min >= 0 && max >= 0 => {
+                        format!("Some((Some({}), Some({})))", min, max)
+                    }
+                    (Some(min), None) if min >= 0 => format!("Some((Some({}), None))", min),
+                    (None, Some(max)) if max >= 0 => format!("Some((None, Some({})))", max),
+                    _ => "None".to_string(),
+                };
                 (
                     format!(
                         "AttributeType::Custom {{\n\
-                         \x20               name: \"Int({})\".to_string(),\n\
+                         \x20               semantic_name: None,\n\
+                         \x20               pattern: None,\n\
+                         \x20               length: {},\n\
                          \x20               base: Box::new(AttributeType::Int),\n\
                          \x20               validate: {},\n\
                          \x20               namespace: None,\n\
                          \x20               to_dsl: None,\n\
                          \x20           }}",
-                        display, validate_fn
+                        length_expr, validate_fn
                     ),
                     None,
                 )

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -184,7 +184,13 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             base,
             namespace,
         } => CoreAttributeType::Custom {
-            name: name.clone(),
+            semantic_name: if name.is_empty() {
+                None
+            } else {
+                Some(name.clone())
+            },
+            pattern: None,
+            length: None,
             base: Box::new(proto_to_core_attribute_type(base)),
             validate: |_| Ok(()),
             namespace: namespace.clone(),
@@ -241,6 +247,7 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
             create_timeout_secs: c.create_timeout_secs,
             create_max_retries: c.create_max_retries,
         }),
+        exclusive_required: s.exclusive_required.clone(),
     }
 }
 
@@ -273,12 +280,12 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             fields: fields.iter().map(core_to_proto_struct_field).collect(),
         },
         CoreAttributeType::Custom {
-            name,
+            semantic_name,
             base,
             namespace,
             ..
         } => ProtoAttributeType::Custom {
-            name: name.clone(),
+            name: semantic_name.clone().unwrap_or_default(),
             base: Box::new(core_to_proto_attribute_type(base)),
             namespace: namespace.clone(),
         },
@@ -335,6 +342,7 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
             create_max_retries: c.create_max_retries,
         }),
         validators: vec![],
+        exclusive_required: s.exclusive_required.clone(),
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -70,7 +70,9 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                 AttributeSchema::new(
                     "from_port",
                     AttributeType::Custom {
-                        name: "Int(-1..=65535)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: None,
                         base: Box::new(AttributeType::Int),
                         validate: validate_from_port_range,
                         namespace: None,
@@ -129,7 +131,9 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                 AttributeSchema::new(
                     "to_port",
                     AttributeType::Custom {
-                        name: "Int(-1..=65535)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: None,
                         base: Box::new(AttributeType::Int),
                         validate: validate_to_port_range,
                         namespace: None,

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -62,7 +62,9 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("from_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_from_port_range,
                 namespace: None,
@@ -116,7 +118,9 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_to_port_range,
                 namespace: None,

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -85,7 +85,9 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Custom {
-                name: "Int(0..=32)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(0), Some(32))),
                 base: Box::new(AttributeType::Int),
                 validate: validate_ipv4_netmask_length_range,
                 namespace: None,
@@ -115,7 +117,9 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv6_netmask_length", AttributeType::Custom {
-                name: "Int(0..=128)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(0), Some(128))),
                 base: Box::new(AttributeType::Int),
                 validate: validate_ipv6_netmask_length_range,
                 namespace: None,

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -67,7 +67,9 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Custom {
-                name: "Int(0..=32)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(0), Some(32))),
                 base: Box::new(AttributeType::Int),
                 validate: validate_ipv4_netmask_length_range,
                 namespace: None,

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -45,7 +45,9 @@ pub fn iam_role_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("max_session_duration", AttributeType::Custom {
-                name: "Int(3600..=43200)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(3600), Some(43200))),
                 base: Box::new(AttributeType::Int),
                 validate: validate_max_session_duration_range,
                 namespace: None,

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -59,7 +59,9 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ttl", AttributeType::Custom {
-                name: "Int(0..=2147483647)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(0), Some(2147483647))),
                 base: Box::new(AttributeType::Int),
                 validate: validate_ttl_range,
                 namespace: None,

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -32,7 +32,9 @@ pub struct AwsSchemaConfig {
 /// - Shorthand: ap_northeast_1
 pub fn aws_region() -> AttributeType {
     AttributeType::Custom {
-        name: "Region".to_string(),
+        semantic_name: Some("Region".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -65,7 +67,9 @@ pub fn aws_region() -> AttributeType {
 /// - Shorthand: us_east_1a
 pub fn availability_zone() -> AttributeType {
     AttributeType::Custom {
-        name: "AvailabilityZone".to_string(),
+        semantic_name: Some("AvailabilityZone".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -94,7 +98,9 @@ pub fn availability_zone() -> AttributeType {
 /// Multiple grantees can be comma-separated.
 pub fn s3_grantee() -> AttributeType {
     AttributeType::Custom {
-        name: "S3Grantee".to_string(),
+        semantic_name: Some("S3Grantee".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -169,22 +169,20 @@ impl AwsProvider {
                             .for_resource(id.clone())
                     })?;
             }
-            None => {
+            None if from.attributes.contains_key("retention_in_days") => {
                 // If retention was previously set but now removed, delete the policy
-                if from.attributes.contains_key("retention_in_days") {
-                    self.logs_client
-                        .delete_retention_policy()
-                        .log_group_name(identifier)
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            ProviderError::new(sdk_error_message(
-                                "Failed to delete retention policy",
-                                &e,
-                            ))
-                            .for_resource(id.clone())
-                        })?;
-                }
+                self.logs_client
+                    .delete_retention_policy()
+                    .log_group_name(identifier)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        ProviderError::new(sdk_error_message(
+                            "Failed to delete retention policy",
+                            &e,
+                        ))
+                        .for_resource(id.clone())
+                    })?;
             }
             _ => {}
         }

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -494,11 +494,8 @@ impl AwsProvider {
 
             use aws_sdk_s3::types::Permission;
             match permission {
-                Permission::FullControl => {
-                    if !is_owner {
-                        full_control.push(grantee_str);
-                    }
-                }
+                Permission::FullControl if !is_owner => full_control.push(grantee_str),
+                Permission::FullControl => {}
                 Permission::Read => read.push(grantee_str),
                 Permission::ReadAcp => read_acp.push(grantee_str),
                 Permission::Write => write.push(grantee_str),


### PR DESCRIPTION
## Summary

Adapt carina-provider-aws to the upstream carina-core restructuring of `AttributeType::Custom`, which replaced `name: String` with `semantic_name: Option<String>` + `pattern: Option<String>` + `length: Option<(Option<u64>, Option<u64>)>`. Bundles tasks 9, 10, and 11 because the struct-shape change breaks the whole workspace until every call site migrates.

- Migrate every `carina-aws-types` helper to the new shape; populate pattern/length where the format is unambiguous (e.g. `AwsAccountId` gets `^\d{12}$` + length `(12, 12)`).
- Update the `carina-codegen-aws` ranged-int emission template so regenerated schemas produce the new shape, carrying the range as structured `length` bounds.
- Regenerate all `carina-provider-aws/src/schemas/generated/**`.
- Bridge the proto boundary in `convert.rs` (proto still uses `name: String`), and populate the new upstream `exclusive_required` field.
- Migrate hand-written provider helpers (`aws_region`, `availability_zone`, `s3_grantee`).
- Fix two unrelated `clippy::collapsible_match` errors triggered by newer stable toolchains so the pre-commit clippy gate passes (per `feedback_never_skip_clippy.md`).

Closes #133
Closes #134
Closes #135
Refs carina-rs/carina#2079 carina-rs/carina#2080

## Test plan

- [x] `cargo test --workspace` — all 83 aws-types + 149 provider-aws tests pass, including new `aws_account_id_carries_pattern_and_length` and `vpc_id_carries_semantic_name_and_pattern`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo check -p carina-provider-aws --target wasm32-wasip2` builds
- [x] `./scripts/generate-schemas-smithy.sh` regenerates cleanly with the new shape