### PR TITLE
codegen+fixtures: migrate provider-aws to Strategy Y casing

### DIFF
--- a/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
@@ -7,7 +7,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.200.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -7,7 +7,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.201.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
@@ -6,11 +6,11 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-aws.ec2.egress_only_internet_gateway {
+aws.ec2.EgressOnlyInternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/ec2_eip/basic.crn
+++ b/acceptance-tests/ec2_eip/basic.crn
@@ -6,8 +6,8 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.eip {
-  domain = aws.ec2.eip.Domain.vpc
+aws.ec2.Eip {
+  domain = aws.ec2.Eip.Domain.vpc
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/ec2_flow_log/basic.crn
+++ b/acceptance-tests/ec2_flow_log/basic.crn
@@ -7,7 +7,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -15,7 +15,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let log_group = aws.logs.log_group {
+let log_group = aws.logs.LogGroup {
   log_group_name    = '/acceptance-test/vpc-flow-logs'
   retention_in_days = 1
 
@@ -24,7 +24,7 @@ let log_group = aws.logs.log_group {
   }
 }
 
-let flow_log_role = aws.iam.role {
+let flow_log_role = aws.iam.Role {
   role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
@@ -45,11 +45,11 @@ let flow_log_role = aws.iam.role {
   }
 }
 
-aws.ec2.flow_log {
+aws.ec2.FlowLog {
   resource_id                 = vpc.vpc_id
-  resource_type               = aws.ec2.flow_log.ResourceType.VPC
-  traffic_type                = aws.ec2.flow_log.TrafficType.ALL
-  log_destination_type        = aws.ec2.flow_log.LogDestinationType.cloud_watch_logs
+  resource_type               = aws.ec2.FlowLog.ResourceType.VPC
+  traffic_type                = aws.ec2.FlowLog.TrafficType.ALL
+  log_destination_type        = aws.ec2.FlowLog.LogDestinationType.cloud_watch_logs
   log_group_name              = log_group.log_group_name
   deliver_logs_permission_arn = flow_log_role.arn
 

--- a/acceptance-tests/ec2_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_internet_gateway/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.internet_gateway {
+aws.ec2.InternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/ec2_nat_gateway/basic.crn
+++ b/acceptance-tests/ec2_nat_gateway/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.internet_gateway {
+aws.ec2.InternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -22,7 +22,7 @@ aws.ec2.internet_gateway {
   }
 }
 
-let subnet = aws.ec2.subnet {
+let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
@@ -32,18 +32,18 @@ let subnet = aws.ec2.subnet {
   }
 }
 
-let eip = aws.ec2.eip {
-  domain = aws.ec2.eip.Domain.vpc
+let eip = aws.ec2.Eip {
+  domain = aws.ec2.Eip.Domain.vpc
 
   tags = {
     Environment = 'acceptance-test'
   }
 }
 
-aws.ec2.nat_gateway {
+aws.ec2.NatGateway {
   allocation_id     = eip.allocation_id
   subnet_id         = subnet.subnet_id
-  connectivity_type = aws.ec2.nat_gateway.ConnectivityType.public
+  connectivity_type = aws.ec2.NatGateway.ConnectivityType.public
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/ec2_route/igw.crn
+++ b/acceptance-tests/ec2_route/igw.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let igw = aws.ec2.internet_gateway {
+let igw = aws.ec2.InternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -22,7 +22,7 @@ let igw = aws.ec2.internet_gateway {
   }
 }
 
-let rt = aws.ec2.route_table {
+let rt = aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -30,7 +30,7 @@ let rt = aws.ec2.route_table {
   }
 }
 
-aws.ec2.route {
+aws.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw.internet_gateway_id

--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -13,7 +13,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -21,7 +21,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.internet_gateway {
+aws.ec2.InternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -29,7 +29,7 @@ aws.ec2.internet_gateway {
   }
 }
 
-let subnet = aws.ec2.subnet {
+let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -48,7 +48,7 @@ let nat_gw = awscc.ec2.nat_gateway {
   subnet_id     = subnet.subnet_id
 }
 
-let rt = aws.ec2.route_table {
+let rt = aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -56,7 +56,7 @@ let rt = aws.ec2.route_table {
   }
 }
 
-aws.ec2.route {
+aws.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw.nat_gateway_id

--- a/acceptance-tests/ec2_route_table/basic.crn
+++ b/acceptance-tests/ec2_route_table/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.route_table {
+aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-sg-ipv6'
   description = 'Acceptance test - IPv6 rules'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_ingress {
+aws.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from IPv6'
   ip_protocol = 'tcp'
@@ -33,7 +33,7 @@ aws.ec2.security_group_ingress {
   cidr_ipv6   = '::/0'
 }
 
-aws.ec2.security_group_egress {
+aws.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all IPv6 outbound'
   ip_protocol = all

--- a/acceptance-tests/ec2_security_group/with_egress.crn
+++ b/acceptance-tests/ec2_security_group/with_egress.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-sg-egress'
   description = 'Acceptance test - egress rules'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_egress {
+aws.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow HTTPS outbound'
   ip_protocol = tcp
@@ -33,7 +33,7 @@ aws.ec2.security_group_egress {
   cidr_ip     = '0.0.0.0/0'
 }
 
-aws.ec2.security_group_egress {
+aws.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all to private ranges'
   ip_protocol = all

--- a/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-sg-ingress'
   description = 'Acceptance test - ingress rules'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_ingress {
+aws.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTP'
   ip_protocol = 'tcp'
@@ -33,7 +33,7 @@ aws.ec2.security_group_ingress {
   cidr_ip     = '0.0.0.0/0'
 }
 
-aws.ec2.security_group_ingress {
+aws.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS'
   ip_protocol = 'tcp'

--- a/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -9,7 +9,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -17,7 +17,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-sg-egress'
   description = 'SG for egress rule test'
   vpc_id      = vpc.vpc_id
@@ -27,7 +27,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_egress {
+aws.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow HTTPS outbound'
   ip_protocol = tcp

--- a/acceptance-tests/ec2_security_group_egress/dest_sg.crn
+++ b/acceptance-tests/ec2_security_group_egress/dest_sg.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let source_sg = aws.ec2.security_group {
+let source_sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-egress-src'
   description = 'Source security group'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let source_sg = aws.ec2.security_group {
   }
 }
 
-let dest_sg = aws.ec2.security_group {
+let dest_sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-egress-dst'
   description = 'Destination security group'
   vpc_id      = vpc.vpc_id
@@ -34,7 +34,7 @@ let dest_sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_egress {
+aws.ec2.SecurityGroupEgress {
   group_id                      = source_sg.group_id
   description                   = 'Allow HTTPS to destination SG'
   ip_protocol                   = 'tcp'

--- a/acceptance-tests/ec2_security_group_egress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_egress/ipv6.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-egress-ipv6'
   description = 'SG for IPv6 egress rule test'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_egress {
+aws.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all IPv6 outbound'
   ip_protocol = all

--- a/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-sg-ingress'
   description = 'SG for ingress rule test'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_ingress {
+aws.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'

--- a/acceptance-tests/ec2_security_group_ingress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_ingress/ipv6.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-ingress-ipv6'
   description = 'SG for IPv6 ingress rule test'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_ingress {
+aws.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from IPv6'
   ip_protocol = 'tcp'

--- a/acceptance-tests/ec2_security_group_ingress/source_sg.crn
+++ b/acceptance-tests/ec2_security_group_ingress/source_sg.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let source_sg = aws.ec2.security_group {
+let source_sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-ingress-src'
   description = 'Source security group'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let source_sg = aws.ec2.security_group {
   }
 }
 
-let dest_sg = aws.ec2.security_group {
+let dest_sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-ingress-dst'
   description = 'Destination security group'
   vpc_id      = vpc.vpc_id
@@ -34,7 +34,7 @@ let dest_sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_ingress {
+aws.ec2.SecurityGroupIngress {
   group_id                 = dest_sg.group_id
   description              = 'Allow HTTPS from source SG'
   ip_protocol              = 'tcp'

--- a/acceptance-tests/ec2_subnet/basic.crn
+++ b/acceptance-tests/ec2_subnet/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a

--- a/acceptance-tests/ec2_subnet/ipv6.crn
+++ b/acceptance-tests/ec2_subnet/ipv6.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id                          = vpc.vpc_id
   cidr_block                      = '10.0.1.0/24'
   availability_zone               = aws.AvailabilityZone.ap_northeast_1a

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
@@ -16,14 +16,14 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   private_dns_name_options_on_launch = {
     enable_resource_name_dns_a_record = true
-    hostname_type                     = aws.ec2.subnet.HostnameType.ip_name
+    hostname_type                     = aws.ec2.Subnet.HostnameType.ip_name
   }
 
   tags = {

--- a/acceptance-tests/ec2_subnet_route_table_association/basic.crn
+++ b/acceptance-tests/ec2_subnet_route_table_association/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let subnet = aws.ec2.subnet {
+let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
@@ -24,7 +24,7 @@ let subnet = aws.ec2.subnet {
   }
 }
 
-let rt = aws.ec2.route_table {
+let rt = aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -32,7 +32,7 @@ let rt = aws.ec2.route_table {
   }
 }
 
-aws.ec2.subnet_route_table_association {
+aws.ec2.SubnetRouteTableAssociation {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/acceptance-tests/ec2_transit_gateway/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.transit_gateway {
+aws.ec2.TransitGateway {
   description = 'Acceptance test Transit Gateway'
 
   tags = {

--- a/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -6,21 +6,21 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let subnet = aws.ec2.subnet {
+let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 }
 
-let tgw = aws.ec2.transit_gateway {
+let tgw = aws.ec2.TransitGateway {
   description = 'Acceptance test Transit Gateway'
 }
 
-aws.ec2.transit_gateway_attachment {
+aws.ec2.TransitGatewayAttachment {
   subnet_ids         = [subnet.subnet_id]
   transit_gateway_id = tgw.transit_gateway_id
   vpc_id             = vpc.vpc_id

--- a/acceptance-tests/ec2_vpc/basic.crn
+++ b/acceptance-tests/ec2_vpc/basic.crn
@@ -6,11 +6,11 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
-  instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
+  instance_tenancy     = aws.ec2.Vpc.InstanceTenancy.default
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/ec2_vpc_endpoint/basic.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let rt = aws.ec2.route_table {
+let rt = aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -22,10 +22,10 @@ let rt = aws.ec2.route_table {
   }
 }
 
-aws.ec2.vpc_endpoint {
+aws.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
-  vpc_endpoint_type = aws.ec2.vpc_endpoint.VpcEndpointType.Gateway
+  vpc_endpoint_type = aws.ec2.VpcEndpoint.VpcEndpointType.Gateway
   route_table_ids   = [rt.route_table_id]
 
   tags = {

--- a/acceptance-tests/ec2_vpc_gateway_attachment/basic.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,13 +14,13 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let igw = aws.ec2.internet_gateway {
+let igw = aws.ec2.InternetGateway {
   tags = {
     Environment = 'acceptance-test'
   }
 }
 
-aws.ec2.vpc_gateway_attachment {
+aws.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/acceptance-tests/ec2_vpc_peering_connection/basic.crn
+++ b/acceptance-tests/ec2_vpc_peering_connection/basic.crn
@@ -6,15 +6,15 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc1 = aws.ec2.vpc {
+let vpc1 = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let vpc2 = aws.ec2.vpc {
+let vpc2 = aws.ec2.Vpc {
   cidr_block = '10.1.0.0/16'
 }
 
-aws.ec2.vpc_peering_connection {
+aws.ec2.VpcPeeringConnection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/acceptance-tests/ec2_vpn_gateway/basic.crn
+++ b/acceptance-tests/ec2_vpn_gateway/basic.crn
@@ -6,8 +6,8 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpn_gateway {
-  type = aws.ec2.vpn_gateway.Type.ipsec.1
+aws.ec2.VpnGateway {
+  type = aws.ec2.VpnGateway.Type.ipsec.1
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/iam_role/basic.crn
+++ b/acceptance-tests/iam_role/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.iam.role {
+aws.iam.Role {
   role_name = 'carina-acceptance-test-role'
   assume_role_policy_document = {
     version = '2012-10-17'

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -13,7 +13,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -21,7 +21,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let igw = aws.ec2.internet_gateway {
+let igw = aws.ec2.InternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -29,7 +29,7 @@ let igw = aws.ec2.internet_gateway {
   }
 }
 
-let subnet = aws.ec2.subnet {
+let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -48,7 +48,7 @@ awscc.ec2.nat_gateway {
   subnet_id     = subnet.subnet_id
 }
 
-let rt = aws.ec2.route_table {
+let rt = aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -56,7 +56,7 @@ let rt = aws.ec2.route_table {
   }
 }
 
-aws.ec2.route {
+aws.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '10.1.0.0/16'
   gateway_id             = igw.internet_gateway_id

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -13,7 +13,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -21,7 +21,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.internet_gateway {
+aws.ec2.InternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -29,7 +29,7 @@ aws.ec2.internet_gateway {
   }
 }
 
-let subnet = aws.ec2.subnet {
+let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -48,7 +48,7 @@ let nat_gw = awscc.ec2.nat_gateway {
   subnet_id     = subnet.subnet_id
 }
 
-let rt = aws.ec2.route_table {
+let rt = aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -56,7 +56,7 @@ let rt = aws.ec2.route_table {
   }
 }
 
-aws.ec2.route {
+aws.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '10.1.0.0/16'
   nat_gateway_id         = nat_gw.nat_gateway_id

--- a/acceptance-tests/in_place_update/ec2_route_table_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step1.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.103.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.route_table {
+aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_route_table_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step2.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.103.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.route_table {
+aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_security_group_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step1.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.102.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.security_group {
+aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-sg-update'
   description = 'carina acceptance test - in-place update'
   vpc_id      = vpc.vpc_id

--- a/acceptance-tests/in_place_update/ec2_security_group_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step2.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.102.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.security_group {
+aws.ec2.SecurityGroup {
   group_name  = 'carina-acc-test-aws-sg-update'
   description = 'carina acceptance test - in-place update'
   vpc_id      = vpc.vpc_id

--- a/acceptance-tests/in_place_update/ec2_subnet_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step1.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.101.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.101.1.0/24'
   availability_zone       = aws.AvailabilityZone.ap_northeast_1a

--- a/acceptance-tests/in_place_update/ec2_subnet_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step2.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.101.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.101.1.0/24'
   availability_zone       = aws.AvailabilityZone.ap_northeast_1a

--- a/acceptance-tests/in_place_update/ec2_vpc_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step1.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = false

--- a/acceptance-tests/in_place_update/ec2_vpc_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step2.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/in_place_update/s3_bucket_acl_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_acl_step1.crn
@@ -6,11 +6,11 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-acl-update'
 
-  acl              = aws.s3.bucket.ACL.private
-  object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred
+  acl              = aws.s3.Bucket.ACL.private
+  object_ownership = aws.s3.Bucket.ObjectOwnership.BucketOwnerPreferred
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/in_place_update/s3_bucket_acl_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_acl_step2.crn
@@ -6,10 +6,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-acl-update'
 
-  object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced
+  object_ownership = aws.s3.Bucket.ObjectOwnership.BucketOwnerEnforced
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -6,10 +6,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-update'
 
-  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
+  versioning_status = aws.s3.Bucket.VersioningStatus.Enabled
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -6,10 +6,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-update'
 
-  versioning_status = aws.s3.bucket.VersioningStatus.Suspended
+  versioning_status = aws.s3.Bucket.VersioningStatus.Suspended
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/logs_log_group/basic.crn
+++ b/acceptance-tests/logs_log_group/basic.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.logs.log_group {
+aws.logs.LogGroup {
   log_group_name = '/carina/acceptance-test'
   retention_in_days = 7
 

--- a/acceptance-tests/s3_bucket/acl_private.crn
+++ b/acceptance-tests/s3_bucket/acl_private.crn
@@ -7,11 +7,11 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-acl-private'
 
-  acl              = aws.s3.bucket.ACL.private
-  object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred
+  acl              = aws.s3.Bucket.ACL.private
+  object_ownership = aws.s3.Bucket.ObjectOwnership.BucketOwnerPreferred
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/s3_bucket/basic.crn
+++ b/acceptance-tests/s3_bucket/basic.crn
@@ -6,10 +6,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-basic-v2'
 
-  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
+  versioning_status = aws.s3.Bucket.VersioningStatus.Enabled
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/s3_bucket/object_ownership.crn
+++ b/acceptance-tests/s3_bucket/object_ownership.crn
@@ -6,10 +6,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-object-ownership'
 
-  object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced
+  object_ownership = aws.s3.Bucket.ObjectOwnership.BucketOwnerEnforced
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/s3_bucket/versioning.crn
+++ b/acceptance-tests/s3_bucket/versioning.crn
@@ -6,10 +6,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-versioning'
 
-  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
+  versioning_status = aws.s3.Bucket.VersioningStatus.Enabled
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/sts_caller_identity/basic.crn
+++ b/acceptance-tests/sts_caller_identity/basic.crn
@@ -2,4 +2,4 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let caller = read aws.sts.caller_identity {}
+let caller = read aws.sts.CallerIdentity {}

--- a/acceptance-tests/tag_deletion/ec2_route_table_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_route_table_step1.crn
@@ -7,7 +7,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.104.0.0/16'
 
   tags = {
@@ -15,7 +15,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.route_table {
+aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/tag_deletion/ec2_route_table_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_route_table_step2.crn
@@ -8,7 +8,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.104.0.0/16'
 
   tags = {
@@ -16,7 +16,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.route_table {
+aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/tag_deletion/ec2_route_table_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_route_table_step3.crn
@@ -9,7 +9,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.104.0.0/16'
 
   tags = {
@@ -17,6 +17,6 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.route_table {
+aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }

--- a/acceptance-tests/tag_deletion/ec2_security_group_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_security_group_step1.crn
@@ -7,7 +7,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.106.0.0/16'
 
   tags = {
@@ -15,7 +15,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.security_group {
+aws.ec2.SecurityGroup {
   group_name  = 'carina-tag-deletion-test'
   description = 'Carina acceptance test for tag deletion'
   vpc_id      = vpc.vpc_id

--- a/acceptance-tests/tag_deletion/ec2_security_group_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_security_group_step2.crn
@@ -8,7 +8,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.106.0.0/16'
 
   tags = {
@@ -16,7 +16,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.security_group {
+aws.ec2.SecurityGroup {
   group_name  = 'carina-tag-deletion-test'
   description = 'Carina acceptance test for tag deletion'
   vpc_id      = vpc.vpc_id

--- a/acceptance-tests/tag_deletion/ec2_security_group_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_security_group_step3.crn
@@ -9,7 +9,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.106.0.0/16'
 
   tags = {
@@ -17,7 +17,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.security_group {
+aws.ec2.SecurityGroup {
   group_name  = 'carina-tag-deletion-test'
   description = 'Carina acceptance test for tag deletion'
   vpc_id      = vpc.vpc_id

--- a/acceptance-tests/tag_deletion/ec2_subnet_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step1.crn
@@ -7,7 +7,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.105.0.0/16'
 
   tags = {
@@ -15,7 +15,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.105.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a

--- a/acceptance-tests/tag_deletion/ec2_subnet_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step2.crn
@@ -8,7 +8,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.105.0.0/16'
 
   tags = {
@@ -16,7 +16,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.105.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a

--- a/acceptance-tests/tag_deletion/ec2_subnet_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step3.crn
@@ -9,7 +9,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.105.0.0/16'
 
   tags = {
@@ -17,7 +17,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.105.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a

--- a/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
@@ -7,11 +7,11 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
-  instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
+  instance_tenancy     = aws.ec2.Vpc.InstanceTenancy.default
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
@@ -8,11 +8,11 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
-  instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
+  instance_tenancy     = aws.ec2.Vpc.InstanceTenancy.default
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
@@ -8,9 +8,9 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
-  instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
+  instance_tenancy     = aws.ec2.Vpc.InstanceTenancy.default
 }

--- a/acceptance-tests/tag_deletion/s3_bucket_step1.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step1.crn
@@ -7,10 +7,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-tag-del'
 
-  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
+  versioning_status = aws.s3.Bucket.VersioningStatus.Enabled
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/tag_deletion/s3_bucket_step2.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step2.crn
@@ -9,10 +9,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-tag-del'
 
-  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
+  versioning_status = aws.s3.Bucket.VersioningStatus.Enabled
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/tag_deletion/s3_bucket_step3.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step3.crn
@@ -8,8 +8,8 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-tag-del'
 
-  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
+  versioning_status = aws.s3.Bucket.VersioningStatus.Enabled
 }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1369,7 +1369,7 @@ pub fn iam_policy_document() -> AttributeType {
 
 /// IAM condition operator mappings: (snake_case, PascalCase).
 ///
-/// See <https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html>
+/// See <https://docs.aws.amazon.Com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html>
 const CONDITION_OPERATORS: &[(&str, &str)] = &[
     // String
     ("string_equals", "StringEquals"),

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -29,7 +29,7 @@ struct Args {
     #[arg(long)]
     output_dir: PathBuf,
 
-    /// Generate only the specified resource (e.g., "ec2.vpc")
+    /// Generate only the specified resource (e.g., "ec2.Vpc")
     #[arg(long)]
     resource: Option<String>,
 
@@ -93,16 +93,46 @@ struct IntRange {
     max: Option<i64>,
 }
 
+/// Convert a PascalCase token (e.g., `"SecurityGroupIngress"`) to snake_case
+/// (`"security_group_ingress"`) for use in Rust module names and identifiers.
+fn pascal_to_snake(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, c) in s.chars().enumerate() {
+        if c.is_ascii_uppercase() {
+            if i != 0 {
+                out.push('_');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Convert a DSL resource name to a Rust module name.
-/// e.g., "ec2.vpc" -> "ec2_vpc", "ec2.security_group_ingress" -> "ec2_security_group_ingress"
+/// e.g., "ec2.Vpc" -> "ec2_vpc", "ec2.SecurityGroupIngress" -> "ec2_security_group_ingress".
+/// The DSL name uses PascalCase for the final segment per the naming-conventions
+/// rule (design D2); Rust modules stay snake_case.
 fn module_name(name: &str) -> String {
-    name.replace('.', "_")
+    let (service, resource) = split_service_resource(name);
+    format!("{}_{}", service, pascal_to_snake(resource))
 }
 
 /// Split a DSL resource name into (service, resource).
-/// e.g., "ec2.vpc" -> ("ec2", "vpc"), "s3.bucket" -> ("s3", "bucket")
+/// e.g., "ec2.Vpc" -> ("ec2", "Vpc"), "s3.Bucket" -> ("s3", "Bucket").
+/// The final segment is PascalCase per design D2; callers that need a
+/// snake_case form should apply `pascal_to_snake` to the second element.
 fn split_service_resource(name: &str) -> (&str, &str) {
     name.split_once('.').expect("DSL name must contain '.'")
+}
+
+/// Split a DSL resource name and snake_case the final segment.
+/// Returns (service, snake_resource) suitable for Rust module paths,
+/// file names, and identifier generation.
+fn split_service_resource_snake(name: &str) -> (&str, String) {
+    let (service, resource) = split_service_resource(name);
+    (service, pascal_to_snake(resource))
 }
 
 /// Escape Rust reserved keywords with the raw identifier prefix `r#`.
@@ -198,6 +228,7 @@ fn main() -> Result<()> {
                 let code = generate_resource(res, model)?;
 
                 let (service, resource) = split_service_resource(res.name);
+                let resource = pascal_to_snake(resource);
                 let service_dir = args.output_dir.join(service);
                 std::fs::create_dir_all(&service_dir)?;
 
@@ -214,6 +245,7 @@ fn main() -> Result<()> {
                 let code = generate_data_source(ds, model)?;
 
                 let (service, resource) = split_service_resource(ds.name);
+                let resource = pascal_to_snake(resource);
                 let service_dir = args.output_dir.join(service);
                 std::fs::create_dir_all(&service_dir)?;
 
@@ -248,6 +280,7 @@ fn main() -> Result<()> {
                 let md = generate_markdown_resource(res, model)?;
 
                 let (service, resource) = split_service_resource(res.name);
+                let resource = pascal_to_snake(resource);
                 let service_dir = args.output_dir.join(service);
                 std::fs::create_dir_all(&service_dir)?;
                 let output_path = service_dir.join(format!("{}.md", resource));
@@ -260,6 +293,7 @@ fn main() -> Result<()> {
                 let md = generate_markdown_data_source(ds, model)?;
 
                 let (service, resource) = split_service_resource(ds.name);
+                let resource = pascal_to_snake(resource);
                 let service_dir = args.output_dir.join(service);
                 std::fs::create_dir_all(&service_dir)?;
                 let output_path = service_dir.join(format!("{}.md", resource));
@@ -276,7 +310,7 @@ fn main() -> Result<()> {
 
 /// Load a Smithy model from a JSON file in the model directory.
 fn load_model(model_dir: &Path, namespace: &str) -> Result<SmithyModel> {
-    // Map namespace to file name: "com.amazonaws.ec2" -> "ec2.json"
+    // Map namespace to file name: "com.amazonaws.ec2" -> "ec2.Json"
     let service_name = namespace
         .strip_prefix("com.amazonaws.")
         .unwrap_or(namespace);
@@ -1264,11 +1298,12 @@ fn get_int_range(model: &SmithyModel, target: &str, field_name: &str) -> Option<
 
 /// Generate per-service mod.rs files that declare resource modules.
 fn generate_service_mod_files(output_dir: &std::path::Path, dsl_names: &[&str]) -> Result<()> {
-    // Group resources by service
-    let mut services: std::collections::BTreeMap<&str, Vec<&str>> =
+    // Group resources by service. Resource segments are snake_cased because
+    // they become Rust `mod resource;` declarations in the generated code.
+    let mut services: std::collections::BTreeMap<&str, Vec<String>> =
         std::collections::BTreeMap::new();
     for name in dsl_names {
-        let (service, resource) = split_service_resource(name);
+        let (service, resource) = split_service_resource_snake(name);
         services.entry(service).or_default().push(resource);
     }
 
@@ -1283,7 +1318,7 @@ fn generate_service_mod_files(output_dir: &std::path::Path, dsl_names: &[&str]) 
              pub use super::*;\n\n",
         );
 
-        let mut sorted_resources: Vec<&&str> = resources.iter().collect();
+        let mut sorted_resources: Vec<&String> = resources.iter().collect();
         sorted_resources.sort();
         for resource in sorted_resources {
             code.push_str(&format!("pub mod {};\n", resource));
@@ -1300,10 +1335,20 @@ fn generate_service_mod_files(output_dir: &std::path::Path, dsl_names: &[&str]) 
 
 /// Scan `output_dir` for orphaned service/resource modules — files that exist on disk
 /// but are not registered in `resource_defs.rs`. These are typically legacy schemas
-/// generated by an earlier codegen pipeline. Returns DSL names like "iam.role".
+/// generated by an earlier codegen pipeline. Returns DSL names using the
+/// naming-conventions spelling (PascalCase final segment, e.g. `"iam.Role"`).
 fn scan_orphaned_modules(output_dir: &std::path::Path, known_names: &[&str]) -> Vec<String> {
     let mut orphaned = Vec::new();
-    let known_set: std::collections::HashSet<&str> = known_names.iter().copied().collect();
+    // The on-disk filename is snake_case (e.g. `role.rs`), but `known_names`
+    // carries the DSL spelling (`"iam.Role"`). Compare in the snake_case
+    // domain by snake-casing the known set.
+    let known_snake: std::collections::HashSet<String> = known_names
+        .iter()
+        .map(|name| {
+            let (service, resource) = split_service_resource_snake(name);
+            format!("{}.{}", service, resource)
+        })
+        .collect();
 
     let Ok(entries) = std::fs::read_dir(output_dir) else {
         return orphaned;
@@ -1331,9 +1376,26 @@ fn scan_orphaned_modules(output_dir: &std::path::Path, known_names: &[&str]) -> 
             if file_stem == "mod" {
                 continue;
             }
-            let dsl_name = format!("{}.{}", service, file_stem);
-            if !known_set.contains(dsl_name.as_str()) {
-                orphaned.push(dsl_name);
+            let snake_name = format!("{}.{}", service, file_stem);
+            if !known_snake.contains(&snake_name) {
+                // Emit in new-spelling DSL form so callers can compose output
+                // paths with `split_service_resource`.
+                let resource_pascal: String = {
+                    let mut out = String::with_capacity(file_stem.len());
+                    let mut upper = true;
+                    for c in file_stem.chars() {
+                        if c == '_' {
+                            upper = true;
+                        } else if upper {
+                            out.push(c.to_ascii_uppercase());
+                            upper = false;
+                        } else {
+                            out.push(c);
+                        }
+                    }
+                    out
+                };
+                orphaned.push(format!("{}.{}", service, resource_pascal));
             }
         }
     }
@@ -1380,7 +1442,7 @@ fn generate_mod_rs(dsl_names: &[&str], output_dir: &std::path::Path) -> String {
          \x20   vec![\n",
     );
     for name in &sorted {
-        let (service, resource) = split_service_resource(name);
+        let (service, resource) = split_service_resource_snake(name);
         let mn = module_name(name);
         code.push_str(&format!(
             "\x20       {}::{}::{}_config(),\n",
@@ -1403,7 +1465,7 @@ fn generate_mod_rs(dsl_names: &[&str], output_dir: &std::path::Path) -> String {
          \x20   let modules: &[(&str, &[(&str, &[&str])])] = &[\n",
     );
     for name in &sorted {
-        let (service, resource) = split_service_resource(name);
+        let (service, resource) = split_service_resource_snake(name);
         code.push_str(&format!(
             "\x20       {}::{}::enum_valid_values(),\n",
             service, resource
@@ -1432,7 +1494,7 @@ fn generate_mod_rs(dsl_names: &[&str], output_dir: &std::path::Path) -> String {
          pub fn get_enum_alias_reverse(resource_type: &str, attr_name: &str, value: &str) -> Option<&'static str> {\n",
     );
     for name in &sorted {
-        let (service, resource) = split_service_resource(name);
+        let (service, resource) = split_service_resource_snake(name);
         code.push_str(&format!(
             "\x20   if resource_type == \"{}\" {{\n\
              \x20       return {}::{}::enum_alias_reverse(attr_name, value);\n\
@@ -1451,7 +1513,7 @@ fn generate_mod_rs(dsl_names: &[&str], output_dir: &std::path::Path) -> String {
          \x20   let mut map = std::collections::HashMap::new();\n",
     );
     for name in &sorted {
-        let (service, resource) = split_service_resource(name);
+        let (service, resource) = split_service_resource_snake(name);
         code.push_str(&format!(
             "\x20   for (attr, alias, canonical) in {}::{}::enum_alias_entries() {{\n\
              \x20       map.entry(\"{}\".to_string())\n\
@@ -1544,7 +1606,8 @@ fn generate_provider_code(
 
     // Simple delete methods
     for res in all_resources.iter().filter(|r| r.simple_delete) {
-        let method_name = format!("delete_{}", res.name.replace('.', "_"));
+        let (service, resource) = split_service_resource_snake(res.name);
+        let method_name = format!("delete_{}_{}", service, resource);
         if manual_methods.contains(&method_name) {
             continue;
         }
@@ -1552,13 +1615,11 @@ fn generate_provider_code(
         let sdk_method = res.delete_op.to_snake_case();
         let id_setter = res.identifier.to_snake_case();
 
-        // Human-readable resource name for error message
-        let display_name = res
-            .name
-            .split('.')
-            .next_back()
-            .unwrap_or(res.name)
-            .replace('_', " ");
+        // Human-readable resource name for error message. The final segment
+        // is PascalCase under the naming-conventions rule; snake_case it and
+        // convert underscores to spaces for display ("SecurityGroup" -> "security group").
+        let display_name =
+            pascal_to_snake(res.name.split('.').next_back().unwrap_or(res.name)).replace('_', " ");
 
         code.push_str(&format!(
             "\x20   /// Delete {} (generated)\n\
@@ -1579,11 +1640,11 @@ fn generate_provider_code(
 
     // No-op update methods (with optional tag handling)
     for res in all_resources.iter().filter(|r| r.noop_update) {
-        let method_name = format!("update_{}", res.name.replace('.', "_"));
+        let method_name = format!("update_{}", module_name(res.name));
         if manual_methods.contains(&method_name) {
             continue;
         }
-        let read_method = format!("read_{}", res.name.replace('.', "_"));
+        let read_method = format!("read_{}", module_name(res.name));
 
         if res.has_tags {
             // Tag-enabled noop update: apply tags then read back
@@ -1630,7 +1691,7 @@ fn generate_provider_code(
         let ns = res.service_namespace;
         let client_field = client_field_name(ns);
         let id_setter = res.identifier.to_snake_case();
-        let resource_name = res.name.replace('.', "_");
+        let resource_name = module_name(res.name);
 
         for read_op in &res.read_ops {
             let suffix = op_suffix(read_op.operation, res.identifier);
@@ -1729,7 +1790,7 @@ fn generate_provider_code(
         let ns = res.service_namespace;
         let client_field = client_field_name(ns);
         let id_setter = res.identifier.to_snake_case();
-        let resource_name = res.name.replace('.', "_");
+        let resource_name = module_name(res.name);
         let sdk_crate_name = sdk_crate_name(ns);
 
         // Build reverse rename map from read_ops: effective_name -> original_smithy_name
@@ -1892,7 +1953,7 @@ fn generate_provider_code(
             None => continue,
         };
 
-        let resource_name = res.name.replace('.', "_");
+        let resource_name = module_name(res.name);
         if manual_methods.contains(&format!("extract_{}_attributes", resource_name)) {
             continue;
         }
@@ -2498,7 +2559,7 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
 fn generate_data_source(ds: &resource_defs::DataSourceDef, model: &SmithyModel) -> Result<String> {
     let ns = ds.service_namespace;
     let namespace = format!("aws.{}", ds.name);
-    let config_fn = format!("{}_config", ds.name.replace('.', "_"));
+    let config_fn = format!("{}_config", module_name(ds.name));
     let cf_type = cf_type_name(ds.name);
 
     let type_overrides: HashMap<&str, &str> = ds.type_overrides.iter().copied().collect();
@@ -3182,33 +3243,33 @@ fn get_resource_id_type(prop_name: &str) -> &'static str {
 /// Map resource name to CloudFormation type name for backward compatibility.
 fn cf_type_name(resource_name: &str) -> &'static str {
     match resource_name {
-        "ec2.vpc" => "AWS::EC2::VPC",
-        "ec2.subnet" => "AWS::EC2::Subnet",
-        "ec2.internet_gateway" => "AWS::EC2::InternetGateway",
-        "ec2.route_table" => "AWS::EC2::RouteTable",
-        "ec2.route" => "AWS::EC2::Route",
-        "ec2.security_group" => "AWS::EC2::SecurityGroup",
-        "ec2.security_group_ingress" => "AWS::EC2::SecurityGroupIngress",
-        "ec2.security_group_egress" => "AWS::EC2::SecurityGroupEgress",
-        "ec2.egress_only_internet_gateway" => "AWS::EC2::EgressOnlyInternetGateway",
-        "ec2.eip" => "AWS::EC2::EIP",
-        "ec2.flow_log" => "AWS::EC2::FlowLog",
-        "ec2.nat_gateway" => "AWS::EC2::NatGateway",
-        "ec2.subnet_route_table_association" => "AWS::EC2::SubnetRouteTableAssociation",
-        "ec2.transit_gateway" => "AWS::EC2::TransitGateway",
-        "ec2.transit_gateway_attachment" => "AWS::EC2::TransitGatewayAttachment",
-        "ec2.vpc_endpoint" => "AWS::EC2::VPCEndpoint",
-        "ec2.vpc_gateway_attachment" => "AWS::EC2::VPCGatewayAttachment",
-        "ec2.vpc_peering_connection" => "AWS::EC2::VPCPeeringConnection",
-        "ec2.vpn_gateway" => "AWS::EC2::VPNGateway",
-        "s3.bucket" => "AWS::S3::Bucket",
-        "sts.caller_identity" => "AWS::STS::CallerIdentity",
-        "organizations.organization" => "AWS::Organizations::Organization",
-        "organizations.account" => "AWS::Organizations::Account",
-        "route53.record_set" => "AWS::Route53::RecordSet",
-        "iam.role" => "AWS::IAM::Role",
-        "logs.log_group" => "AWS::Logs::LogGroup",
-        "identitystore.user" => "AWS::IdentityStore::User",
+        "ec2.Vpc" => "AWS::EC2::VPC",
+        "ec2.Subnet" => "AWS::EC2::Subnet",
+        "ec2.InternetGateway" => "AWS::EC2::InternetGateway",
+        "ec2.RouteTable" => "AWS::EC2::RouteTable",
+        "ec2.Route" => "AWS::EC2::Route",
+        "ec2.SecurityGroup" => "AWS::EC2::SecurityGroup",
+        "ec2.SecurityGroupIngress" => "AWS::EC2::SecurityGroupIngress",
+        "ec2.SecurityGroupEgress" => "AWS::EC2::SecurityGroupEgress",
+        "ec2.EgressOnlyInternetGateway" => "AWS::EC2::EgressOnlyInternetGateway",
+        "ec2.Eip" => "AWS::EC2::EIP",
+        "ec2.FlowLog" => "AWS::EC2::FlowLog",
+        "ec2.NatGateway" => "AWS::EC2::NatGateway",
+        "ec2.SubnetRouteTableAssociation" => "AWS::EC2::SubnetRouteTableAssociation",
+        "ec2.TransitGateway" => "AWS::EC2::TransitGateway",
+        "ec2.TransitGatewayAttachment" => "AWS::EC2::TransitGatewayAttachment",
+        "ec2.VpcEndpoint" => "AWS::EC2::VPCEndpoint",
+        "ec2.VpcGatewayAttachment" => "AWS::EC2::VPCGatewayAttachment",
+        "ec2.VpcPeeringConnection" => "AWS::EC2::VPCPeeringConnection",
+        "ec2.VpnGateway" => "AWS::EC2::VPNGateway",
+        "s3.Bucket" => "AWS::S3::Bucket",
+        "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
+        "organizations.Organization" => "AWS::Organizations::Organization",
+        "organizations.Account" => "AWS::Organizations::Account",
+        "route53.RecordSet" => "AWS::Route53::RecordSet",
+        "iam.Role" => "AWS::IAM::Role",
+        "logs.LogGroup" => "AWS::Logs::LogGroup",
+        "identitystore.User" => "AWS::IdentityStore::User",
         _ => panic!(
             "Unknown resource: {}. Add it to cf_type_name().",
             resource_name
@@ -3288,8 +3349,8 @@ mod tests {
             .expect("failed to parse Smithy fixture");
         let resource = resource_defs::s3_resources()
             .into_iter()
-            .find(|res| res.name == "s3.bucket")
-            .expect("missing s3.bucket resource def");
+            .find(|res| res.name == "s3.Bucket")
+            .expect("missing s3.Bucket resource def");
 
         let generated = generate_resource(&resource, &model).expect("failed to generate resource");
 
@@ -3326,10 +3387,10 @@ mod tests {
         std::fs::write(logs_dir.join("log_group.rs"), "// orphaned").unwrap();
         std::fs::write(logs_dir.join("mod.rs"), "pub mod log_group;").unwrap();
 
-        let known = vec!["ec2.vpc"];
+        let known = vec!["ec2.Vpc"];
         let orphaned = scan_orphaned_modules(output_dir, &known);
 
-        assert_eq!(orphaned, vec!["iam.role", "logs.log_group"]);
+        assert_eq!(orphaned, vec!["iam.Role", "logs.LogGroup"]);
     }
 
     #[test]
@@ -3342,8 +3403,8 @@ mod tests {
         std::fs::create_dir_all(&iam_dir).unwrap();
         std::fs::write(iam_dir.join("role.rs"), "// orphaned").unwrap();
 
-        // Generate with a different known resource (ec2.vpc)
-        let dsl_names = &["ec2.vpc"];
+        // Generate with a different known resource (ec2.Vpc)
+        let dsl_names = &["ec2.Vpc"];
         let generated = generate_mod_rs(dsl_names, output_dir);
 
         assert!(
@@ -3352,11 +3413,11 @@ mod tests {
         );
         assert!(
             generated.contains("iam::role::iam_role_config()"),
-            "orphaned iam.role config should be included: {generated}"
+            "orphaned iam.Role config should be included: {generated}"
         );
         assert!(
-            generated.contains("if resource_type == \"iam.role\""),
-            "orphaned iam.role enum_alias_reverse should be included: {generated}"
+            generated.contains("if resource_type == \"iam.Role\""),
+            "orphaned iam.Role enum_alias_reverse should be included: {generated}"
         );
     }
 

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -29,7 +29,7 @@ pub struct ReadOp {
 
 /// Defines how to map an AWS API resource to a Carina schema.
 pub struct ResourceDef {
-    /// Carina DSL resource name (e.g., "ec2.vpc")
+    /// Carina DSL resource name (e.g., "ec2.Vpc")
     pub name: &'static str,
     /// Smithy service namespace (e.g., "com.amazonaws.ec2")
     pub service_namespace: &'static str,
@@ -123,7 +123,7 @@ pub struct UpdateOp {
 /// Lookup logic is hand-written in `services/{service}/{resource}.rs`;
 /// the codegen generates schema, docs, and dispatch boilerplate.
 pub struct DataSourceDef {
-    /// Carina DSL resource name (e.g., "identitystore.user")
+    /// Carina DSL resource name (e.g., "identitystore.User")
     pub name: &'static str,
     /// Smithy service namespace (e.g., "com.amazonaws.identitystore")
     pub service_namespace: &'static str,
@@ -156,7 +156,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
     vec![
         // ec2.vpc
         ResourceDef {
-            name: "ec2.vpc",
+            name: "ec2.Vpc",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -194,7 +194,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.subnet
         ResourceDef {
-            name: "ec2.subnet",
+            name: "ec2.Subnet",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -228,7 +228,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.internet_gateway
         ResourceDef {
-            name: "ec2.internet_gateway",
+            name: "ec2.InternetGateway",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: false,
@@ -253,7 +253,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.route_table
         ResourceDef {
-            name: "ec2.route_table",
+            name: "ec2.RouteTable",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -278,7 +278,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.route
         ResourceDef {
-            name: "ec2.route",
+            name: "ec2.Route",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: false,
@@ -321,7 +321,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.security_group
         ResourceDef {
-            name: "ec2.security_group",
+            name: "ec2.SecurityGroup",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -346,7 +346,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.security_group_ingress
         ResourceDef {
-            name: "ec2.security_group_ingress",
+            name: "ec2.SecurityGroupIngress",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: false,
@@ -400,7 +400,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.security_group_egress
         ResourceDef {
-            name: "ec2.security_group_egress",
+            name: "ec2.SecurityGroupEgress",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: false,
@@ -454,7 +454,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.egress_only_internet_gateway
         ResourceDef {
-            name: "ec2.egress_only_internet_gateway",
+            name: "ec2.EgressOnlyInternetGateway",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -479,7 +479,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.eip
         ResourceDef {
-            name: "ec2.eip",
+            name: "ec2.Eip",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -510,7 +510,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.flow_log
         ResourceDef {
-            name: "ec2.flow_log",
+            name: "ec2.FlowLog",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -544,7 +544,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.nat_gateway
         ResourceDef {
-            name: "ec2.nat_gateway",
+            name: "ec2.NatGateway",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -576,7 +576,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.subnet_route_table_association
         ResourceDef {
-            name: "ec2.subnet_route_table_association",
+            name: "ec2.SubnetRouteTableAssociation",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -601,7 +601,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.transit_gateway
         ResourceDef {
-            name: "ec2.transit_gateway",
+            name: "ec2.TransitGateway",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -629,7 +629,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.transit_gateway_attachment
         ResourceDef {
-            name: "ec2.transit_gateway_attachment",
+            name: "ec2.TransitGatewayAttachment",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -654,7 +654,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.vpc_endpoint
         ResourceDef {
-            name: "ec2.vpc_endpoint",
+            name: "ec2.VpcEndpoint",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -689,7 +689,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.vpc_gateway_attachment
         ResourceDef {
-            name: "ec2.vpc_gateway_attachment",
+            name: "ec2.VpcGatewayAttachment",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: false,
@@ -725,7 +725,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.vpc_peering_connection
         ResourceDef {
-            name: "ec2.vpc_peering_connection",
+            name: "ec2.VpcPeeringConnection",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -750,7 +750,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
         },
         // ec2.vpn_gateway
         ResourceDef {
-            name: "ec2.vpn_gateway",
+            name: "ec2.VpnGateway",
             service_namespace: "com.amazonaws.ec2",
             schema_structure: None,
             simple_delete: true,
@@ -784,7 +784,7 @@ pub fn sts_resources() -> Vec<ResourceDef> {
 /// Returns STS data source definitions.
 pub fn sts_data_sources() -> Vec<DataSourceDef> {
     vec![DataSourceDef {
-        name: "sts.caller_identity",
+        name: "sts.CallerIdentity",
         service_namespace: "com.amazonaws.sts",
         inputs: vec![],
         read_ops: vec![ReadOp {
@@ -807,7 +807,7 @@ pub fn sts_data_sources() -> Vec<DataSourceDef> {
 /// Returns Identity Store data source definitions.
 pub fn identitystore_data_sources() -> Vec<DataSourceDef> {
     vec![DataSourceDef {
-        name: "identitystore.user",
+        name: "identitystore.User",
         service_namespace: "com.amazonaws.identitystore",
         inputs: vec![
             DataSourceInput {
@@ -847,7 +847,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
     vec![
         // organizations.organization
         ResourceDef {
-            name: "organizations.organization",
+            name: "organizations.Organization",
             service_namespace: "com.amazonaws.organizations",
             schema_structure: None,
             simple_delete: true,
@@ -877,7 +877,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
         },
         // organizations.account
         ResourceDef {
-            name: "organizations.account",
+            name: "organizations.Account",
             service_namespace: "com.amazonaws.organizations",
             schema_structure: None,
             simple_delete: false,
@@ -913,7 +913,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
     vec![
         // s3.bucket
         ResourceDef {
-            name: "s3.bucket",
+            name: "s3.Bucket",
             service_namespace: "com.amazonaws.s3",
             schema_structure: None,
             simple_delete: false, // manually implemented to support lifecycle.force_delete
@@ -980,7 +980,7 @@ pub fn route53_resources() -> Vec<ResourceDef> {
         // Uses schema_structure because ChangeResourceRecordSets wraps fields
         // in a nested ChangeBatch, not as top-level input parameters.
         ResourceDef {
-            name: "route53.record_set",
+            name: "route53.RecordSet",
             service_namespace: "com.amazonaws.route53",
             schema_structure: Some("ResourceRecordSet"),
             simple_delete: false,
@@ -1033,7 +1033,7 @@ pub fn route53_resources() -> Vec<ResourceDef> {
 /// Returns IAM resource definitions.
 pub fn iam_resources() -> Vec<ResourceDef> {
     vec![ResourceDef {
-        name: "iam.role",
+        name: "iam.Role",
         service_namespace: "com.amazonaws.iam",
         schema_structure: None,
         simple_delete: true,
@@ -1070,7 +1070,7 @@ pub fn iam_resources() -> Vec<ResourceDef> {
 /// Returns CloudWatch Logs resource definitions.
 pub fn logs_resources() -> Vec<ResourceDef> {
     vec![ResourceDef {
-        name: "logs.log_group",
+        name: "logs.LogGroup",
         service_namespace: "com.amazonaws.cloudwatchlogs",
         schema_structure: None,
         simple_delete: true,

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -355,7 +355,7 @@ mod tests {
         let core_type = CoreAttributeType::StringEnum {
             name: "VersioningStatus".to_string(),
             values: vec!["Enabled".to_string(), "Suspended".to_string()],
-            namespace: Some("aws.s3.bucket".to_string()),
+            namespace: Some("aws.s3.Bucket".to_string()),
             to_dsl: None,
         };
         let proto_type = core_to_proto_attribute_type(&core_type);
@@ -370,7 +370,7 @@ mod tests {
                     values,
                     &vec!["Enabled".to_string(), "Suspended".to_string()]
                 );
-                assert_eq!(namespace.as_deref(), Some("aws.s3.bucket"));
+                assert_eq!(namespace.as_deref(), Some("aws.s3.Bucket"));
             }
             _ => panic!("Expected StringEnum"),
         }

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -27,7 +27,7 @@ pub fn require_string_attr(resource: &Resource, attr_name: &str) -> ProviderResu
 /// Extract a required enum attribute from a resource, stripping the DSL namespace prefix.
 ///
 /// StringEnum attributes arrive as namespaced identifiers
-/// (e.g., `aws.route53.record_set.Type.A`). This extracts just the variant (`A`).
+/// (e.g., `aws.route53.RecordSet.Type.A`). This extracts just the variant (`A`).
 /// Using `require_string_attr` instead will pass the full namespaced path to
 /// the AWS API, causing failures that are hard to diagnose.
 pub fn require_enum_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
@@ -177,7 +177,7 @@ mod tests {
 
     fn make_test_resource(attrs: Vec<(&str, &str)>) -> Resource {
         use carina_core::resource::Expr;
-        let mut resource = Resource::new("route53.record_set", "test");
+        let mut resource = Resource::new("route53.RecordSet", "test");
         for (k, v) in attrs {
             resource
                 .attributes
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_require_enum_attr_strips_namespace() {
-        let resource = make_test_resource(vec![("type", "aws.route53.record_set.Type.A")]);
+        let resource = make_test_resource(vec![("type", "aws.route53.RecordSet.Type.A")]);
         assert_eq!(require_enum_attr(&resource, "type").unwrap(), "A");
     }
 

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -292,7 +292,7 @@ mod tests {
         let schemas = provider.schemas();
         let bucket = schemas
             .iter()
-            .find(|s| s.resource_type == "aws.s3.bucket")
+            .find(|s| s.resource_type == "aws.s3.Bucket")
             .expect("s3.bucket schema should exist");
         assert!(
             bucket
@@ -326,14 +326,14 @@ mod tests {
         let provider = AwsProcessProvider::new();
         let schemas = provider.schemas();
         assert!(
-            schemas.iter().any(|s| s.resource_type == "aws.iam.role"),
-            "aws.iam.role schema should be registered"
+            schemas.iter().any(|s| s.resource_type == "aws.iam.Role"),
+            "aws.iam.Role schema should be registered"
         );
         assert!(
             schemas
                 .iter()
-                .any(|s| s.resource_type == "aws.logs.log_group"),
-            "aws.logs.log_group schema should be registered"
+                .any(|s| s.resource_type == "aws.logs.LogGroup"),
+            "aws.logs.LogGroup schema should be registered"
         );
     }
 

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -29,7 +29,7 @@ impl ProviderNormalizer for AwsNormalizer {
 /// Resolve enum identifiers in resources to their fully-qualified DSL format.
 ///
 /// For example, resolves bare `Enabled` or `VersioningStatus.Enabled` into
-/// `aws.s3.bucket.VersioningStatus.Enabled` based on schema definitions.
+/// `aws.s3.Bucket.VersioningStatus.Enabled` based on schema definitions.
 pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
     let configs = crate::schemas::generated::configs();
 
@@ -72,7 +72,7 @@ pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
 /// Normalize enum values in read-returned state attributes to namespaced DSL format.
 ///
 /// Read methods return plain values like `"Enabled"` from AWS APIs.
-/// This converts them to namespaced format like `aws.s3.bucket.VersioningStatus.Enabled`
+/// This converts them to namespaced format like `aws.s3.Bucket.VersioningStatus.Enabled`
 /// to match the resolved DSL values.
 pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMap<String, Value>) {
     let configs = crate::schemas::generated::configs();
@@ -141,24 +141,24 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_namespaced_value() {
-        let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
+        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test-bucket");
         resource.set_attr(
             "versioning_status".to_string(),
-            Value::String("aws.s3.bucket.VersioningStatus.Enabled".to_string()),
+            Value::String("aws.s3.Bucket.VersioningStatus.Enabled".to_string()),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         assert_eq!(
             resources[0].get_attr("versioning_status"),
             Some(&Value::String(
-                "aws.s3.bucket.VersioningStatus.Enabled".to_string()
+                "aws.s3.Bucket.VersioningStatus.Enabled".to_string()
             ))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
+        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test-bucket");
         resource.set_attr(
             "versioning_status".to_string(),
             Value::String("Enabled".to_string()),
@@ -168,14 +168,14 @@ mod tests {
         assert_eq!(
             resources[0].get_attr("versioning_status"),
             Some(&Value::String(
-                "aws.s3.bucket.VersioningStatus.Enabled".to_string()
+                "aws.s3.Bucket.VersioningStatus.Enabled".to_string()
             ))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
+        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test-bucket");
         resource.set_attr(
             "object_ownership".to_string(),
             Value::String("ObjectOwnership.BucketOwnerEnforced".to_string()),
@@ -185,14 +185,14 @@ mod tests {
         assert_eq!(
             resources[0].get_attr("object_ownership"),
             Some(&Value::String(
-                "aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced".to_string()
+                "aws.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string()
             ))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_plain_string() {
-        let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
+        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test-bucket");
         resource.set_attr(
             "versioning_status".to_string(),
             Value::String("Enabled".to_string()),
@@ -202,14 +202,14 @@ mod tests {
         assert_eq!(
             resources[0].get_attr("versioning_status"),
             Some(&Value::String(
-                "aws.s3.bucket.VersioningStatus.Enabled".to_string()
+                "aws.s3.Bucket.VersioningStatus.Enabled".to_string()
             ))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_aws() {
-        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test");
+        let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test");
         resource.set_attr(
             "versioning_status".to_string(),
             Value::String("Enabled".to_string()),
@@ -226,15 +226,14 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_with_to_dsl() {
         // ip_protocol has to_dsl that maps "-1" → "all"
-        let mut resource =
-            Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule");
+        let mut resource = Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule");
         resource.set_attr("ip_protocol".to_string(), Value::String("-1".to_string()));
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         assert_eq!(
             resources[0].get_attr("ip_protocol"),
             Some(&Value::String(
-                "aws.ec2.security_group_ingress.IpProtocol.all".to_string()
+                "aws.ec2.SecurityGroupIngress.IpProtocol.all".to_string()
             ))
         );
     }
@@ -244,11 +243,11 @@ mod tests {
         // Read returns "-1" for ip_protocol, should be normalized to "all" via to_dsl
         let mut attributes =
             HashMap::from([("ip_protocol".to_string(), Value::String("-1".to_string()))]);
-        normalize_state_enums("ec2.security_group_ingress", &mut attributes);
+        normalize_state_enums("ec2.SecurityGroupIngress", &mut attributes);
         assert_eq!(
             attributes.get("ip_protocol"),
             Some(&Value::String(
-                "aws.ec2.security_group_ingress.IpProtocol.all".to_string()
+                "aws.ec2.SecurityGroupIngress.IpProtocol.all".to_string()
             ))
         );
     }
@@ -266,17 +265,17 @@ mod tests {
                 Value::String("BucketOwnerEnforced".to_string()),
             ),
         ]);
-        normalize_state_enums("s3.bucket", &mut attributes);
+        normalize_state_enums("s3.Bucket", &mut attributes);
         assert_eq!(
             attributes.get("versioning_status"),
             Some(&Value::String(
-                "aws.s3.bucket.VersioningStatus.Enabled".to_string()
+                "aws.s3.Bucket.VersioningStatus.Enabled".to_string()
             ))
         );
         assert_eq!(
             attributes.get("object_ownership"),
             Some(&Value::String(
-                "aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced".to_string()
+                "aws.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string()
             ))
         );
         // Non-enum attributes should not be modified
@@ -290,21 +289,21 @@ mod tests {
     fn test_normalize_state_enums_already_namespaced() {
         let mut attributes = HashMap::from([(
             "versioning_status".to_string(),
-            Value::String("aws.s3.bucket.VersioningStatus.Enabled".to_string()),
+            Value::String("aws.s3.Bucket.VersioningStatus.Enabled".to_string()),
         )]);
-        normalize_state_enums("s3.bucket", &mut attributes);
+        normalize_state_enums("s3.Bucket", &mut attributes);
         // Already namespaced values (contain dots) should not be modified
         assert_eq!(
             attributes.get("versioning_status"),
             Some(&Value::String(
-                "aws.s3.bucket.VersioningStatus.Enabled".to_string()
+                "aws.s3.Bucket.VersioningStatus.Enabled".to_string()
             ))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_ec2_vpc_instance_tenancy() {
-        let mut resource = Resource::with_provider("aws", "ec2.vpc", "test-vpc");
+        let mut resource = Resource::with_provider("aws", "ec2.Vpc", "test-vpc");
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::String("InstanceTenancy.dedicated".to_string()),
@@ -314,15 +313,14 @@ mod tests {
         assert_eq!(
             resources[0].get_attr("instance_tenancy"),
             Some(&Value::String(
-                "aws.ec2.vpc.InstanceTenancy.dedicated".to_string()
+                "aws.ec2.Vpc.InstanceTenancy.dedicated".to_string()
             ))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_ec2_security_group_ingress_protocol() {
-        let mut resource =
-            Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule");
+        let mut resource = Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule");
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::String("IpProtocol.tcp".to_string()),
@@ -332,7 +330,7 @@ mod tests {
         assert_eq!(
             resources[0].get_attr("ip_protocol"),
             Some(&Value::String(
-                "aws.ec2.security_group_ingress.IpProtocol.tcp".to_string()
+                "aws.ec2.SecurityGroupIngress.IpProtocol.tcp".to_string()
             ))
         );
     }
@@ -343,11 +341,11 @@ mod tests {
             "instance_tenancy".to_string(),
             Value::String("default".to_string()),
         )]);
-        normalize_state_enums("ec2.vpc", &mut attributes);
+        normalize_state_enums("ec2.Vpc", &mut attributes);
         assert_eq!(
             attributes.get("instance_tenancy"),
             Some(&Value::String(
-                "aws.ec2.vpc.InstanceTenancy.default".to_string()
+                "aws.ec2.Vpc.InstanceTenancy.default".to_string()
             ))
         );
     }
@@ -356,11 +354,11 @@ mod tests {
     fn test_normalize_state_enums_ec2_security_group_egress() {
         let mut attributes =
             HashMap::from([("ip_protocol".to_string(), Value::String("-1".to_string()))]);
-        normalize_state_enums("ec2.security_group_egress", &mut attributes);
+        normalize_state_enums("ec2.SecurityGroupEgress", &mut attributes);
         assert_eq!(
             attributes.get("ip_protocol"),
             Some(&Value::String(
-                "aws.ec2.security_group_egress.IpProtocol.all".to_string()
+                "aws.ec2.SecurityGroupEgress.IpProtocol.all".to_string()
             ))
         );
     }
@@ -380,12 +378,12 @@ mod tests {
             "private_dns_name_options_on_launch".to_string(),
             Value::Map(inner),
         )]);
-        normalize_state_enums("ec2.subnet", &mut attributes);
+        normalize_state_enums("ec2.Subnet", &mut attributes);
         if let Some(Value::Map(fields)) = attributes.get("private_dns_name_options_on_launch") {
             assert_eq!(
                 fields.get("hostname_type"),
                 Some(&Value::String(
-                    "aws.ec2.subnet.HostnameType.ip_name".to_string()
+                    "aws.ec2.Subnet.HostnameType.ip_name".to_string()
                 ))
             );
             // Non-enum fields should not be modified
@@ -402,11 +400,11 @@ mod tests {
     fn test_normalize_state_enums_ec2_security_group_egress_tcp() {
         let mut attributes =
             HashMap::from([("ip_protocol".to_string(), Value::String("tcp".to_string()))]);
-        normalize_state_enums("ec2.security_group_egress", &mut attributes);
+        normalize_state_enums("ec2.SecurityGroupEgress", &mut attributes);
         assert_eq!(
             attributes.get("ip_protocol"),
             Some(&Value::String(
-                "aws.ec2.security_group_egress.IpProtocol.tcp".to_string()
+                "aws.ec2.SecurityGroupEgress.IpProtocol.tcp".to_string()
             ))
         );
     }
@@ -417,11 +415,11 @@ mod tests {
         // The normalizer should recognize it as a valid enum value and namespace it.
         let mut attributes =
             HashMap::from([("type".to_string(), Value::String("ipsec.1".to_string()))]);
-        normalize_state_enums("ec2.vpn_gateway", &mut attributes);
+        normalize_state_enums("ec2.VpnGateway", &mut attributes);
         assert_eq!(
             attributes.get("type"),
             Some(&Value::String(
-                "aws.ec2.vpn_gateway.Type.ipsec.1".to_string()
+                "aws.ec2.VpnGateway.Type.ipsec.1".to_string()
             ))
         );
     }
@@ -431,13 +429,13 @@ mod tests {
         // Already in DSL format — should NOT be double-normalized.
         let mut attributes = HashMap::from([(
             "type".to_string(),
-            Value::String("aws.ec2.vpn_gateway.Type.ipsec.1".to_string()),
+            Value::String("aws.ec2.VpnGateway.Type.ipsec.1".to_string()),
         )]);
-        normalize_state_enums("ec2.vpn_gateway", &mut attributes);
+        normalize_state_enums("ec2.VpnGateway", &mut attributes);
         assert_eq!(
             attributes.get("type"),
             Some(&Value::String(
-                "aws.ec2.vpn_gateway.Type.ipsec.1".to_string()
+                "aws.ec2.VpnGateway.Type.ipsec.1".to_string()
             ))
         );
     }

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -20,71 +20,71 @@ impl Provider for AwsProvider {
         let identifier = identifier.map(String::from);
         Box::pin(async move {
             let mut state = match id.resource_type.as_str() {
-                "s3.bucket" => self.read_s3_bucket(&id, identifier.as_deref()).await,
-                "ec2.eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
-                "ec2.vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
-                "ec2.subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
-                "ec2.internet_gateway" => {
+                "s3.Bucket" => self.read_s3_bucket(&id, identifier.as_deref()).await,
+                "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
+                "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
+                "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
+                "ec2.InternetGateway" => {
                     self.read_ec2_internet_gateway(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.nat_gateway" => self.read_ec2_nat_gateway(&id, identifier.as_deref()).await,
-                "ec2.route_table" => self.read_ec2_route_table(&id, identifier.as_deref()).await,
-                "ec2.route" => self.read_ec2_route(&id, identifier.as_deref()).await,
-                "ec2.security_group" => {
+                "ec2.NatGateway" => self.read_ec2_nat_gateway(&id, identifier.as_deref()).await,
+                "ec2.RouteTable" => self.read_ec2_route_table(&id, identifier.as_deref()).await,
+                "ec2.Route" => self.read_ec2_route(&id, identifier.as_deref()).await,
+                "ec2.SecurityGroup" => {
                     self.read_ec2_security_group(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.security_group_ingress" => {
+                "ec2.SecurityGroupIngress" => {
                     self.read_ec2_security_group_ingress(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.security_group_egress" => {
+                "ec2.SecurityGroupEgress" => {
                     self.read_ec2_security_group_egress(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.subnet_route_table_association" => {
+                "ec2.SubnetRouteTableAssociation" => {
                     self.read_ec2_subnet_route_table_association(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.flow_log" => self.read_ec2_flow_log(&id, identifier.as_deref()).await,
-                "ec2.vpc_endpoint" => self.read_ec2_vpc_endpoint(&id, identifier.as_deref()).await,
-                "ec2.vpc_gateway_attachment" => {
+                "ec2.FlowLog" => self.read_ec2_flow_log(&id, identifier.as_deref()).await,
+                "ec2.VpcEndpoint" => self.read_ec2_vpc_endpoint(&id, identifier.as_deref()).await,
+                "ec2.VpcGatewayAttachment" => {
                     self.read_ec2_vpc_gateway_attachment(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.vpn_gateway" => self.read_ec2_vpn_gateway(&id, identifier.as_deref()).await,
-                "ec2.transit_gateway" => {
+                "ec2.VpnGateway" => self.read_ec2_vpn_gateway(&id, identifier.as_deref()).await,
+                "ec2.TransitGateway" => {
                     self.read_ec2_transit_gateway(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.transit_gateway_attachment" => {
+                "ec2.TransitGatewayAttachment" => {
                     self.read_ec2_transit_gateway_attachment(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.vpc_peering_connection" => {
+                "ec2.VpcPeeringConnection" => {
                     self.read_ec2_vpc_peering_connection(&id, identifier.as_deref())
                         .await
                 }
-                "ec2.egress_only_internet_gateway" => {
+                "ec2.EgressOnlyInternetGateway" => {
                     self.read_ec2_egress_only_internet_gateway(&id, identifier.as_deref())
                         .await
                 }
-                "organizations.account" => {
+                "organizations.Account" => {
                     self.read_organizations_account(&id, identifier.as_deref())
                         .await
                 }
-                "organizations.organization" => {
+                "organizations.Organization" => {
                     self.read_organizations_organization(&id, identifier.as_deref())
                         .await
                 }
-                "iam.role" => self.read_iam_role(&id, identifier.as_deref()).await,
-                "logs.log_group" => self.read_logs_log_group(&id, identifier.as_deref()).await,
-                "route53.record_set" => {
+                "iam.Role" => self.read_iam_role(&id, identifier.as_deref()).await,
+                "logs.LogGroup" => self.read_logs_log_group(&id, identifier.as_deref()).await,
+                "route53.RecordSet" => {
                     self.read_route53_record_set(&id, identifier.as_deref())
                         .await
                 }
-                "sts.caller_identity" => self.read_sts_caller_identity(&id).await,
+                "sts.CallerIdentity" => self.read_sts_caller_identity(&id).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
                     id.resource_type
@@ -105,7 +105,7 @@ impl Provider for AwsProvider {
         let resource = resource.clone();
         Box::pin(async move {
             let mut state = match resource.id.resource_type.as_str() {
-                "identitystore.user" => self.read_identitystore_user(&resource).await?,
+                "identitystore.User" => self.read_identitystore_user(&resource).await?,
                 _ => {
                     // Fallback for data sources this provider doesn't dispatch
                     // explicitly. Route zero-input cases (e.g. `sts.caller_identity`)
@@ -144,48 +144,46 @@ impl Provider for AwsProvider {
         let resource = resource.clone();
         Box::pin(async move {
             match resource.id.resource_type.as_str() {
-                "s3.bucket" => self.create_s3_bucket(resource).await,
-                "ec2.eip" => self.create_ec2_eip(resource).await,
-                "ec2.vpc" => self.create_ec2_vpc(resource).await,
-                "ec2.subnet" => self.create_ec2_subnet(resource).await,
-                "ec2.internet_gateway" => self.create_ec2_internet_gateway(resource).await,
-                "ec2.nat_gateway" => self.create_ec2_nat_gateway(resource).await,
-                "ec2.route_table" => self.create_ec2_route_table(resource).await,
-                "ec2.route" => self.create_ec2_route(resource).await,
-                "ec2.security_group" => self.create_ec2_security_group(resource).await,
-                "ec2.security_group_ingress" => {
+                "s3.Bucket" => self.create_s3_bucket(resource).await,
+                "ec2.Eip" => self.create_ec2_eip(resource).await,
+                "ec2.Vpc" => self.create_ec2_vpc(resource).await,
+                "ec2.Subnet" => self.create_ec2_subnet(resource).await,
+                "ec2.InternetGateway" => self.create_ec2_internet_gateway(resource).await,
+                "ec2.NatGateway" => self.create_ec2_nat_gateway(resource).await,
+                "ec2.RouteTable" => self.create_ec2_route_table(resource).await,
+                "ec2.Route" => self.create_ec2_route(resource).await,
+                "ec2.SecurityGroup" => self.create_ec2_security_group(resource).await,
+                "ec2.SecurityGroupIngress" => {
                     self.create_ec2_security_group_ingress(resource).await
                 }
-                "ec2.security_group_egress" => {
-                    self.create_ec2_security_group_egress(resource).await
-                }
-                "ec2.subnet_route_table_association" => {
+                "ec2.SecurityGroupEgress" => self.create_ec2_security_group_egress(resource).await,
+                "ec2.SubnetRouteTableAssociation" => {
                     self.create_ec2_subnet_route_table_association(resource)
                         .await
                 }
-                "ec2.flow_log" => self.create_ec2_flow_log(resource).await,
-                "ec2.vpc_endpoint" => self.create_ec2_vpc_endpoint(resource).await,
-                "ec2.vpc_gateway_attachment" => {
+                "ec2.FlowLog" => self.create_ec2_flow_log(resource).await,
+                "ec2.VpcEndpoint" => self.create_ec2_vpc_endpoint(resource).await,
+                "ec2.VpcGatewayAttachment" => {
                     self.create_ec2_vpc_gateway_attachment(resource).await
                 }
-                "ec2.vpn_gateway" => self.create_ec2_vpn_gateway(resource).await,
-                "ec2.transit_gateway" => self.create_ec2_transit_gateway(resource).await,
-                "ec2.transit_gateway_attachment" => {
+                "ec2.VpnGateway" => self.create_ec2_vpn_gateway(resource).await,
+                "ec2.TransitGateway" => self.create_ec2_transit_gateway(resource).await,
+                "ec2.TransitGatewayAttachment" => {
                     self.create_ec2_transit_gateway_attachment(resource).await
                 }
-                "ec2.vpc_peering_connection" => {
+                "ec2.VpcPeeringConnection" => {
                     self.create_ec2_vpc_peering_connection(resource).await
                 }
-                "ec2.egress_only_internet_gateway" => {
+                "ec2.EgressOnlyInternetGateway" => {
                     self.create_ec2_egress_only_internet_gateway(resource).await
                 }
-                "organizations.account" => self.create_organizations_account(resource).await,
-                "organizations.organization" => {
+                "organizations.Account" => self.create_organizations_account(resource).await,
+                "organizations.Organization" => {
                     self.create_organizations_organization(resource).await
                 }
-                "iam.role" => self.create_iam_role(resource).await,
-                "logs.log_group" => self.create_logs_log_group(resource).await,
-                "route53.record_set" => self.create_route53_record_set(resource).await,
+                "iam.Role" => self.create_iam_role(resource).await,
+                "logs.LogGroup" => self.create_logs_log_group(resource).await,
+                "route53.RecordSet" => self.create_route53_record_set(resource).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
                     resource.id.resource_type
@@ -208,80 +206,80 @@ impl Provider for AwsProvider {
         let to = to.clone();
         Box::pin(async move {
             match id.resource_type.as_str() {
-                "s3.bucket" => self.update_s3_bucket(id, &identifier, &from, to).await,
-                "ec2.eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
-                "ec2.vpc" => self.update_ec2_vpc(id, &identifier, &from, to).await,
-                "ec2.subnet" => self.update_ec2_subnet(id, &identifier, &from, to).await,
-                "ec2.internet_gateway" => {
+                "s3.Bucket" => self.update_s3_bucket(id, &identifier, &from, to).await,
+                "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
+                "ec2.Vpc" => self.update_ec2_vpc(id, &identifier, &from, to).await,
+                "ec2.Subnet" => self.update_ec2_subnet(id, &identifier, &from, to).await,
+                "ec2.InternetGateway" => {
                     self.update_ec2_internet_gateway(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.nat_gateway" => {
+                "ec2.NatGateway" => {
                     self.update_ec2_nat_gateway(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.route_table" => {
+                "ec2.RouteTable" => {
                     self.update_ec2_route_table(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.route" => self.update_ec2_route(id, &identifier, to).await,
-                "ec2.security_group" => {
+                "ec2.Route" => self.update_ec2_route(id, &identifier, to).await,
+                "ec2.SecurityGroup" => {
                     self.update_ec2_security_group(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.security_group_ingress" => {
+                "ec2.SecurityGroupIngress" => {
                     self.update_ec2_security_group_ingress(id, &identifier, to)
                         .await
                 }
-                "ec2.security_group_egress" => {
+                "ec2.SecurityGroupEgress" => {
                     self.update_ec2_security_group_egress(id, &identifier, to)
                         .await
                 }
-                "ec2.subnet_route_table_association" => {
+                "ec2.SubnetRouteTableAssociation" => {
                     self.update_ec2_subnet_route_table_association(id, &identifier, to)
                         .await
                 }
-                "ec2.flow_log" => self.update_ec2_flow_log(id, &identifier, &from, to).await,
-                "ec2.vpc_endpoint" => {
+                "ec2.FlowLog" => self.update_ec2_flow_log(id, &identifier, &from, to).await,
+                "ec2.VpcEndpoint" => {
                     self.update_ec2_vpc_endpoint(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.vpc_gateway_attachment" => {
+                "ec2.VpcGatewayAttachment" => {
                     self.update_ec2_vpc_gateway_attachment(id, &identifier)
                         .await
                 }
-                "ec2.vpn_gateway" => {
+                "ec2.VpnGateway" => {
                     self.update_ec2_vpn_gateway(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.transit_gateway" => {
+                "ec2.TransitGateway" => {
                     self.update_ec2_transit_gateway(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.transit_gateway_attachment" => {
+                "ec2.TransitGatewayAttachment" => {
                     self.update_ec2_transit_gateway_attachment(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.vpc_peering_connection" => {
+                "ec2.VpcPeeringConnection" => {
                     self.update_ec2_vpc_peering_connection(id, &identifier, &from, to)
                         .await
                 }
-                "ec2.egress_only_internet_gateway" => {
+                "ec2.EgressOnlyInternetGateway" => {
                     self.update_ec2_egress_only_internet_gateway(id, &identifier, &from, to)
                         .await
                 }
-                "organizations.account" => {
+                "organizations.Account" => {
                     self.update_organizations_account(id, &identifier, &from, to)
                         .await
                 }
-                "organizations.organization" => {
+                "organizations.Organization" => {
                     // All attributes are read-only or create-only; read back current state
                     self.read_organizations_organization(&id, Some(&identifier))
                         .await
                 }
-                "iam.role" => self.update_iam_role(id, &identifier, &from, to).await,
-                "logs.log_group" => self.update_logs_log_group(id, &identifier, &from, to).await,
-                "route53.record_set" => self.update_route53_record_set(id, &identifier, to).await,
+                "iam.Role" => self.update_iam_role(id, &identifier, &from, to).await,
+                "logs.LogGroup" => self.update_logs_log_group(id, &identifier, &from, to).await,
+                "route53.RecordSet" => self.update_route53_record_set(id, &identifier, to).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
                     id.resource_type
@@ -302,54 +300,54 @@ impl Provider for AwsProvider {
         let lifecycle = lifecycle.clone();
         Box::pin(async move {
             match id.resource_type.as_str() {
-                "s3.bucket" => self.delete_s3_bucket(id, &identifier, &lifecycle).await,
-                "ec2.eip" => self.delete_ec2_eip(id, &identifier).await,
-                "ec2.vpc" => self.delete_ec2_vpc(id, &identifier).await,
-                "ec2.subnet" => self.delete_ec2_subnet(id, &identifier).await,
-                "ec2.internet_gateway" => self.delete_ec2_internet_gateway(id, &identifier).await,
-                "ec2.nat_gateway" => self.delete_ec2_nat_gateway(id, &identifier).await,
-                "ec2.route_table" => self.delete_ec2_route_table(id, &identifier).await,
-                "ec2.route" => self.delete_ec2_route(id, &identifier).await,
-                "ec2.security_group" => self.delete_ec2_security_group(id, &identifier).await,
-                "ec2.security_group_ingress" => {
+                "s3.Bucket" => self.delete_s3_bucket(id, &identifier, &lifecycle).await,
+                "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,
+                "ec2.Vpc" => self.delete_ec2_vpc(id, &identifier).await,
+                "ec2.Subnet" => self.delete_ec2_subnet(id, &identifier).await,
+                "ec2.InternetGateway" => self.delete_ec2_internet_gateway(id, &identifier).await,
+                "ec2.NatGateway" => self.delete_ec2_nat_gateway(id, &identifier).await,
+                "ec2.RouteTable" => self.delete_ec2_route_table(id, &identifier).await,
+                "ec2.Route" => self.delete_ec2_route(id, &identifier).await,
+                "ec2.SecurityGroup" => self.delete_ec2_security_group(id, &identifier).await,
+                "ec2.SecurityGroupIngress" => {
                     self.delete_ec2_security_group_ingress(id, &identifier)
                         .await
                 }
-                "ec2.security_group_egress" => {
+                "ec2.SecurityGroupEgress" => {
                     self.delete_ec2_security_group_egress(id, &identifier).await
                 }
-                "ec2.subnet_route_table_association" => {
+                "ec2.SubnetRouteTableAssociation" => {
                     self.delete_ec2_subnet_route_table_association(id, &identifier)
                         .await
                 }
-                "ec2.flow_log" => self.delete_ec2_flow_log(id, &identifier).await,
-                "ec2.vpc_endpoint" => self.delete_ec2_vpc_endpoint(id, &identifier).await,
-                "ec2.vpc_gateway_attachment" => {
+                "ec2.FlowLog" => self.delete_ec2_flow_log(id, &identifier).await,
+                "ec2.VpcEndpoint" => self.delete_ec2_vpc_endpoint(id, &identifier).await,
+                "ec2.VpcGatewayAttachment" => {
                     self.delete_ec2_vpc_gateway_attachment(id, &identifier)
                         .await
                 }
-                "ec2.vpn_gateway" => self.delete_ec2_vpn_gateway(id, &identifier).await,
-                "ec2.transit_gateway" => self.delete_ec2_transit_gateway(id, &identifier).await,
-                "ec2.transit_gateway_attachment" => {
+                "ec2.VpnGateway" => self.delete_ec2_vpn_gateway(id, &identifier).await,
+                "ec2.TransitGateway" => self.delete_ec2_transit_gateway(id, &identifier).await,
+                "ec2.TransitGatewayAttachment" => {
                     self.delete_ec2_transit_gateway_attachment(id, &identifier)
                         .await
                 }
-                "ec2.vpc_peering_connection" => {
+                "ec2.VpcPeeringConnection" => {
                     self.delete_ec2_vpc_peering_connection(id, &identifier)
                         .await
                 }
-                "ec2.egress_only_internet_gateway" => {
+                "ec2.EgressOnlyInternetGateway" => {
                     self.delete_ec2_egress_only_internet_gateway(id, &identifier)
                         .await
                 }
-                "organizations.account" => self.delete_organizations_account(id, &identifier).await,
-                "organizations.organization" => {
+                "organizations.Account" => self.delete_organizations_account(id, &identifier).await,
+                "organizations.Organization" => {
                     self.delete_organizations_organization(id, &identifier)
                         .await
                 }
-                "iam.role" => self.delete_iam_role(id, &identifier).await,
-                "logs.log_group" => self.delete_logs_log_group(id, &identifier).await,
-                "route53.record_set" => self.delete_route53_record_set(id, &identifier).await,
+                "iam.Role" => self.delete_iam_role(id, &identifier).await,
+                "logs.LogGroup" => self.delete_logs_log_group(id, &identifier).await,
+                "route53.RecordSet" => self.delete_route53_record_set(id, &identifier).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
                     id.resource_type

--- a/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
@@ -1,4 +1,4 @@
-//! egress_only_internet_gateway schema definition for AWS Cloud Control
+//! EgressOnlyInternetGateway schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -9,13 +9,13 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
-/// Returns the schema config for ec2.egress_only_internet_gateway (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.EgressOnlyInternetGateway (Smithy: com.amazonaws.ec2)
 pub fn ec2_egress_only_internet_gateway_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::EgressOnlyInternetGateway",
-        resource_type_name: "ec2.egress_only_internet_gateway",
+        resource_type_name: "ec2.EgressOnlyInternetGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.egress_only_internet_gateway")
+        schema: ResourceSchema::new("aws.ec2.EgressOnlyInternetGateway")
             .with_description("Describes an egress-only internet gateway.")
             .attribute(
                 AttributeSchema::new("vpc_id", super::vpc_id())
@@ -48,7 +48,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.egress_only_internet_gateway", &[])
+    ("ec2.EgressOnlyInternetGateway", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/eip.rs
@@ -1,4 +1,4 @@
-//! eip schema definition for AWS Cloud Control
+//! Eip schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -11,13 +11,13 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types}
 
 const VALID_DOMAIN: &[&str] = &["standard", "vpc"];
 
-/// Returns the schema config for ec2.eip (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.Eip (Smithy: com.amazonaws.ec2)
 pub fn ec2_eip_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::EIP",
-        resource_type_name: "ec2.eip",
+        resource_type_name: "ec2.Eip",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.eip")
+        schema: ResourceSchema::new("aws.ec2.Eip")
         .with_description("Describes an Elastic IP address, or a carrier IP address.")
         .attribute(
             AttributeSchema::new("address", AttributeType::String)
@@ -29,7 +29,7 @@ pub fn ec2_eip_config() -> AwsSchemaConfig {
             AttributeSchema::new("domain", AttributeType::StringEnum {
                 name: "Domain".to_string(),
                 values: vec!["standard".to_string(), "vpc".to_string()],
-                namespace: Some("aws.ec2.eip".to_string()),
+                namespace: Some("aws.ec2.Eip".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -66,7 +66,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.eip", &[("domain", VALID_DOMAIN)])
+    ("ec2.Eip", &[("domain", VALID_DOMAIN)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -1,4 +1,4 @@
-//! flow_log schema definition for AWS Cloud Control
+//! FlowLog schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -22,13 +22,13 @@ const VALID_RESOURCE_TYPE: &[&str] = &[
 
 const VALID_TRAFFIC_TYPE: &[&str] = &["ACCEPT", "ALL", "REJECT"];
 
-/// Returns the schema config for ec2.flow_log (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.FlowLog (Smithy: com.amazonaws.ec2)
 pub fn ec2_flow_log_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::FlowLog",
-        resource_type_name: "ec2.flow_log",
+        resource_type_name: "ec2.FlowLog",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.flow_log")
+        schema: ResourceSchema::new("aws.ec2.FlowLog")
         .with_description("Describes a flow log.")
         .attribute(
             AttributeSchema::new("deliver_logs_permission_arn", super::iam_role_arn())
@@ -46,7 +46,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
             AttributeSchema::new("log_destination_type", AttributeType::StringEnum {
                 name: "LogDestinationType".to_string(),
                 values: vec!["cloud-watch-logs".to_string(), "kinesis-data-firehose".to_string(), "s3".to_string()],
-                namespace: Some("aws.ec2.flow_log".to_string()),
+                namespace: Some("aws.ec2.FlowLog".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .create_only()
@@ -82,7 +82,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
             AttributeSchema::new("resource_type", AttributeType::StringEnum {
                 name: "ResourceType".to_string(),
                 values: vec!["NetworkInterface".to_string(), "RegionalNatGateway".to_string(), "Subnet".to_string(), "TransitGateway".to_string(), "TransitGatewayAttachment".to_string(), "VPC".to_string()],
-                namespace: Some("aws.ec2.flow_log".to_string()),
+                namespace: Some("aws.ec2.FlowLog".to_string()),
                 to_dsl: None,
             })
                 .required()
@@ -94,7 +94,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
             AttributeSchema::new("traffic_type", AttributeType::StringEnum {
                 name: "TrafficType".to_string(),
                 values: vec!["ACCEPT".to_string(), "ALL".to_string(), "REJECT".to_string()],
-                namespace: Some("aws.ec2.flow_log".to_string()),
+                namespace: Some("aws.ec2.FlowLog".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -121,7 +121,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.flow_log",
+        "ec2.FlowLog",
         &[
             ("log_destination_type", VALID_LOG_DESTINATION_TYPE),
             ("resource_type", VALID_RESOURCE_TYPE),

--- a/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
@@ -1,4 +1,4 @@
-//! internet_gateway schema definition for AWS Cloud Control
+//! InternetGateway schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -9,13 +9,13 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
-/// Returns the schema config for ec2.internet_gateway (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.InternetGateway (Smithy: com.amazonaws.ec2)
 pub fn ec2_internet_gateway_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::InternetGateway",
-        resource_type_name: "ec2.internet_gateway",
+        resource_type_name: "ec2.InternetGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.internet_gateway")
+        schema: ResourceSchema::new("aws.ec2.InternetGateway")
             .with_description("Describes an internet gateway.")
             .attribute(
                 AttributeSchema::new("internet_gateway_id", super::internet_gateway_id())
@@ -36,7 +36,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.internet_gateway", &[])
+    ("ec2.InternetGateway", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
@@ -1,4 +1,4 @@
-//! nat_gateway schema definition for AWS Cloud Control
+//! NatGateway schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -13,13 +13,13 @@ const VALID_AVAILABILITY_MODE: &[&str] = &["regional", "zonal"];
 
 const VALID_CONNECTIVITY_TYPE: &[&str] = &["private", "public"];
 
-/// Returns the schema config for ec2.nat_gateway (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.NatGateway (Smithy: com.amazonaws.ec2)
 pub fn ec2_nat_gateway_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::NatGateway",
-        resource_type_name: "ec2.nat_gateway",
+        resource_type_name: "ec2.NatGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.nat_gateway")
+        schema: ResourceSchema::new("aws.ec2.NatGateway")
         .with_description("Describes a NAT gateway.")
         .attribute(
             AttributeSchema::new("allocation_id", super::allocation_id())
@@ -31,7 +31,7 @@ pub fn ec2_nat_gateway_config() -> AwsSchemaConfig {
             AttributeSchema::new("availability_mode", AttributeType::StringEnum {
                 name: "AvailabilityMode".to_string(),
                 values: vec!["regional".to_string(), "zonal".to_string()],
-                namespace: Some("aws.ec2.nat_gateway".to_string()),
+                namespace: Some("aws.ec2.NatGateway".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -55,7 +55,7 @@ pub fn ec2_nat_gateway_config() -> AwsSchemaConfig {
             AttributeSchema::new("connectivity_type", AttributeType::StringEnum {
                 name: "ConnectivityType".to_string(),
                 values: vec!["private".to_string(), "public".to_string()],
-                namespace: Some("aws.ec2.nat_gateway".to_string()),
+                namespace: Some("aws.ec2.NatGateway".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -101,7 +101,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.nat_gateway",
+        "ec2.NatGateway",
         &[
             ("availability_mode", VALID_AVAILABILITY_MODE),
             ("connectivity_type", VALID_CONNECTIVITY_TYPE),

--- a/carina-provider-aws/src/schemas/generated/ec2/route.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route.rs
@@ -1,4 +1,4 @@
-//! route schema definition for AWS Cloud Control
+//! Route schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -7,13 +7,13 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, ResourceSchema, types};
 
-/// Returns the schema config for ec2.route (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.Route (Smithy: com.amazonaws.ec2)
 pub fn ec2_route_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::Route",
-        resource_type_name: "ec2.route",
+        resource_type_name: "ec2.Route",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.route")
+        schema: ResourceSchema::new("aws.ec2.Route")
         .with_description("Describes a route in a route table.")
         .attribute(
             AttributeSchema::new("destination_cidr_block", types::ipv4_cidr())
@@ -46,7 +46,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.route", &[])
+    ("ec2.Route", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
@@ -1,4 +1,4 @@
-//! route_table schema definition for AWS Cloud Control
+//! RouteTable schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -9,13 +9,13 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
-/// Returns the schema config for ec2.route_table (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.RouteTable (Smithy: com.amazonaws.ec2)
 pub fn ec2_route_table_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::RouteTable",
-        resource_type_name: "ec2.route_table",
+        resource_type_name: "ec2.RouteTable",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.route_table")
+        schema: ResourceSchema::new("aws.ec2.RouteTable")
             .with_description("Describes a route table.")
             .attribute(
                 AttributeSchema::new("vpc_id", super::vpc_id())
@@ -43,7 +43,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.route_table", &[])
+    ("ec2.RouteTable", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
@@ -1,4 +1,4 @@
-//! security_group schema definition for AWS Cloud Control
+//! SecurityGroup schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -9,13 +9,13 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-/// Returns the schema config for ec2.security_group (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.SecurityGroup (Smithy: com.amazonaws.ec2)
 pub fn ec2_security_group_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroup",
-        resource_type_name: "ec2.security_group",
+        resource_type_name: "ec2.SecurityGroup",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.security_group")
+        schema: ResourceSchema::new("aws.ec2.SecurityGroup")
         .with_description("Describes a security group.")
         .attribute(
             AttributeSchema::new("description", AttributeType::String)
@@ -56,7 +56,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.security_group", &[])
+    ("ec2.SecurityGroup", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -1,4 +1,4 @@
-//! security_group_egress schema definition for AWS Cloud Control
+//! SecurityGroupEgress schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -34,13 +34,13 @@ fn validate_to_port_range(value: &Value) -> Result<(), String> {
     }
 }
 
-/// Returns the schema config for ec2.security_group_egress (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.SecurityGroupEgress (Smithy: com.amazonaws.ec2)
 pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupEgress",
-        resource_type_name: "ec2.security_group_egress",
+        resource_type_name: "ec2.SecurityGroupEgress",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.security_group_egress")
+        schema: ResourceSchema::new("aws.ec2.SecurityGroupEgress")
             .with_description("Describes a security group rule.")
             .attribute(
                 AttributeSchema::new("cidr_ip", types::ipv4_cidr())
@@ -103,7 +103,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                             "-1".to_string(),
                             "all".to_string(),
                         ],
-                        namespace: Some("aws.ec2.security_group_egress".to_string()),
+                        namespace: Some("aws.ec2.SecurityGroupEgress".to_string()),
                         to_dsl: Some(|s: &str| match s {
                             "-1" => "all".to_string(),
                             _ => s.replace('-', "_"),
@@ -164,7 +164,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.security_group_egress",
+        "ec2.SecurityGroupEgress",
         &[("ip_protocol", VALID_IP_PROTOCOL)],
     )
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -1,4 +1,4 @@
-//! security_group_ingress schema definition for AWS Cloud Control
+//! SecurityGroupIngress schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -34,13 +34,13 @@ fn validate_to_port_range(value: &Value) -> Result<(), String> {
     }
 }
 
-/// Returns the schema config for ec2.security_group_ingress (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.SecurityGroupIngress (Smithy: com.amazonaws.ec2)
 pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupIngress",
-        resource_type_name: "ec2.security_group_ingress",
+        resource_type_name: "ec2.SecurityGroupIngress",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.security_group_ingress")
+        schema: ResourceSchema::new("aws.ec2.SecurityGroupIngress")
         .with_description("Describes a security group rule.")
         .attribute(
             AttributeSchema::new("cidr_ip", types::ipv4_cidr())
@@ -90,7 +90,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
             AttributeSchema::new("ip_protocol", AttributeType::StringEnum {
                 name: "IpProtocol".to_string(),
                 values: vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string(), "all".to_string()],
-                namespace: Some("aws.ec2.security_group_ingress".to_string()),
+                namespace: Some("aws.ec2.SecurityGroupIngress".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
             })
                 .required()
@@ -150,7 +150,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.security_group_ingress",
+        "ec2.SecurityGroupIngress",
         &[("ip_protocol", VALID_IP_PROTOCOL)],
     )
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -1,4 +1,4 @@
-//! subnet schema definition for AWS Cloud Control
+//! Subnet schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -36,13 +36,13 @@ fn validate_ipv6_netmask_length_range(value: &Value) -> Result<(), String> {
     }
 }
 
-/// Returns the schema config for ec2.subnet (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.Subnet (Smithy: com.amazonaws.ec2)
 pub fn ec2_subnet_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::Subnet",
-        resource_type_name: "ec2.subnet",
+        resource_type_name: "ec2.Subnet",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.subnet")
+        schema: ResourceSchema::new("aws.ec2.Subnet")
         .with_description("Describes a subnet.")
         .attribute(
             AttributeSchema::new("assign_ipv6_address_on_creation", AttributeType::Bool)
@@ -149,7 +149,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                     StructField::new("hostname_type", AttributeType::StringEnum {
                 name: "HostnameType".to_string(),
                 values: vec!["ip-name".to_string(), "resource-name".to_string()],
-                namespace: Some("aws.ec2.subnet".to_string()),
+                namespace: Some("aws.ec2.Subnet".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             }).with_description("The type of hostname for EC2 instances. For IPv4 only subnets, an instance DNS name must be based on the instance IPv4 address. For IPv6 only subnets,...").with_provider_name("HostnameType")
                     ],
@@ -183,7 +183,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.subnet", &[("hostname_type", VALID_HOSTNAME_TYPE)])
+    ("ec2.Subnet", &[("hostname_type", VALID_HOSTNAME_TYPE)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet_route_table_association.rs
@@ -1,4 +1,4 @@
-//! subnet_route_table_association schema definition for AWS Cloud Control
+//! SubnetRouteTableAssociation schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -7,13 +7,13 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-/// Returns the schema config for ec2.subnet_route_table_association (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.SubnetRouteTableAssociation (Smithy: com.amazonaws.ec2)
 pub fn ec2_subnet_route_table_association_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SubnetRouteTableAssociation",
-        resource_type_name: "ec2.subnet_route_table_association",
+        resource_type_name: "ec2.SubnetRouteTableAssociation",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.subnet_route_table_association")
+        schema: ResourceSchema::new("aws.ec2.SubnetRouteTableAssociation")
         .with_description("Describes an association between a route table and a subnet or gateway.")
         .attribute(
             AttributeSchema::new("public_ipv4_pool", AttributeType::String)
@@ -43,7 +43,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.subnet_route_table_association", &[])
+    ("ec2.SubnetRouteTableAssociation", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
@@ -1,4 +1,4 @@
-//! transit_gateway schema definition for AWS Cloud Control
+//! TransitGateway schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -23,13 +23,13 @@ const VALID_SECURITY_GROUP_REFERENCING_SUPPORT: &[&str] = &["disable", "enable"]
 
 const VALID_VPN_ECMP_SUPPORT: &[&str] = &["disable", "enable"];
 
-/// Returns the schema config for ec2.transit_gateway (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.TransitGateway (Smithy: com.amazonaws.ec2)
 pub fn ec2_transit_gateway_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::TransitGateway",
-        resource_type_name: "ec2.transit_gateway",
+        resource_type_name: "ec2.TransitGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.transit_gateway")
+        schema: ResourceSchema::new("aws.ec2.TransitGateway")
         .with_description("Describes a transit gateway.")
         .attribute(
             AttributeSchema::new("description", AttributeType::String)
@@ -44,44 +44,44 @@ pub fn ec2_transit_gateway_config() -> AwsSchemaConfig {
                     StructField::new("auto_accept_shared_attachments", AttributeType::StringEnum {
                 name: "AutoAcceptSharedAttachments".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway".to_string()),
+                namespace: Some("aws.ec2.TransitGateway".to_string()),
                 to_dsl: None,
             }).with_description("Enable or disable automatic acceptance of attachment requests. Disabled by default.").with_provider_name("AutoAcceptSharedAttachments"),
                     StructField::new("default_route_table_association", AttributeType::StringEnum {
                 name: "DefaultRouteTableAssociation".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway".to_string()),
+                namespace: Some("aws.ec2.TransitGateway".to_string()),
                 to_dsl: None,
             }).with_description("Enable or disable automatic association with the default association route table. Enabled by default.").with_provider_name("DefaultRouteTableAssociation"),
                     StructField::new("default_route_table_propagation", AttributeType::StringEnum {
                 name: "DefaultRouteTablePropagation".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway".to_string()),
+                namespace: Some("aws.ec2.TransitGateway".to_string()),
                 to_dsl: None,
             }).with_description("Enable or disable automatic propagation of routes to the default propagation route table. Enabled by default.").with_provider_name("DefaultRouteTablePropagation"),
                     StructField::new("dns_support", AttributeType::StringEnum {
                 name: "DnsSupport".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway".to_string()),
+                namespace: Some("aws.ec2.TransitGateway".to_string()),
                 to_dsl: None,
             }).with_description("Enable or disable DNS support. Enabled by default.").with_provider_name("DnsSupport"),
                     StructField::new("multicast_support", AttributeType::StringEnum {
                 name: "MulticastSupport".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway".to_string()),
+                namespace: Some("aws.ec2.TransitGateway".to_string()),
                 to_dsl: None,
             }).with_description("Indicates whether multicast is enabled on the transit gateway").with_provider_name("MulticastSupport"),
                     StructField::new("security_group_referencing_support", AttributeType::StringEnum {
                 name: "SecurityGroupReferencingSupport".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway".to_string()),
+                namespace: Some("aws.ec2.TransitGateway".to_string()),
                 to_dsl: None,
             }).with_description("Enables you to reference a security group across VPCs attached to a transit gateway to simplify security group management. This option is disabled by ...").with_provider_name("SecurityGroupReferencingSupport"),
                     StructField::new("transit_gateway_cidr_blocks", AttributeType::list(types::ipv4_cidr())).with_description("One or more IPv4 or IPv6 CIDR blocks for the transit gateway. Must be a size /24 CIDR block or larger for IPv4, or a size /64 CIDR block or larger for...").with_provider_name("TransitGatewayCidrBlocks"),
                     StructField::new("vpn_ecmp_support", AttributeType::StringEnum {
                 name: "VpnEcmpSupport".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway".to_string()),
+                namespace: Some("aws.ec2.TransitGateway".to_string()),
                 to_dsl: None,
             }).with_description("Enable or disable Equal Cost Multipath Protocol support. Enabled by default.").with_provider_name("VpnEcmpSupport")
                     ],
@@ -110,7 +110,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.transit_gateway",
+        "ec2.TransitGateway",
         &[
             (
                 "auto_accept_shared_attachments",

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -1,4 +1,4 @@
-//! transit_gateway_attachment schema definition for AWS Cloud Control
+//! TransitGatewayAttachment schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -17,13 +17,13 @@ const VALID_IPV6_SUPPORT: &[&str] = &["disable", "enable"];
 
 const VALID_SECURITY_GROUP_REFERENCING_SUPPORT: &[&str] = &["disable", "enable"];
 
-/// Returns the schema config for ec2.transit_gateway_attachment (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.TransitGatewayAttachment (Smithy: com.amazonaws.ec2)
 pub fn ec2_transit_gateway_attachment_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::TransitGatewayAttachment",
-        resource_type_name: "ec2.transit_gateway_attachment",
+        resource_type_name: "ec2.TransitGatewayAttachment",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.transit_gateway_attachment")
+        schema: ResourceSchema::new("aws.ec2.TransitGatewayAttachment")
         .with_description("Describes a VPC attachment.")
         .attribute(
             AttributeSchema::new("options", AttributeType::Struct {
@@ -32,25 +32,25 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsSchemaConfig {
                     StructField::new("appliance_mode_support", AttributeType::StringEnum {
                 name: "ApplianceModeSupport".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway_attachment".to_string()),
+                namespace: Some("aws.ec2.TransitGatewayAttachment".to_string()),
                 to_dsl: None,
             }).with_description("Enable or disable support for appliance mode. If enabled, a traffic flow between a source and destination uses the same Availability Zone for the VPC ...").with_provider_name("ApplianceModeSupport"),
                     StructField::new("dns_support", AttributeType::StringEnum {
                 name: "DnsSupport".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway_attachment".to_string()),
+                namespace: Some("aws.ec2.TransitGatewayAttachment".to_string()),
                 to_dsl: None,
             }).with_description("Enable or disable DNS support. The default is enable.").with_provider_name("DnsSupport"),
                     StructField::new("ipv6_support", AttributeType::StringEnum {
                 name: "Ipv6Support".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway_attachment".to_string()),
+                namespace: Some("aws.ec2.TransitGatewayAttachment".to_string()),
                 to_dsl: None,
             }).with_description("Enable or disable IPv6 support. The default is disable.").with_provider_name("Ipv6Support"),
                     StructField::new("security_group_referencing_support", AttributeType::StringEnum {
                 name: "SecurityGroupReferencingSupport".to_string(),
                 values: vec!["disable".to_string(), "enable".to_string()],
-                namespace: Some("aws.ec2.transit_gateway_attachment".to_string()),
+                namespace: Some("aws.ec2.TransitGatewayAttachment".to_string()),
                 to_dsl: None,
             }).with_description("Enables you to reference a security group across VPCs attached to a transit gateway to simplify security group management. This option is set to enabl...").with_provider_name("SecurityGroupReferencingSupport")
                     ],
@@ -100,7 +100,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.transit_gateway_attachment",
+        "ec2.TransitGatewayAttachment",
         &[
             ("appliance_mode_support", VALID_APPLIANCE_MODE_SUPPORT),
             ("dns_support", VALID_DNS_SUPPORT),

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -1,4 +1,4 @@
-//! vpc schema definition for AWS Cloud Control
+//! Vpc schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -24,13 +24,13 @@ fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
     }
 }
 
-/// Returns the schema config for ec2.vpc (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.Vpc (Smithy: com.amazonaws.ec2)
 pub fn ec2_vpc_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPC",
-        resource_type_name: "ec2.vpc",
+        resource_type_name: "ec2.Vpc",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.vpc")
+        schema: ResourceSchema::new("aws.ec2.Vpc")
         .with_description("Describes a VPC.")
         .attribute(
             AttributeSchema::new("cidr_block", types::ipv4_cidr())
@@ -52,7 +52,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
             AttributeSchema::new("instance_tenancy", AttributeType::StringEnum {
                 name: "InstanceTenancy".to_string(),
                 values: vec!["dedicated".to_string(), "default".to_string(), "host".to_string()],
-                namespace: Some("aws.ec2.vpc".to_string()),
+                namespace: Some("aws.ec2.Vpc".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -98,7 +98,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.vpc", &[("instance_tenancy", VALID_INSTANCE_TENANCY)])
+    ("ec2.Vpc", &[("instance_tenancy", VALID_INSTANCE_TENANCY)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -1,4 +1,4 @@
-//! vpc_endpoint schema definition for AWS Cloud Control
+//! VpcEndpoint schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -17,13 +17,13 @@ const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
     "ServiceNetwork",
 ];
 
-/// Returns the schema config for ec2.vpc_endpoint (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.VpcEndpoint (Smithy: com.amazonaws.ec2)
 pub fn ec2_vpc_endpoint_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPCEndpoint",
-        resource_type_name: "ec2.vpc_endpoint",
+        resource_type_name: "ec2.VpcEndpoint",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.vpc_endpoint")
+        schema: ResourceSchema::new("aws.ec2.VpcEndpoint")
         .with_description("Describes a VPC endpoint.")
         .attribute(
             AttributeSchema::new("policy_document", AttributeType::String)
@@ -82,7 +82,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsSchemaConfig {
             AttributeSchema::new("vpc_endpoint_type", AttributeType::StringEnum {
                 name: "VpcEndpointType".to_string(),
                 values: vec!["Gateway".to_string(), "GatewayLoadBalancer".to_string(), "Interface".to_string(), "Resource".to_string(), "ServiceNetwork".to_string()],
-                namespace: Some("aws.ec2.vpc_endpoint".to_string()),
+                namespace: Some("aws.ec2.VpcEndpoint".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -116,7 +116,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.vpc_endpoint",
+        "ec2.VpcEndpoint",
         &[("vpc_endpoint_type", VALID_VPC_ENDPOINT_TYPE)],
     )
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_gateway_attachment.rs
@@ -1,4 +1,4 @@
-//! vpc_gateway_attachment schema definition for AWS Cloud Control
+//! VpcGatewayAttachment schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -7,13 +7,13 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
-/// Returns the schema config for ec2.vpc_gateway_attachment (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.VpcGatewayAttachment (Smithy: com.amazonaws.ec2)
 pub fn ec2_vpc_gateway_attachment_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPCGatewayAttachment",
-        resource_type_name: "ec2.vpc_gateway_attachment",
+        resource_type_name: "ec2.VpcGatewayAttachment",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.vpc_gateway_attachment")
+        schema: ResourceSchema::new("aws.ec2.VpcGatewayAttachment")
             .attribute(
                 AttributeSchema::new("internet_gateway_id", super::internet_gateway_id())
                     .required()
@@ -48,7 +48,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.vpc_gateway_attachment", &[])
+    ("ec2.VpcGatewayAttachment", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -1,4 +1,4 @@
-//! vpc_peering_connection schema definition for AWS Cloud Control
+//! VpcPeeringConnection schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -9,13 +9,13 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, ResourceSchema};
 
-/// Returns the schema config for ec2.vpc_peering_connection (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.VpcPeeringConnection (Smithy: com.amazonaws.ec2)
 pub fn ec2_vpc_peering_connection_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPCPeeringConnection",
-        resource_type_name: "ec2.vpc_peering_connection",
+        resource_type_name: "ec2.VpcPeeringConnection",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.vpc_peering_connection")
+        schema: ResourceSchema::new("aws.ec2.VpcPeeringConnection")
         .with_description("Describes a VPC peering connection.")
         .attribute(
             AttributeSchema::new("peer_owner_id", super::aws_account_id())
@@ -56,7 +56,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.vpc_peering_connection", &[])
+    ("ec2.VpcPeeringConnection", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
@@ -1,4 +1,4 @@
-//! vpn_gateway schema definition for AWS Cloud Control
+//! VpnGateway schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.ec2
 //!
@@ -11,13 +11,13 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_TYPE: &[&str] = &["ipsec.1"];
 
-/// Returns the schema config for ec2.vpn_gateway (Smithy: com.amazonaws.ec2)
+/// Returns the schema config for ec2.VpnGateway (Smithy: com.amazonaws.ec2)
 pub fn ec2_vpn_gateway_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPNGateway",
-        resource_type_name: "ec2.vpn_gateway",
+        resource_type_name: "ec2.VpnGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.vpn_gateway")
+        schema: ResourceSchema::new("aws.ec2.VpnGateway")
         .with_description("Describes a virtual private gateway.")
         .attribute(
             AttributeSchema::new("amazon_side_asn", AttributeType::Int)
@@ -35,7 +35,7 @@ pub fn ec2_vpn_gateway_config() -> AwsSchemaConfig {
             AttributeSchema::new("type", AttributeType::StringEnum {
                 name: "Type".to_string(),
                 values: vec!["ipsec.1".to_string()],
-                namespace: Some("aws.ec2.vpn_gateway".to_string()),
+                namespace: Some("aws.ec2.VpnGateway".to_string()),
                 to_dsl: None,
             })
                 .required()
@@ -62,7 +62,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.vpn_gateway", &[("type", VALID_TYPE)])
+    ("ec2.VpnGateway", &[("type", VALID_TYPE)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -1,4 +1,4 @@
-//! iam.role schema definition for AWS Cloud Control
+//! iam.Role schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.iam
 //!
@@ -22,13 +22,13 @@ fn validate_max_session_duration_range(value: &Value) -> Result<(), String> {
     }
 }
 
-/// Returns the schema config for iam.role (Smithy: com.amazonaws.iam)
+/// Returns the schema config for iam.Role (Smithy: com.amazonaws.iam)
 pub fn iam_role_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::IAM::Role",
-        resource_type_name: "iam.role",
+        resource_type_name: "iam.Role",
         has_tags: true,
-        schema: ResourceSchema::new("aws.iam.role")
+        schema: ResourceSchema::new("aws.iam.Role")
         .with_description("Contains information about an IAM role. This structure is returned as a response element in several API operations that interact with roles.")
         .attribute(
             AttributeSchema::new("assume_role_policy_document", super::iam_policy_document())
@@ -94,7 +94,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("iam.role", &[])
+    ("iam.Role", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/identitystore/user.rs
+++ b/carina-provider-aws/src/schemas/generated/identitystore/user.rs
@@ -1,4 +1,4 @@
-//! user schema definition for AWS Cloud Control
+//! User schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.identitystore
 //!
@@ -7,13 +7,13 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-/// Returns the schema config for identitystore.user (Smithy: com.amazonaws.identitystore)
+/// Returns the schema config for identitystore.User (Smithy: com.amazonaws.identitystore)
 pub fn identitystore_user_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::IdentityStore::User",
-        resource_type_name: "identitystore.user",
+        resource_type_name: "identitystore.User",
         has_tags: false,
-        schema: ResourceSchema::new("aws.identitystore.user")
+        schema: ResourceSchema::new("aws.identitystore.User")
             .as_data_source()
             .attribute(
                 AttributeSchema::new("identity_store_id", AttributeType::String)
@@ -51,7 +51,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("identitystore.user", &[])
+    ("identitystore.User", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-aws/src/schemas/generated/logs/log_group.rs
@@ -1,4 +1,4 @@
-//! logs.log_group schema definition for AWS Cloud Control
+//! logs.LogGroup schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.cloudwatchlogs
 //!
@@ -11,13 +11,13 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_LOG_GROUP_CLASS: &[&str] = &["DELIVERY", "INFREQUENT_ACCESS", "STANDARD"];
 
-/// Returns the schema config for logs.log_group (Smithy: com.amazonaws.cloudwatchlogs)
+/// Returns the schema config for logs.LogGroup (Smithy: com.amazonaws.cloudwatchlogs)
 pub fn logs_log_group_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::Logs::LogGroup",
-        resource_type_name: "logs.log_group",
+        resource_type_name: "logs.LogGroup",
         has_tags: true,
-        schema: ResourceSchema::new("aws.logs.log_group")
+        schema: ResourceSchema::new("aws.logs.LogGroup")
         .with_description("Represents a log group.")
         .attribute(
             AttributeSchema::new("deletion_protection_enabled", AttributeType::Bool)
@@ -35,7 +35,7 @@ pub fn logs_log_group_config() -> AwsSchemaConfig {
             AttributeSchema::new("log_group_class", AttributeType::StringEnum {
                 name: "logGroupClass".to_string(),
                 values: vec!["DELIVERY".to_string(), "INFREQUENT_ACCESS".to_string(), "STANDARD".to_string()],
-                namespace: Some("aws.logs.log_group".to_string()),
+                namespace: Some("aws.logs.LogGroup".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -70,7 +70,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "logs.log_group",
+        "logs.LogGroup",
         &[("log_group_class", VALID_LOG_GROUP_CLASS)],
     )
 }

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -107,85 +107,85 @@ pub fn get_enum_alias_reverse(
     attr_name: &str,
     value: &str,
 ) -> Option<&'static str> {
-    if resource_type == "ec2.egress_only_internet_gateway" {
+    if resource_type == "ec2.EgressOnlyInternetGateway" {
         return ec2::egress_only_internet_gateway::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.eip" {
+    if resource_type == "ec2.Eip" {
         return ec2::eip::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.flow_log" {
+    if resource_type == "ec2.FlowLog" {
         return ec2::flow_log::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.internet_gateway" {
+    if resource_type == "ec2.InternetGateway" {
         return ec2::internet_gateway::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.nat_gateway" {
+    if resource_type == "ec2.NatGateway" {
         return ec2::nat_gateway::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.route" {
+    if resource_type == "ec2.Route" {
         return ec2::route::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.route_table" {
+    if resource_type == "ec2.RouteTable" {
         return ec2::route_table::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.security_group" {
+    if resource_type == "ec2.SecurityGroup" {
         return ec2::security_group::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.security_group_egress" {
+    if resource_type == "ec2.SecurityGroupEgress" {
         return ec2::security_group_egress::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.security_group_ingress" {
+    if resource_type == "ec2.SecurityGroupIngress" {
         return ec2::security_group_ingress::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.subnet" {
+    if resource_type == "ec2.Subnet" {
         return ec2::subnet::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.subnet_route_table_association" {
+    if resource_type == "ec2.SubnetRouteTableAssociation" {
         return ec2::subnet_route_table_association::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.transit_gateway" {
+    if resource_type == "ec2.TransitGateway" {
         return ec2::transit_gateway::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.transit_gateway_attachment" {
+    if resource_type == "ec2.TransitGatewayAttachment" {
         return ec2::transit_gateway_attachment::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.vpc" {
+    if resource_type == "ec2.Vpc" {
         return ec2::vpc::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.vpc_endpoint" {
+    if resource_type == "ec2.VpcEndpoint" {
         return ec2::vpc_endpoint::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.vpc_gateway_attachment" {
+    if resource_type == "ec2.VpcGatewayAttachment" {
         return ec2::vpc_gateway_attachment::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.vpc_peering_connection" {
+    if resource_type == "ec2.VpcPeeringConnection" {
         return ec2::vpc_peering_connection::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "ec2.vpn_gateway" {
+    if resource_type == "ec2.VpnGateway" {
         return ec2::vpn_gateway::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "iam.role" {
+    if resource_type == "iam.Role" {
         return iam::role::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "identitystore.user" {
+    if resource_type == "identitystore.User" {
         return identitystore::user::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "logs.log_group" {
+    if resource_type == "logs.LogGroup" {
         return logs::log_group::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "organizations.account" {
+    if resource_type == "organizations.Account" {
         return organizations::account::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "organizations.organization" {
+    if resource_type == "organizations.Organization" {
         return organizations::organization::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "route53.record_set" {
+    if resource_type == "route53.RecordSet" {
         return route53::record_set::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "s3.bucket" {
+    if resource_type == "s3.Bucket" {
         return s3::bucket::enum_alias_reverse(attr_name, value);
     }
-    if resource_type == "sts.caller_identity" {
+    if resource_type == "sts.CallerIdentity" {
         return sts::caller_identity::enum_alias_reverse(attr_name, value);
     }
     None
@@ -200,189 +200,189 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
 > {
     let mut map = std::collections::HashMap::new();
     for (attr, alias, canonical) in ec2::egress_only_internet_gateway::enum_alias_entries() {
-        map.entry("ec2.egress_only_internet_gateway".to_string())
+        map.entry("ec2.EgressOnlyInternetGateway".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::eip::enum_alias_entries() {
-        map.entry("ec2.eip".to_string())
+        map.entry("ec2.Eip".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::flow_log::enum_alias_entries() {
-        map.entry("ec2.flow_log".to_string())
+        map.entry("ec2.FlowLog".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::internet_gateway::enum_alias_entries() {
-        map.entry("ec2.internet_gateway".to_string())
+        map.entry("ec2.InternetGateway".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::nat_gateway::enum_alias_entries() {
-        map.entry("ec2.nat_gateway".to_string())
+        map.entry("ec2.NatGateway".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::route::enum_alias_entries() {
-        map.entry("ec2.route".to_string())
+        map.entry("ec2.Route".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::route_table::enum_alias_entries() {
-        map.entry("ec2.route_table".to_string())
+        map.entry("ec2.RouteTable".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::security_group::enum_alias_entries() {
-        map.entry("ec2.security_group".to_string())
+        map.entry("ec2.SecurityGroup".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::security_group_egress::enum_alias_entries() {
-        map.entry("ec2.security_group_egress".to_string())
+        map.entry("ec2.SecurityGroupEgress".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::security_group_ingress::enum_alias_entries() {
-        map.entry("ec2.security_group_ingress".to_string())
+        map.entry("ec2.SecurityGroupIngress".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::subnet::enum_alias_entries() {
-        map.entry("ec2.subnet".to_string())
+        map.entry("ec2.Subnet".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::subnet_route_table_association::enum_alias_entries() {
-        map.entry("ec2.subnet_route_table_association".to_string())
+        map.entry("ec2.SubnetRouteTableAssociation".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::transit_gateway::enum_alias_entries() {
-        map.entry("ec2.transit_gateway".to_string())
+        map.entry("ec2.TransitGateway".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::transit_gateway_attachment::enum_alias_entries() {
-        map.entry("ec2.transit_gateway_attachment".to_string())
+        map.entry("ec2.TransitGatewayAttachment".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpc::enum_alias_entries() {
-        map.entry("ec2.vpc".to_string())
+        map.entry("ec2.Vpc".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpc_endpoint::enum_alias_entries() {
-        map.entry("ec2.vpc_endpoint".to_string())
+        map.entry("ec2.VpcEndpoint".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpc_gateway_attachment::enum_alias_entries() {
-        map.entry("ec2.vpc_gateway_attachment".to_string())
+        map.entry("ec2.VpcGatewayAttachment".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpc_peering_connection::enum_alias_entries() {
-        map.entry("ec2.vpc_peering_connection".to_string())
+        map.entry("ec2.VpcPeeringConnection".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpn_gateway::enum_alias_entries() {
-        map.entry("ec2.vpn_gateway".to_string())
+        map.entry("ec2.VpnGateway".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in iam::role::enum_alias_entries() {
-        map.entry("iam.role".to_string())
+        map.entry("iam.Role".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in identitystore::user::enum_alias_entries() {
-        map.entry("identitystore.user".to_string())
+        map.entry("identitystore.User".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in logs::log_group::enum_alias_entries() {
-        map.entry("logs.log_group".to_string())
+        map.entry("logs.LogGroup".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in organizations::account::enum_alias_entries() {
-        map.entry("organizations.account".to_string())
+        map.entry("organizations.Account".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in organizations::organization::enum_alias_entries() {
-        map.entry("organizations.organization".to_string())
+        map.entry("organizations.Organization".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in route53::record_set::enum_alias_entries() {
-        map.entry("route53.record_set".to_string())
+        map.entry("route53.RecordSet".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in s3::bucket::enum_alias_entries() {
-        map.entry("s3.bucket".to_string())
+        map.entry("s3.Bucket".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in sts::caller_identity::enum_alias_entries() {
-        map.entry("sts.caller_identity".to_string())
+        map.entry("sts.CallerIdentity".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -1,4 +1,4 @@
-//! organizations.account schema definition for AWS Cloud Control
+//! organizations.Account schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.organizations
 //!
@@ -15,13 +15,13 @@ const VALID_JOINED_METHOD: &[&str] = &["CREATED", "INVITED"];
 
 const VALID_STATUS: &[&str] = &["ACTIVE", "PENDING_CLOSURE", "SUSPENDED"];
 
-/// Returns the schema config for organizations.account (Smithy: com.amazonaws.organizations)
+/// Returns the schema config for organizations.Account (Smithy: com.amazonaws.organizations)
 pub fn organizations_account_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::Organizations::Account",
-        resource_type_name: "organizations.account",
+        resource_type_name: "organizations.Account",
         has_tags: true,
-        schema: ResourceSchema::new("aws.organizations.account")
+        schema: ResourceSchema::new("aws.organizations.Account")
         .with_description("Contains information about an Amazon Web Services account that is a member of an organization.")
         .attribute(
             AttributeSchema::new("account_name", AttributeType::String)
@@ -41,7 +41,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
             AttributeSchema::new("iam_user_access_to_billing", AttributeType::StringEnum {
                 name: "IamUserAccessToBilling".to_string(),
                 values: vec!["ALLOW".to_string(), "DENY".to_string()],
-                namespace: Some("aws.organizations.account".to_string()),
+                namespace: Some("aws.organizations.Account".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -68,7 +68,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
             AttributeSchema::new("joined_method", AttributeType::StringEnum {
                 name: "JoinedMethod".to_string(),
                 values: vec!["CREATED".to_string(), "INVITED".to_string()],
-                namespace: Some("aws.organizations.account".to_string()),
+                namespace: Some("aws.organizations.Account".to_string()),
                 to_dsl: None,
             })
                 .with_description("The method by which the account joined the organization. (read-only)")
@@ -88,7 +88,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
             AttributeSchema::new("status", AttributeType::StringEnum {
                 name: "Status".to_string(),
                 values: vec!["ACTIVE".to_string(), "PENDING_CLOSURE".to_string(), "SUSPENDED".to_string()],
-                namespace: Some("aws.organizations.account".to_string()),
+                namespace: Some("aws.organizations.Account".to_string()),
                 to_dsl: None,
             })
                 .with_description("The status of the account in the organization. The Status parameter in the Account object will be retired on September 9, 2026. Although both the acco... (read-only)")
@@ -109,7 +109,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "organizations.account",
+        "organizations.Account",
         &[
             (
                 "iam_user_access_to_billing",

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -1,4 +1,4 @@
-//! organizations.organization schema definition for AWS Cloud Control
+//! organizations.Organization schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.organizations
 //!
@@ -9,19 +9,19 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING"];
 
-/// Returns the schema config for organizations.organization (Smithy: com.amazonaws.organizations)
+/// Returns the schema config for organizations.Organization (Smithy: com.amazonaws.organizations)
 pub fn organizations_organization_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::Organizations::Organization",
-        resource_type_name: "organizations.organization",
+        resource_type_name: "organizations.Organization",
         has_tags: false,
-        schema: ResourceSchema::new("aws.organizations.organization")
+        schema: ResourceSchema::new("aws.organizations.Organization")
         .with_description("Contains details about an organization. An organization is a collection of accounts that are centrally managed together using consolidated billing, organized hierarchically with organizational units (...")
         .attribute(
             AttributeSchema::new("feature_set", AttributeType::StringEnum {
                 name: "FeatureSet".to_string(),
                 values: vec!["ALL".to_string(), "CONSOLIDATED_BILLING".to_string()],
-                namespace: Some("aws.organizations.organization".to_string()),
+                namespace: Some("aws.organizations.Organization".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -62,7 +62,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "organizations.organization",
+        "organizations.Organization",
         &[("feature_set", VALID_FEATURE_SET)],
     )
 }

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -1,4 +1,4 @@
-//! route53.record_set schema definition for AWS Cloud Control
+//! route53.RecordSet schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.route53
 //!
@@ -25,13 +25,13 @@ fn validate_ttl_range(value: &Value) -> Result<(), String> {
     }
 }
 
-/// Returns the schema config for route53.record_set (Smithy: com.amazonaws.route53)
+/// Returns the schema config for route53.RecordSet (Smithy: com.amazonaws.route53)
 pub fn route53_record_set_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::Route53::RecordSet",
-        resource_type_name: "route53.record_set",
+        resource_type_name: "route53.RecordSet",
         has_tags: false,
-        schema: ResourceSchema::new("aws.route53.record_set")
+        schema: ResourceSchema::new("aws.route53.RecordSet")
         .with_description("Information about the resource record set to create or delete.")
         .attribute(
             AttributeSchema::new("alias_target", AttributeType::Struct {
@@ -74,7 +74,7 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
             AttributeSchema::new("type", AttributeType::StringEnum {
                 name: "Type".to_string(),
                 values: vec!["A".to_string(), "AAAA".to_string(), "CAA".to_string(), "CNAME".to_string(), "DS".to_string(), "HTTPS".to_string(), "MX".to_string(), "NAPTR".to_string(), "NS".to_string(), "PTR".to_string(), "SOA".to_string(), "SPF".to_string(), "SRV".to_string(), "SSHFP".to_string(), "SVCB".to_string(), "TLSA".to_string(), "TXT".to_string()],
-                namespace: Some("aws.route53.record_set".to_string()),
+                namespace: Some("aws.route53.RecordSet".to_string()),
                 to_dsl: None,
             })
                 .required()
@@ -96,7 +96,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("route53.record_set", &[("type", VALID_TYPE)])
+    ("route53.RecordSet", &[("type", VALID_TYPE)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -1,4 +1,4 @@
-//! bucket schema definition for AWS Cloud Control
+//! Bucket schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.s3
 //!
@@ -26,18 +26,18 @@ const VALID_OBJECT_OWNERSHIP: &[&str] = &[
 
 const VALID_VERSIONING_STATUS: &[&str] = &["Enabled", "Suspended"];
 
-/// Returns the schema config for s3.bucket (Smithy: com.amazonaws.s3)
+/// Returns the schema config for s3.Bucket (Smithy: com.amazonaws.s3)
 pub fn s3_bucket_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::S3::Bucket",
-        resource_type_name: "s3.bucket",
+        resource_type_name: "s3.Bucket",
         has_tags: true,
-        schema: ResourceSchema::new("aws.s3.bucket")
+        schema: ResourceSchema::new("aws.s3.Bucket")
         .attribute(
             AttributeSchema::new("acl", AttributeType::StringEnum {
                 name: "ACL".to_string(),
                 values: vec!["authenticated-read".to_string(), "private".to_string(), "public-read".to_string(), "public-read-write".to_string()],
-                namespace: Some("aws.s3.bucket".to_string()),
+                namespace: Some("aws.s3.Bucket".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .with_description("The canned ACL to apply to the bucket. This functionality is not supported for directory buckets.")
@@ -54,7 +54,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
             AttributeSchema::new("bucket_namespace", AttributeType::StringEnum {
                 name: "BucketNamespace".to_string(),
                 values: vec!["account-regional".to_string(), "global".to_string()],
-                namespace: Some("aws.s3.bucket".to_string()),
+                namespace: Some("aws.s3.Bucket".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .create_only()
@@ -96,7 +96,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
             AttributeSchema::new("object_ownership", AttributeType::StringEnum {
                 name: "ObjectOwnership".to_string(),
                 values: vec!["BucketOwnerEnforced".to_string(), "BucketOwnerPreferred".to_string(), "ObjectWriter".to_string()],
-                namespace: Some("aws.s3.bucket".to_string()),
+                namespace: Some("aws.s3.Bucket".to_string()),
                 to_dsl: None,
             })
                 .with_provider_name("ObjectOwnership"),
@@ -105,7 +105,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
             AttributeSchema::new("versioning_status", AttributeType::StringEnum {
                 name: "VersioningStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Suspended".to_string()],
-                namespace: Some("aws.s3.bucket".to_string()),
+                namespace: Some("aws.s3.Bucket".to_string()),
                 to_dsl: None,
             })
                 .with_description("The versioning state of the bucket.")
@@ -126,7 +126,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "s3.bucket",
+        "s3.Bucket",
         &[
             ("acl", VALID_ACL),
             ("bucket_namespace", VALID_BUCKET_NAMESPACE),

--- a/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
+++ b/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
@@ -1,4 +1,4 @@
-//! caller_identity schema definition for AWS Cloud Control
+//! CallerIdentity schema definition for AWS Cloud Control
 //!
 //! Auto-generated from Smithy model: com.amazonaws.sts
 //!
@@ -7,13 +7,13 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-/// Returns the schema config for sts.caller_identity (Smithy: com.amazonaws.sts)
+/// Returns the schema config for sts.CallerIdentity (Smithy: com.amazonaws.sts)
 pub fn sts_caller_identity_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
         aws_type_name: "AWS::STS::CallerIdentity",
-        resource_type_name: "sts.caller_identity",
+        resource_type_name: "sts.CallerIdentity",
         has_tags: false,
-        schema: ResourceSchema::new("aws.sts.caller_identity")
+        schema: ResourceSchema::new("aws.sts.CallerIdentity")
         .as_data_source()
         .attribute(
             AttributeSchema::new("account_id", super::aws_account_id())
@@ -38,7 +38,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("sts.caller_identity", &[])
+    ("sts.CallerIdentity", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-aws/src/services/identitystore/user.rs
+++ b/carina-provider-aws/src/services/identitystore/user.rs
@@ -1,4 +1,4 @@
-//! Data source read for `aws.identitystore.user`.
+//! Data source read for `aws.identitystore.User`.
 //!
 //! Looks a user up by `user_name` (via `GetUserId` → `DescribeUser`) or by
 //! `user_id` (via `DescribeUser` directly). One of the two must be set.

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -554,16 +554,16 @@ fn test_subnet_hostname_type_dsl_to_aws_sdk() {
     use aws_sdk_ec2::types::HostnameType;
     use carina_core::utils::convert_enum_value;
 
-    // DSL uses underscores: aws.ec2.subnet.HostnameType.ip_name
+    // DSL uses underscores: aws.ec2.Subnet.HostnameType.ip_name
     // convert_enum_value extracts the value, then underscore→hyphen for AWS SDK
-    let dsl_value = "aws.ec2.subnet.HostnameType.ip_name";
+    let dsl_value = "aws.ec2.Subnet.HostnameType.ip_name";
     let extracted = convert_enum_value(dsl_value);
     assert_eq!(extracted, "ip_name");
     let aws_value = extracted.replace('_', "-");
     let hostname_type = HostnameType::from(aws_value.as_str());
     assert_eq!(hostname_type, HostnameType::IpName);
 
-    let dsl_value2 = "aws.ec2.subnet.HostnameType.resource_name";
+    let dsl_value2 = "aws.ec2.Subnet.HostnameType.resource_name";
     let extracted2 = convert_enum_value(dsl_value2);
     assert_eq!(extracted2, "resource_name");
     let aws_value2 = extracted2.replace('_', "-");
@@ -573,7 +573,7 @@ fn test_subnet_hostname_type_dsl_to_aws_sdk() {
 
 // --- Subnet modify_subnet_attributes: DNS options must be separate API calls ---
 // The AWS ModifySubnetAttribute API only allows modifying one attribute at a time.
-// See: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySubnetAttribute.html
+// See: https://docs.aws.amazon.Com/AWSEC2/latest/APIReference/API_ModifySubnetAttribute.html
 // "You can only modify one attribute at a time."
 // This test verifies that private_dns_name_options_on_launch fields are parsed
 // correctly for separate API calls.
@@ -586,7 +586,7 @@ fn test_subnet_dns_options_fields_parsed_separately() {
     let mut fields = HashMap::new();
     fields.insert(
         "hostname_type".to_string(),
-        Value::String("aws.ec2.subnet.HostnameType.ip_name".to_string()),
+        Value::String("aws.ec2.Subnet.HostnameType.ip_name".to_string()),
     );
     fields.insert(
         "enable_resource_name_dns_a_record".to_string(),

--- a/examples/ec2_internet_gateway/main.crn
+++ b/examples/ec2_internet_gateway/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.internet_gateway {
+aws.ec2.InternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/examples/ec2_route/main.crn
+++ b/examples/ec2_route/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let igw = aws.ec2.internet_gateway {
+let igw = aws.ec2.InternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -22,7 +22,7 @@ let igw = aws.ec2.internet_gateway {
   }
 }
 
-let rt = aws.ec2.route_table {
+let rt = aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -30,7 +30,7 @@ let rt = aws.ec2.route_table {
   }
 }
 
-aws.ec2.route {
+aws.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw.internet_gateway_id

--- a/examples/ec2_route_table/main.crn
+++ b/examples/ec2_route_table/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.route_table {
+aws.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/examples/ec2_security_group/main.crn
+++ b/examples/ec2_security_group/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.security_group {
+aws.ec2.SecurityGroup {
   group_name  = 'carina-example-sg'
   description = 'Example security group'
   vpc_id      = vpc.vpc_id

--- a/examples/ec2_security_group_egress/main.crn
+++ b/examples/ec2_security_group_egress/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-example-sg-egress'
   description = 'SG for egress rule example'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_egress {
+aws.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow HTTPS outbound'
   ip_protocol = tcp

--- a/examples/ec2_security_group_ingress/main.crn
+++ b/examples/ec2_security_group_ingress/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+let sg = aws.ec2.SecurityGroup {
   group_name  = 'carina-example-sg-ingress'
   description = 'SG for ingress rule example'
   vpc_id      = vpc.vpc_id
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-aws.ec2.security_group_ingress {
+aws.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = tcp

--- a/examples/ec2_subnet/main.crn
+++ b/examples/ec2_subnet/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+let vpc = aws.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-aws.ec2.subnet {
+aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a

--- a/examples/ec2_vpc/main.crn
+++ b/examples/ec2_vpc/main.crn
@@ -6,11 +6,11 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.vpc {
+aws.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
-  instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
+  instance_tenancy     = aws.ec2.Vpc.InstanceTenancy.default
 
   tags = {
     Environment = 'example'

--- a/examples/s3_bucket/main.crn
+++ b/examples/s3_bucket/main.crn
@@ -6,10 +6,10 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.s3.bucket {
+aws.s3.Bucket {
   bucket = 'carina-example-s3-bucket'
 
-  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
+  versioning_status = aws.s3.Bucket.VersioningStatus.Enabled
 
   tags = {
     Environment = 'example'

--- a/examples/sts_caller_identity/main.crn
+++ b/examples/sts_caller_identity/main.crn
@@ -7,4 +7,4 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let _ = read aws.sts.caller_identity {}
+let _ = read aws.sts.CallerIdentity {}

--- a/generated-docs/aws/iam/role.md
+++ b/generated-docs/aws/iam/role.md
@@ -1,5 +1,5 @@
 ---
-title: "aws.iam.role"
+title: "aws.iam.Role"
 description: "AWS IAM role resource reference"
 ---
 

--- a/generated-docs/aws/identitystore/user.md
+++ b/generated-docs/aws/identitystore/user.md
@@ -1,5 +1,5 @@
 ---
-title: "aws.identitystore.user"
+title: "aws.identitystore.User"
 description: "AWS IDENTITYSTORE user resource reference"
 ---
 

--- a/generated-docs/aws/logs/log_group.md
+++ b/generated-docs/aws/logs/log_group.md
@@ -1,5 +1,5 @@
 ---
-title: "aws.logs.log_group"
+title: "aws.logs.LogGroup"
 description: "AWS LOGS log_group resource reference"
 ---
 
@@ -58,9 +58,9 @@ The tags for the resource.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `DELIVERY` | `aws.logs.log_group.logGroupClass.DELIVERY` |
-| `INFREQUENT_ACCESS` | `aws.logs.log_group.logGroupClass.INFREQUENT_ACCESS` |
-| `STANDARD` | `aws.logs.log_group.logGroupClass.STANDARD` |
+| `DELIVERY` | `aws.logs.LogGroup.logGroupClass.DELIVERY` |
+| `INFREQUENT_ACCESS` | `aws.logs.LogGroup.logGroupClass.INFREQUENT_ACCESS` |
+| `STANDARD` | `aws.logs.LogGroup.logGroupClass.STANDARD` |
 
 Shorthand formats: `DELIVERY` or `logGroupClass.DELIVERY`
 

--- a/generated-docs/aws/route53/record_set.md
+++ b/generated-docs/aws/route53/record_set.md
@@ -1,5 +1,5 @@
 ---
-title: "aws.route53.record_set"
+title: "aws.route53.RecordSet"
 description: "AWS ROUTE53 record_set resource reference"
 ---
 
@@ -58,23 +58,23 @@ The ID of the hosted zone that contains this record set.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `A` | `aws.route53.record_set.Type.A` |
-| `AAAA` | `aws.route53.record_set.Type.AAAA` |
-| `CAA` | `aws.route53.record_set.Type.CAA` |
-| `CNAME` | `aws.route53.record_set.Type.CNAME` |
-| `DS` | `aws.route53.record_set.Type.DS` |
-| `HTTPS` | `aws.route53.record_set.Type.HTTPS` |
-| `MX` | `aws.route53.record_set.Type.MX` |
-| `NAPTR` | `aws.route53.record_set.Type.NAPTR` |
-| `NS` | `aws.route53.record_set.Type.NS` |
-| `PTR` | `aws.route53.record_set.Type.PTR` |
-| `SOA` | `aws.route53.record_set.Type.SOA` |
-| `SPF` | `aws.route53.record_set.Type.SPF` |
-| `SRV` | `aws.route53.record_set.Type.SRV` |
-| `SSHFP` | `aws.route53.record_set.Type.SSHFP` |
-| `SVCB` | `aws.route53.record_set.Type.SVCB` |
-| `TLSA` | `aws.route53.record_set.Type.TLSA` |
-| `TXT` | `aws.route53.record_set.Type.TXT` |
+| `A` | `aws.route53.RecordSet.Type.A` |
+| `AAAA` | `aws.route53.RecordSet.Type.AAAA` |
+| `CAA` | `aws.route53.RecordSet.Type.CAA` |
+| `CNAME` | `aws.route53.RecordSet.Type.CNAME` |
+| `DS` | `aws.route53.RecordSet.Type.DS` |
+| `HTTPS` | `aws.route53.RecordSet.Type.HTTPS` |
+| `MX` | `aws.route53.RecordSet.Type.MX` |
+| `NAPTR` | `aws.route53.RecordSet.Type.NAPTR` |
+| `NS` | `aws.route53.RecordSet.Type.NS` |
+| `PTR` | `aws.route53.RecordSet.Type.PTR` |
+| `SOA` | `aws.route53.RecordSet.Type.SOA` |
+| `SPF` | `aws.route53.RecordSet.Type.SPF` |
+| `SRV` | `aws.route53.RecordSet.Type.SRV` |
+| `SSHFP` | `aws.route53.RecordSet.Type.SSHFP` |
+| `SVCB` | `aws.route53.RecordSet.Type.SVCB` |
+| `TLSA` | `aws.route53.RecordSet.Type.TLSA` |
+| `TXT` | `aws.route53.RecordSet.Type.TXT` |
 
 Shorthand formats: `A` or `Type.A`
 

--- a/generated-docs/aws/sts/caller_identity.md
+++ b/generated-docs/aws/sts/caller_identity.md
@@ -1,5 +1,5 @@
 ---
-title: "aws.sts.caller_identity"
+title: "aws.sts.CallerIdentity"
 description: "AWS STS caller_identity resource reference"
 ---
 


### PR DESCRIPTION
Closes #139. Refs carina-rs/carina#2143.

Phase A of the naming-conventions migration for \`carina-provider-aws\`. Resource kinds now emit as \`aws.<service>.<TypeName>\` (three-segment paths, final segment PascalCase).

## Changes

- \`carina-codegen-aws/src/resource_defs.rs\`: every \`ResourceDef::name\` / \`DataSourceDef::name\` value PascalCased (e.g. \`\"ec2.vpc\"\` → \`\"ec2.Vpc\"\`).
- \`carina-codegen-aws/src/main.rs\`: new \`pascal_to_snake\` / \`split_service_resource_snake\` helpers; \`module_name()\` now snake-cases the resource segment for Rust module paths; \`cf_type_name()\` keys updated to PascalCase; orphan scanner compares in the snake domain and reports orphans in the new DSL form; \`res.name.replace('.', \"_\")\` call sites routed through \`module_name()\`.
- \`carina-provider-aws/src/schemas/generated/**\` regenerated via \`generate-schemas-smithy.sh\`.
- \`generated-docs/**\` regenerated via \`generate-docs.sh\`.
- \`carina-provider-aws/src/provider.rs\`: \`create\` / \`read\` / \`update\` / \`delete\` dispatch match arms switched to the new PascalCase spellings.
- \`carina-provider-aws/src/{normalizer,convert,helpers,tests,main,services/*}.rs\`: namespaced enum identifiers and test expectations updated (e.g. \`aws.ec2.vpc.InstanceTenancy.default\` → \`aws.ec2.Vpc.InstanceTenancy.default\`).
- \`acceptance-tests/**/*.crn\` (66 files) and \`examples/**/*.crn\` (10 files) rewritten to the new spellings; primitive type annotations (\`: string\` → \`: String\`, etc.) migrated in the same pass.

## Out of scope

\`provider_generated.rs\` is intentionally left untouched. It contains no resource-kind string literals, and the diff that \`generate-provider.sh\` produces against \`main\` is a pre-existing drift between the checked-in hand-edited file and the current codegen template — orthogonal to naming-conventions and tracked separately.

## Verification

- \`cargo build\` — green
- \`cargo test\` — 288 passed, 0 failed
- \`cargo clippy --all-targets -- -D warnings\` — clean
- \`cargo fmt --check\` — clean
- Regenerated schemas and generated-docs carry the new spellings
- \`module_name(\"ec2.Vpc\")\` → \`\"ec2_vpc\"\`; snake-case file names, Rust module paths, and delete method identifiers all preserved

## Test plan

- [x] \`cargo test\` workspace-wide green
- [x] Acceptance-test \`.crn\` files use the new spellings exclusively
- [x] Generated \`resource_type_name:\` literals in \`src/schemas/generated/**\` use the new spellings
- [x] Dispatch table in \`provider.rs\` matches the new spellings