### PR TITLE
Release v0.5.0 (task 12/18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,14 +621,14 @@ dependencies = [
 
 [[package]]
 name = "carina-aws-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "carina-core",
 ]
 
 [[package]]
 name = "carina-codegen-aws"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "carina-smithy",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "carina-provider-aws"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aws-config",
  "aws-sdk-cloudwatchlogs",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "carina-smithy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carina-aws-types"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 description = "AWS type definitions for Carina infrastructure management tool"


### PR DESCRIPTION
## Summary

Bump versions so downstream consumers can pick up the new `AttributeType::Custom` shape:
- workspace 0.4.0 -> 0.5.0
- carina-aws-types 0.3.0 -> 0.4.0

Tag `v0.5.0` will be pushed after this PR merges.

Closes #136
Refs carina-rs/carina#2079 carina-rs/carina#2080

## Test plan

- [x] `cargo build --workspace` succeeds with bumped versions
- [x] Pre-commit hooks (format, clippy) pass