### PR TITLE
acceptance-tests: update awscc cross-provider fixtures to Strategy Y casing

### DIFF
--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -39,11 +39,11 @@ let subnet = aws.ec2.Subnet {
   }
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-let nat_gw = awscc.ec2.nat_gateway {
+let nat_gw = awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = subnet.subnet_id
 }

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -39,11 +39,11 @@ let subnet = aws.ec2.Subnet {
   }
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = subnet.subnet_id
 }

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -39,11 +39,11 @@ let subnet = aws.ec2.Subnet {
   }
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-let nat_gw = awscc.ec2.nat_gateway {
+let nat_gw = awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = subnet.subnet_id
 }


### PR DESCRIPTION
## Summary

[carina-rs/carina-provider-awscc#140](https://github.com/carina-rs/carina-provider-awscc/pull/140) migrated awscc resource names to PascalCase (Strategy Y):

- `awscc.ec2.eip` → `awscc.ec2.Eip`
- `awscc.ec2.nat_gateway` → `awscc.ec2.NatGateway`

Three fixtures in this repo cross into awscc to stand up EIP + NAT Gateway (because the aws provider doesn't yet own those resources) and still used the old snake_case forms. They failed with:

```
Error: Unknown resource type: awscc.ec2.eip
Error: Unknown resource type: awscc.ec2.nat_gateway
```

## Updated fixtures

- `acceptance-tests/ec2_route/nat_gateway.crn`
- `acceptance-tests/in_place_update/ec2_route_step1.crn`
- `acceptance-tests/in_place_update/ec2_route_step2.crn`

## Test plan

- [x] `_TEST_AWSCC_WASM=/path/to/awscc.wasm ./acceptance-tests/run-tests.sh full ec2_route/nat_gateway` → 1 passed, 0 failed (previously: unknown resource type errors)
- [ ] `in_place_update/run.sh` to be exercised via the usual `run-acceptance-tests` cadence once the runner-level issues are sorted

Closes #152
