### PR TITLE
ec2.FlowLog: use resource_ids list in fixture, create, and read paths

### DIFF
--- a/acceptance-tests/ec2_flow_log/basic.crn
+++ b/acceptance-tests/ec2_flow_log/basic.crn
@@ -46,7 +46,7 @@ let flow_log_role = aws.iam.Role {
 }
 
 aws.ec2.FlowLog {
-  resource_id                 = vpc.vpc_id
+  resource_ids                = [vpc.vpc_id]
   resource_type               = aws.ec2.FlowLog.ResourceType.VPC
   traffic_type                = aws.ec2.FlowLog.TrafficType.ALL
   log_destination_type        = aws.ec2.FlowLog.LogDestinationType.cloud_watch_logs

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{build_tag_specification, require_string_attr, sdk_error_message};
+use crate::helpers::{build_tag_specification, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 Flow Log
@@ -41,6 +41,18 @@ impl AwsProvider {
 
             let identifier_value = Self::extract_ec2_flow_log_attributes(fl, &mut attributes);
 
+            // Convert the SDK's singular `resource_id` back into the schema's
+            // `resource_ids` list. AWS's CreateFlowLogs input takes a list; the
+            // describe response exposes one resource_id per FlowLog entity. The
+            // generated extractor inserts the singular key, so replace it here
+            // with a one-element list matching the schema.
+            if let Some(Value::String(rid)) = attributes.remove("resource_id") {
+                attributes.insert(
+                    "resource_ids".to_string(),
+                    Value::List(vec![Value::String(rid)]),
+                );
+            }
+
             // Extract user-defined tags
             if let Some(tags_value) = Self::ec2_tags_to_value(fl.tags()) {
                 attributes.insert("tags".to_string(), tags_value);
@@ -59,7 +71,25 @@ impl AwsProvider {
 
     /// Create an EC2 Flow Log
     pub(crate) async fn create_ec2_flow_log(&self, resource: Resource) -> ProviderResult<State> {
-        let resource_id_val = require_string_attr(&resource, "resource_id")?;
+        let resource_ids_val: Vec<String> = match resource.get_attr("resource_ids") {
+            Some(Value::List(items)) => items
+                .iter()
+                .filter_map(|v| {
+                    if let Value::String(s) = v {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
+        if resource_ids_val.is_empty() {
+            return Err(ProviderError::new(
+                "resource_ids must be a non-empty list of resource identifiers",
+            )
+            .for_resource(resource.id.clone()));
+        }
 
         let resource_type_val = match resource.get_attr("resource_type") {
             Some(Value::String(s)) => extract_enum_value(s).to_string(),
@@ -72,7 +102,7 @@ impl AwsProvider {
         let mut req = self
             .ec2_client
             .create_flow_logs()
-            .resource_ids(&resource_id_val)
+            .set_resource_ids(Some(resource_ids_val.clone()))
             .resource_type(aws_sdk_ec2::types::FlowLogsResourceType::from(
                 resource_type_val.as_str(),
             ));


### PR DESCRIPTION
## Summary

The `aws.ec2.FlowLog` schema exposes `resource_ids: list<String>` (mirroring the AWS `CreateFlowLogs` input), but the `basic.crn` fixture and the service code were still written against the scalar `resource_id` shape. After #150 unblocked apply on this fixture, the mismatch surfaced:

- Fixture: `Unknown attribute 'resource_id', did you mean 'resource_ids'?`
- Service (after fixing the fixture): `resource_id is required` raised from `create_ec2_flow_log`.
- And silently: the generated read-path extractor inserts the SDK's singular `resource_id` — which would break `plan-verify` idempotency against the list-shaped schema attribute.

## Fix

1. **Fixture** (`acceptance-tests/ec2_flow_log/basic.crn`): switch to `resource_ids = [vpc.vpc_id]`.
2. **Service create** (`services/ec2/flow_log.rs`): read the list from the resource attributes and forward via `.set_resource_ids(Some(...))`. Reject empty lists.
3. **Service read** (`services/ec2/flow_log.rs`): after the generated extractor runs, take the singular `resource_id` key it produced and rewrite it as a one-element `resource_ids` list so state matches schema.

## Test plan

- [x] `./acceptance-tests/run-tests.sh full ec2_flow_log/basic` → 1 passed, 0 failed (previously: `Unknown attribute 'resource_id'`, then `resource_id is required`, then plan-verify drift)
- [ ] Full suite will run via the usual `run-acceptance-tests` cadence

Closes #151
