### PR TITLE
logs.LogGroup: add retention_in_days attribute to schema

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -543,9 +543,6 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         .iter()
         .map(|e| (e.name, e.description))
         .collect();
-    // Set of field names that are from extra_writable (always create-only)
-    let extra_writable_names: HashSet<&str> = res.extra_writable.iter().map(|e| e.name).collect();
-
     // Build attribute list
     let mut attrs: Vec<AttrInfo> = Vec::new();
 
@@ -556,10 +553,20 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             || required_overrides.contains(name.as_str()))
             && !read_only_overrides.contains(name.as_str());
         let is_read_only = read_only_overrides.contains(name.as_str());
+        // `extra_writable` fields with `read_source = None` are synthetic:
+        // the codegen has no Smithy member to ground them in, so it has to
+        // assume create-only. Fields with `read_source = Some(...)` come
+        // from a real read-structure member and follow the normal rules —
+        // whether they're updatable is decided by `create_only_overrides`
+        // and `update_ops`, the same as any other writable field.
+        let is_synthetic_extra_writable = res
+            .extra_writable
+            .iter()
+            .any(|e| e.name == name.as_str() && e.read_source.is_none());
         let is_create_only = if is_read_only {
             false
-        } else if extra_writable_names.contains(name.as_str()) {
-            true // Extra writable fields are always create-only
+        } else if is_synthetic_extra_writable {
+            true
         } else if schema_structure.is_some() {
             // For schema_structure resources, only explicit overrides are create-only.
             // The default is writable since the update operation is hand-coded.

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1085,7 +1085,12 @@ pub fn logs_resources() -> Vec<ResourceDef> {
         read_structure: Some("LogGroup"),
         read_ops: vec![],
         delete_op: "DeleteLogGroup",
-        update_ops: vec![],
+        // PutRetentionPolicy is the real update path for retention_in_days.
+        // Listing it here lets the codegen mark the attribute as updatable.
+        update_ops: vec![UpdateOp {
+            operation: "PutRetentionPolicy",
+            fields: FieldLayout::Flat(vec!["retentionInDays"]),
+        }],
         identifier: "LogGroupName",
         has_tags: true,
         type_overrides: vec![("KmsKeyId", "super::kms_key_id()"), ("Arn", "super::arn()")],
@@ -1101,7 +1106,13 @@ pub fn logs_resources() -> Vec<ResourceDef> {
         required_overrides: vec![],
         extra_read_only: vec!["Arn"],
         read_only_overrides: vec![],
-        extra_writable: vec![],
+        extra_writable: vec![ExtraField {
+            name: "retentionInDays",
+            read_source: Some("retentionInDays"),
+            description: Some(
+                "The number of days to retain the log events in the log group. If unset, events never expire. The provider applies changes via PutRetentionPolicy / DeleteRetentionPolicy.",
+            ),
+        }],
         identity_overrides: vec![],
     }]
 }

--- a/carina-provider-aws/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-aws/src/schemas/generated/logs/log_group.rs
@@ -50,6 +50,11 @@ pub fn logs_log_group_config() -> AwsSchemaConfig {
                 .with_provider_name("logGroupName"),
         )
         .attribute(
+            AttributeSchema::new("retention_in_days", AttributeType::Int)
+                .with_description("The number of days to retain the log events in the log group. If unset, events never expire. The provider applies changes via PutRetentionPolicy / Del...")
+                .with_provider_name("retentionInDays"),
+        )
+        .attribute(
             AttributeSchema::new("tags", AttributeType::map(AttributeType::String))
                 .create_only()
                 .with_description("The key-value pairs to use for the tags. You can grant users access to certain log groups while preventing them from accessing other log groups. To do...")


### PR DESCRIPTION
## Summary

- Every fixture that set `retention_in_days` on `aws.logs.LogGroup` was failing with `Unknown attribute 'retention_in_days'` at schema validation.
- The service code (`services/logs/log_group.rs`) already fully handles retention on both create (`PutRetentionPolicy`) and update (`PutRetentionPolicy` / `DeleteRetentionPolicy`), and reads the value back from the `LogGroup` describe response. The schema just never exposed the attribute because `retentionInDays` is not part of `CreateLogGroup`'s Smithy input.
- Wire the attribute through the existing `ExtraField` mechanism with `read_source = Some("retentionInDays")` so the type resolves against the read structure (Int), and add `PutRetentionPolicy` to `update_ops` so the codegen classifies the attribute as updatable.
- Teach the codegen that `ExtraField` entries with `read_source = Some(...)` should follow the normal create-only rules — only synthetic extras (`read_source = None`) stay forced create-only. This is the mechanism that lets `retention_in_days` be updatable, and is narrow enough not to affect existing synthetic extras (e.g., the IGW `VpcId` added in #149 still stays create-only).

## Affected tests (previously failing, now passing locally)

- `logs_log_group/basic`
- `ec2_flow_log/basic` (fixture creates a helper log group with `retention_in_days = 1`)

## Test plan

- [x] `./scripts/generate-schemas-smithy.sh` regenerates cleanly (schema now exposes `retention_in_days`, not create-only)
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` succeeds
- [x] `./acceptance-tests/run-tests.sh full logs_log_group/basic` → 1 passed, 0 failed
- [ ] Full suite will run via the usual `run-acceptance-tests` cadence

Closes #145
