### PR TITLE
acceptance-tests: run carina init before apply/plan/destroy

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -742,6 +742,15 @@ if [ "$COMMAND" = "full" ]; then
                 rm -f "$INJECTED_FILE"
                 TEST_INDEX=$((TEST_INDEX + 1))
 
+                # Initialize backend lock and install providers before apply
+                if ! INIT_OUTPUT=$("$CARINA_BIN" init "$CURRENT_STATE_DIR" 2>&1); then
+                    echo "FAIL (init) $REL_PATH"
+                    echo "  ERROR: $INIT_OUTPUT"
+                    FAILED=$((FAILED + 1))
+                    CURRENT_STATE_DIR=""
+                    continue
+                fi
+
                 # Apply (run from state dir so each test has its own state file)
                 echo "RUNNING apply $REL_PATH"
                 APPLY_OUTPUT=$(cd "$CURRENT_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" apply --auto-approve "$CURRENT_STATE_DIR" 2>&1)
@@ -895,6 +904,14 @@ for TEST_FILE in "${TESTS[@]}"; do
         rm -f "$INJECTED_FILE"
         TEST_INDEX=$((TEST_INDEX + 1))
         TARGET_PATH="$STATE_DIR"
+
+        # Initialize backend lock and install providers before the stateful command
+        if ! INIT_OUTPUT=$("$CARINA_BIN" init "$STATE_DIR" 2>&1); then
+            echo "FAIL (init)"
+            ERRORS+=("$REL_PATH: $INIT_OUTPUT")
+            FAILED=$((FAILED + 1))
+            continue
+        fi
     else
         # For validate, create a temp directory with the injected file
         VALIDATE_DIR=$(mktemp -d)


### PR DESCRIPTION
## Summary

- Call `carina init` on each per-test state directory before `apply`/`plan`/`destroy`
- Mirrors the fix in [carina-rs/carina-provider-awscc#153](https://github.com/carina-rs/carina-provider-awscc/pull/153)

## Why

Every acceptance test failed with:

```
Error: Backend lock file not found. Run 'carina init' to initialize the project.
```

Upstream carina commit [`1004ecf1`](https://github.com/carina-rs/carina/commit/1004ecf1) moved backend-lock creation out of `apply`/`destroy` into `carina init`. The runner injects `source`/`version` into provider blocks but never ran `carina init`, so the backend lock and `.carina/providers/` never existed when apply started.

## Test plan

- [x] `./acceptance-tests/run-tests.sh full s3_bucket/basic` — 1 passed, 0 failed (previously: failed with backend-lock error)
- [ ] Full cycle across all tests (will run after merge / as part of usual cadence)

Closes #141