### PR TITLE
acceptance-tests: use AWS_PROFILE + sso-session instead of aws-vault

### DIFF
--- a/acceptance-tests/in_place_update/run.sh
+++ b/acceptance-tests/in_place_update/run.sh
@@ -2,7 +2,7 @@
 # Multi-step acceptance tests for in-place updates
 #
 # Usage:
-#   aws-vault exec <profile> -- ./run.sh [filter]
+#   env AWS_PROFILE="<profile>" ./run.sh [filter]
 #
 # Tests:
 #   ec2_vpc            - Toggle enable_dns_hostnames (false -> true)
@@ -14,6 +14,14 @@
 #   s3_bucket_acl      - ACL/object_ownership transition
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
+#
+# AWS authentication:
+#   Set AWS_PROFILE to one of the carina-test-00X profiles. The script
+#   resolves fresh STS credentials from that profile before each carina
+#   invocation (via `aws configure export-credentials`), so long-running
+#   apply/destroy cycles are not bound to a single SSO access-token
+#   lifetime (see carina-rs/carina-provider-awscc#157). The first run
+#   in a session needs `aws sso login --sso-session carina`.
 
 set -e
 
@@ -26,6 +34,28 @@ source "$SCRIPT_DIR/../shared/_helpers.sh"
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
+# ── with_account_creds: resolve credentials for $AWS_PROFILE into env vars ──
+# and exec the given command. See run-tests.sh for rationale.
+with_account_creds() {
+    local account="${AWS_PROFILE:-}"
+    if [ -z "$account" ]; then
+        echo "ERROR: AWS_PROFILE is not set; cannot resolve credentials" >&2
+        return 1
+    fi
+    local creds
+    if ! creds=$(aws configure export-credentials --profile "$account" --format env-no-export 2>&1); then
+        echo "ERROR: aws configure export-credentials failed for $account: $creds" >&2
+        return 1
+    fi
+    (
+        set -a
+        eval "$creds"
+        set +a
+        unset AWS_PROFILE
+        "$@"
+    )
+}
+
 # Track active work dir for signal cleanup
 ACTIVE_WORK_DIR=""
 ACTIVE_STEP1=""
@@ -36,10 +66,10 @@ signal_cleanup() {
         set +e
         echo ""
         echo "Interrupted. Cleaning up resources..."
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
+        cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
+        cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
         rm -rf "$ACTIVE_WORK_DIR"
         ACTIVE_WORK_DIR=""
     fi
@@ -58,7 +88,7 @@ run_step() {
     printf "  %-55s " "$description"
 
     local output
-    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
+    if output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
         echo "OK"
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
         return 0
@@ -131,7 +161,7 @@ run_plan_verify() {
 
     local output
     local rc
-    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
+    output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
     rc=${rc:-0}
 
     if [ $rc -eq 2 ]; then
@@ -163,17 +193,17 @@ cleanup() {
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    if cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    if cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
         any_success=true
     fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    if cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    if cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
         any_success=true
     fi
     set -e

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -10,16 +10,25 @@
 #
 # Commands:
 #   validate   - Validate .crn files (default, no AWS credentials needed)
-#   plan       - Run plan on .crn files (single account, needs aws-vault)
-#   apply      - Apply .crn files (single account, needs aws-vault)
+#   plan       - Run plan on .crn files (single account, needs AWS credentials)
+#   apply      - Apply .crn files (single account, needs AWS credentials)
 #   destroy    - Destroy resources created by .crn files (single account)
 #   full       - Run apply+plan-verify+destroy per test, accounts in parallel
 #   cleanup    - Run destroy across accounts in parallel (recover from stuck state)
 #   deep-cleanup - Scan and remove orphaned AWS resources across accounts
 #
+# AWS authentication:
+#   The runner selects credentials via AWS_PROFILE rather than wrapping in
+#   aws-vault. Each carina-test-00X profile shares a single sso-session
+#   (`carina`), so the AWS SDK can refresh the SSO access token on its own
+#   during long-running operations (see carina-rs/carina-provider-awscc#157).
+#
+#   Before the first run in a session, log in once:
+#     aws sso login --sso-session carina
+#
 # For validate, no AWS credentials are needed.
-# For plan/apply/destroy, wrap with: aws-vault exec <profile> -- ./run-tests.sh ...
-# For full, aws-vault is called internally per account (carina-test-000..009).
+# For plan/apply/destroy, wrap with: with_account_creds "<profile>" ./run-tests.sh ...
+# For full, AWS_PROFILE is set internally per account (carina-test-000..009).
 #
 # Filter (optional):
 #   One or more substrings to match against test paths.
@@ -194,6 +203,33 @@ case "$COMMAND" in
         ;;
 esac
 
+# ── with_account_creds: resolve the profile's credentials into env vars ──
+# and exec the given command. Uses `aws configure export-credentials` so the
+# resulting AWS_ACCESS_KEY_ID / AWS_SESSION_TOKEN are fresh STS creds derived
+# from the sso-session; the SSO access token in ~/.aws/sso/cache is refreshed
+# automatically when it is close to expiring. Resolving creds before each
+# carina invocation means every test starts with a new STS session, so a
+# single long-running apply/destroy is not limited by the SSO access-token
+# lifetime (see carina-rs/carina-provider-awscc#157).
+#
+# Usage: with_account_creds <account> <cmd> [args...]
+with_account_creds() {
+    local account="$1"
+    shift
+    local creds
+    if ! creds=$(aws configure export-credentials --profile "$account" --format env-no-export 2>&1); then
+        echo "ERROR: aws configure export-credentials failed for $account: $creds" >&2
+        return 1
+    fi
+    (
+        set -a
+        eval "$creds"
+        set +a
+        unset AWS_PROFILE
+        "$@"
+    )
+}
+
 # ── deep_cleanup_account: scan AWS for orphaned resources ────────────
 # Args: account_profile (e.g., "carina-test-000")
 deep_cleanup_account() {
@@ -202,7 +238,7 @@ deep_cleanup_account() {
 
     # 1. Delete non-default VPCs and all dependencies
     local vpcs
-    vpcs=$(aws-vault exec "$account" -- aws ec2 describe-vpcs \
+    vpcs=$(with_account_creds "$account" aws ec2 describe-vpcs \
         --filters "Name=isDefault,Values=false" \
         --query 'Vpcs[*].VpcId' --output text 2>/dev/null)
 
@@ -213,12 +249,12 @@ deep_cleanup_account() {
 
         # Delete NAT Gateways (must be first, takes time)
         local nat_gws
-        nat_gws=$(aws-vault exec "$account" -- aws ec2 describe-nat-gateways \
+        nat_gws=$(with_account_creds "$account" aws ec2 describe-nat-gateways \
             --filter "Name=vpc-id,Values=$vpc_id" "Name=state,Values=available,pending" \
             --query 'NatGateways[*].NatGatewayId' --output text 2>/dev/null)
         for nat_id in $nat_gws; do
             [ -z "$nat_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 delete-nat-gateway --nat-gateway-id "$nat_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-nat-gateway --nat-gateway-id "$nat_id" 2>/dev/null || true
         done
         # Wait for NAT GWs to delete if any were found
         if [ -n "$nat_gws" ] && [ "$nat_gws" != "None" ]; then
@@ -227,94 +263,94 @@ deep_cleanup_account() {
 
         # Delete VPC endpoints
         local endpoints
-        endpoints=$(aws-vault exec "$account" -- aws ec2 describe-vpc-endpoints \
+        endpoints=$(with_account_creds "$account" aws ec2 describe-vpc-endpoints \
             --filters "Name=vpc-id,Values=$vpc_id" \
             --query 'VpcEndpoints[*].VpcEndpointId' --output text 2>/dev/null)
         for ep_id in $endpoints; do
             [ -z "$ep_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 delete-vpc-endpoints --vpc-endpoint-ids "$ep_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-vpc-endpoints --vpc-endpoint-ids "$ep_id" 2>/dev/null || true
         done
 
         # Detach and delete internet gateways
         local igws
-        igws=$(aws-vault exec "$account" -- aws ec2 describe-internet-gateways \
+        igws=$(with_account_creds "$account" aws ec2 describe-internet-gateways \
             --filters "Name=attachment.vpc-id,Values=$vpc_id" \
             --query 'InternetGateways[*].InternetGatewayId' --output text 2>/dev/null)
         for igw_id in $igws; do
             [ -z "$igw_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 detach-internet-gateway --internet-gateway-id "$igw_id" --vpc-id "$vpc_id" 2>/dev/null || true
-            aws-vault exec "$account" -- aws ec2 delete-internet-gateway --internet-gateway-id "$igw_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 detach-internet-gateway --internet-gateway-id "$igw_id" --vpc-id "$vpc_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-internet-gateway --internet-gateway-id "$igw_id" 2>/dev/null || true
         done
 
         # Detach and delete VPN gateways
         local vpn_gws
-        vpn_gws=$(aws-vault exec "$account" -- aws ec2 describe-vpn-gateways \
+        vpn_gws=$(with_account_creds "$account" aws ec2 describe-vpn-gateways \
             --filters "Name=attachment.vpc-id,Values=$vpc_id" \
             --query 'VpnGateways[*].VpnGatewayId' --output text 2>/dev/null)
         for vpn_id in $vpn_gws; do
             [ -z "$vpn_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 detach-vpn-gateway --vpn-gateway-id "$vpn_id" --vpc-id "$vpc_id" 2>/dev/null || true
-            aws-vault exec "$account" -- aws ec2 delete-vpn-gateway --vpn-gateway-id "$vpn_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 detach-vpn-gateway --vpn-gateway-id "$vpn_id" --vpc-id "$vpc_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-vpn-gateway --vpn-gateway-id "$vpn_id" 2>/dev/null || true
         done
 
         # Delete subnets
         local subnets
-        subnets=$(aws-vault exec "$account" -- aws ec2 describe-subnets \
+        subnets=$(with_account_creds "$account" aws ec2 describe-subnets \
             --filters "Name=vpc-id,Values=$vpc_id" \
             --query 'Subnets[*].SubnetId' --output text 2>/dev/null)
         for subnet_id in $subnets; do
             [ -z "$subnet_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 delete-subnet --subnet-id "$subnet_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-subnet --subnet-id "$subnet_id" 2>/dev/null || true
         done
 
         # Delete non-main route tables
         local rts
-        rts=$(aws-vault exec "$account" -- aws ec2 describe-route-tables \
+        rts=$(with_account_creds "$account" aws ec2 describe-route-tables \
             --filters "Name=vpc-id,Values=$vpc_id" \
             --query 'RouteTables[?Associations[0].Main!=`true`].RouteTableId' --output text 2>/dev/null)
         for rt_id in $rts; do
             [ -z "$rt_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 delete-route-table --route-table-id "$rt_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-route-table --route-table-id "$rt_id" 2>/dev/null || true
         done
 
         # Delete non-default security groups
         local sgs
-        sgs=$(aws-vault exec "$account" -- aws ec2 describe-security-groups \
+        sgs=$(with_account_creds "$account" aws ec2 describe-security-groups \
             --filters "Name=vpc-id,Values=$vpc_id" \
             --query 'SecurityGroups[?GroupName!=`default`].GroupId' --output text 2>/dev/null)
         for sg_id in $sgs; do
             [ -z "$sg_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 delete-security-group --group-id "$sg_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-security-group --group-id "$sg_id" 2>/dev/null || true
         done
 
         # Delete VPC peering connections
         local peerings
-        peerings=$(aws-vault exec "$account" -- aws ec2 describe-vpc-peering-connections \
+        peerings=$(with_account_creds "$account" aws ec2 describe-vpc-peering-connections \
             --filters "Name=requester-vpc-info.vpc-id,Values=$vpc_id" \
             --query 'VpcPeeringConnections[*].VpcPeeringConnectionId' --output text 2>/dev/null)
         for peer_id in $peerings; do
             [ -z "$peer_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 delete-vpc-peering-connection --vpc-peering-connection-id "$peer_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-vpc-peering-connection --vpc-peering-connection-id "$peer_id" 2>/dev/null || true
         done
 
         # Finally delete the VPC
-        aws-vault exec "$account" -- aws ec2 delete-vpc --vpc-id "$vpc_id" 2>/dev/null || true
+        with_account_creds "$account" aws ec2 delete-vpc --vpc-id "$vpc_id" 2>/dev/null || true
     done
 
     # 2. Delete orphaned S3 buckets matching carina-acc-test*
     local buckets
-    buckets=$(aws-vault exec "$account" -- aws s3api list-buckets \
+    buckets=$(with_account_creds "$account" aws s3api list-buckets \
         --query 'Buckets[?starts_with(Name, `carina-acc-test`)].Name' --output text 2>/dev/null)
     for bucket in $buckets; do
         [ -z "$bucket" ] && continue
         found=$((found + 1))
         echo "  Cleaning S3 bucket $bucket..."
-        aws-vault exec "$account" -- aws s3 rb "s3://$bucket" --force 2>/dev/null || true
+        with_account_creds "$account" aws s3 rb "s3://$bucket" --force 2>/dev/null || true
     done
 
     # 3. Delete orphaned IAM roles
     local roles
-    roles=$(aws-vault exec "$account" -- aws iam list-roles \
+    roles=$(with_account_creds "$account" aws iam list-roles \
         --query 'Roles[?contains(RoleName, `acceptance-test`) || contains(RoleName, `carina-acc`)].RoleName' --output text 2>/dev/null)
     for role in $roles; do
         [ -z "$role" ] && continue
@@ -322,30 +358,30 @@ deep_cleanup_account() {
         echo "  Cleaning IAM role $role..."
         # Detach all policies first
         local policies
-        policies=$(aws-vault exec "$account" -- aws iam list-attached-role-policies --role-name "$role" \
+        policies=$(with_account_creds "$account" aws iam list-attached-role-policies --role-name "$role" \
             --query 'AttachedPolicies[*].PolicyArn' --output text 2>/dev/null)
         for policy_arn in $policies; do
             [ -z "$policy_arn" ] && continue
-            aws-vault exec "$account" -- aws iam detach-role-policy --role-name "$role" --policy-arn "$policy_arn" 2>/dev/null || true
+            with_account_creds "$account" aws iam detach-role-policy --role-name "$role" --policy-arn "$policy_arn" 2>/dev/null || true
         done
-        aws-vault exec "$account" -- aws iam delete-role --role-name "$role" 2>/dev/null || true
+        with_account_creds "$account" aws iam delete-role --role-name "$role" 2>/dev/null || true
     done
 
     # 4. Delete orphaned log groups
     local log_groups
-    log_groups=$(aws-vault exec "$account" -- aws logs describe-log-groups \
+    log_groups=$(with_account_creds "$account" aws logs describe-log-groups \
         --log-group-name-prefix "/acceptance-test/" \
         --query 'logGroups[*].logGroupName' --output text 2>/dev/null)
     for lg in $log_groups; do
         [ -z "$lg" ] && continue
         found=$((found + 1))
         echo "  Cleaning log group $lg..."
-        aws-vault exec "$account" -- aws logs delete-log-group --log-group-name "$lg" 2>/dev/null || true
+        with_account_creds "$account" aws logs delete-log-group --log-group-name "$lg" 2>/dev/null || true
     done
 
     # 5. Delete transit gateways
     local tgws
-    tgws=$(aws-vault exec "$account" -- aws ec2 describe-transit-gateways \
+    tgws=$(with_account_creds "$account" aws ec2 describe-transit-gateways \
         --filters "Name=state,Values=available,pending" \
         --query 'TransitGateways[*].TransitGatewayId' --output text 2>/dev/null)
     for tgw_id in $tgws; do
@@ -354,25 +390,25 @@ deep_cleanup_account() {
         echo "  Cleaning transit gateway $tgw_id..."
         # Delete attachments first
         local attachments
-        attachments=$(aws-vault exec "$account" -- aws ec2 describe-transit-gateway-attachments \
+        attachments=$(with_account_creds "$account" aws ec2 describe-transit-gateway-attachments \
             --filters "Name=transit-gateway-id,Values=$tgw_id" "Name=state,Values=available" \
             --query 'TransitGatewayAttachments[*].TransitGatewayAttachmentId' --output text 2>/dev/null)
         for att_id in $attachments; do
             [ -z "$att_id" ] && continue
-            aws-vault exec "$account" -- aws ec2 delete-transit-gateway-vpc-attachment --transit-gateway-attachment-id "$att_id" 2>/dev/null || true
+            with_account_creds "$account" aws ec2 delete-transit-gateway-vpc-attachment --transit-gateway-attachment-id "$att_id" 2>/dev/null || true
         done
-        aws-vault exec "$account" -- aws ec2 delete-transit-gateway --transit-gateway-id "$tgw_id" 2>/dev/null || true
+        with_account_creds "$account" aws ec2 delete-transit-gateway --transit-gateway-id "$tgw_id" 2>/dev/null || true
     done
 
     # 6. Release Elastic IPs not associated with anything
     local eips
-    eips=$(aws-vault exec "$account" -- aws ec2 describe-addresses \
+    eips=$(with_account_creds "$account" aws ec2 describe-addresses \
         --query 'Addresses[?AssociationId==null].AllocationId' --output text 2>/dev/null)
     for eip_id in $eips; do
         [ -z "$eip_id" ] && continue
         found=$((found + 1))
         echo "  Releasing Elastic IP $eip_id..."
-        aws-vault exec "$account" -- aws ec2 release-address --allocation-id "$eip_id" 2>/dev/null || true
+        with_account_creds "$account" aws ec2 release-address --allocation-id "$eip_id" 2>/dev/null || true
     done
 
     echo "  $account: $found orphaned resources cleaned"
@@ -498,7 +534,7 @@ if [ "$COMMAND" = "deep-cleanup" ]; then
     for SLOT in $(seq 0 $((NUM_ACCOUNTS - 1))); do
         ACCOUNT="${ACCOUNTS[$SLOT]}"
         echo "  Authenticating $ACCOUNT..."
-        if ! aws-vault exec "$ACCOUNT" -- true 2>&1; then
+        if ! with_account_creds "$ACCOUNT" aws sts get-caller-identity >/dev/null 2>&1; then
             echo "  WARNING: Failed to pre-authenticate $ACCOUNT"
         fi
     done
@@ -546,7 +582,7 @@ if [ "$COMMAND" = "cleanup" ]; then
     for SLOT in $(seq 0 $((NUM_ACCOUNTS - 1))); do
         ACCOUNT="${ACCOUNTS[$SLOT]}"
         echo "  Authenticating $ACCOUNT..."
-        if ! aws-vault exec "$ACCOUNT" -- true 2>&1; then
+        if ! with_account_creds "$ACCOUNT" aws sts get-caller-identity >/dev/null 2>&1; then
             echo "  WARNING: Failed to pre-authenticate $ACCOUNT"
         fi
     done
@@ -582,7 +618,7 @@ if [ "$COMMAND" = "cleanup" ]; then
                     continue
                 fi
                 echo "RUNNING destroy $REL_PATH"
-                DESTROY_OUTPUT=$(cd "$TEST_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" destroy --auto-approve "$TEST_STATE_DIR" 2>&1)
+                DESTROY_OUTPUT=$(cd "$TEST_STATE_DIR" && with_account_creds "$ACCOUNT" "$CARINA_BIN" destroy --auto-approve "$TEST_STATE_DIR" 2>&1)
                 DESTROY_RC=$?
                 if [ $DESTROY_RC -eq 0 ]; then
                     if echo "$DESTROY_OUTPUT" | grep -q "No resources to destroy"; then
@@ -674,7 +710,7 @@ if [ "$COMMAND" = "full" ]; then
     for SLOT in $(seq 0 $((NUM_ACCOUNTS - 1))); do
         ACCOUNT="${ACCOUNTS[$SLOT]}"
         echo "  Authenticating $ACCOUNT..."
-        if ! aws-vault exec "$ACCOUNT" -- true 2>&1; then
+        if ! with_account_creds "$ACCOUNT" aws sts get-caller-identity >/dev/null 2>&1; then
             echo "  WARNING: Failed to pre-authenticate $ACCOUNT"
         fi
     done
@@ -720,7 +756,7 @@ if [ "$COMMAND" = "full" ]; then
                 INTERRUPTED=1
                 if [ -n "$CURRENT_STATE_DIR" ]; then
                     echo "INTERRUPTED - destroying resources for current test"
-                    cd "$CURRENT_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1 || true
+                    cd "$CURRENT_STATE_DIR" && with_account_creds "$ACCOUNT" "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1 || true
                 fi
             }
             trap worker_cleanup INT TERM
@@ -753,7 +789,7 @@ if [ "$COMMAND" = "full" ]; then
 
                 # Apply (run from state dir so each test has its own state file)
                 echo "RUNNING apply $REL_PATH"
-                APPLY_OUTPUT=$(cd "$CURRENT_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" apply --auto-approve "$CURRENT_STATE_DIR" 2>&1)
+                APPLY_OUTPUT=$(cd "$CURRENT_STATE_DIR" && with_account_creds "$ACCOUNT" "$CARINA_BIN" apply --auto-approve "$CURRENT_STATE_DIR" 2>&1)
                 APPLY_RC=$?
                 if [ $INTERRUPTED -eq 1 ]; then
                     break
@@ -763,14 +799,14 @@ if [ "$COMMAND" = "full" ]; then
                     echo "  ERROR: $APPLY_OUTPUT"
                     FAILED=$((FAILED + 1))
                     # Try to destroy whatever was partially created
-                    cd "$CURRENT_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1 || true
+                    cd "$CURRENT_STATE_DIR" && with_account_creds "$ACCOUNT" "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1 || true
                     CURRENT_STATE_DIR=""
                     continue
                 fi
 
                 # Post-apply plan verification (idempotency check)
                 echo "RUNNING plan-verify $REL_PATH"
-                PLAN_OUTPUT=$(cd "$CURRENT_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" plan --detailed-exitcode "$CURRENT_STATE_DIR" 2>&1)
+                PLAN_OUTPUT=$(cd "$CURRENT_STATE_DIR" && with_account_creds "$ACCOUNT" "$CARINA_BIN" plan --detailed-exitcode "$CURRENT_STATE_DIR" 2>&1)
                 PLAN_RC=$?
                 if [ $INTERRUPTED -eq 1 ]; then
                     break
@@ -781,21 +817,21 @@ if [ "$COMMAND" = "full" ]; then
                     echo "  $PLAN_OUTPUT"
                     FAILED=$((FAILED + 1))
                     # Still destroy to clean up
-                    cd "$CURRENT_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1 || true
+                    cd "$CURRENT_STATE_DIR" && with_account_creds "$ACCOUNT" "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1 || true
                     CURRENT_STATE_DIR=""
                     continue
                 elif [ $PLAN_RC -ne 0 ]; then
                     echo "FAIL (plan-verify) $REL_PATH"
                     echo "  ERROR: $PLAN_OUTPUT"
                     FAILED=$((FAILED + 1))
-                    cd "$CURRENT_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1 || true
+                    cd "$CURRENT_STATE_DIR" && with_account_creds "$ACCOUNT" "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1 || true
                     CURRENT_STATE_DIR=""
                     continue
                 fi
 
                 # Destroy
                 echo "RUNNING destroy $REL_PATH"
-                DESTROY_OUTPUT=$(cd "$CURRENT_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1)
+                DESTROY_OUTPUT=$(cd "$CURRENT_STATE_DIR" && with_account_creds "$ACCOUNT" "$CARINA_BIN" destroy --auto-approve "$CURRENT_STATE_DIR" 2>&1)
                 DESTROY_RC=$?
                 if [ $DESTROY_RC -ne 0 ] || echo "$DESTROY_OUTPUT" | grep -q "failed"; then
                     echo "FAIL (destroy) $REL_PATH"

--- a/acceptance-tests/tag_deletion/run.sh
+++ b/acceptance-tests/tag_deletion/run.sh
@@ -2,7 +2,7 @@
 # Multi-step acceptance tests for tag deletion
 #
 # Usage:
-#   aws-vault exec <profile> -- ./run.sh [filter]
+#   env AWS_PROFILE="<profile>" ./run.sh [filter]
 #
 # Tests:
 #   ec2_vpc                      - Remove a tag from VPC (EC2 delete_tags API)
@@ -17,6 +17,14 @@
 #   ec2_security_group_all_tags  - Remove entire tags block from security group (issue #447)
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
+#
+# AWS authentication:
+#   Set AWS_PROFILE to one of the carina-test-00X profiles. The script
+#   resolves fresh STS credentials from that profile before each carina
+#   invocation (via `aws configure export-credentials`), so long-running
+#   apply/destroy cycles are not bound to a single SSO access-token
+#   lifetime (see carina-rs/carina-provider-awscc#157). The first run
+#   in a session needs `aws sso login --sso-session carina`.
 
 set -e
 
@@ -29,6 +37,28 @@ source "$SCRIPT_DIR/../shared/_helpers.sh"
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
+# ── with_account_creds: resolve credentials for $AWS_PROFILE into env vars ──
+# and exec the given command. See run-tests.sh for rationale.
+with_account_creds() {
+    local account="${AWS_PROFILE:-}"
+    if [ -z "$account" ]; then
+        echo "ERROR: AWS_PROFILE is not set; cannot resolve credentials" >&2
+        return 1
+    fi
+    local creds
+    if ! creds=$(aws configure export-credentials --profile "$account" --format env-no-export 2>&1); then
+        echo "ERROR: aws configure export-credentials failed for $account: $creds" >&2
+        return 1
+    fi
+    (
+        set -a
+        eval "$creds"
+        set +a
+        unset AWS_PROFILE
+        "$@"
+    )
+}
+
 # Track active work dir for signal cleanup
 ACTIVE_WORK_DIR=""
 
@@ -37,8 +67,8 @@ signal_cleanup() {
         set +e
         echo ""
         echo "Interrupted. Cleaning up resources..."
-        (cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1)
-        (cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1)
+        (cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1)
+        (cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1)
         rm -rf "$ACTIVE_WORK_DIR"
         ACTIVE_WORK_DIR=""
     fi
@@ -56,7 +86,7 @@ run_step() {
     printf "  %-55s " "$description"
 
     local output
-    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args . 2>&1); then
+    if output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" $command $extra_args . 2>&1); then
         echo "OK"
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
         return 0
@@ -76,7 +106,7 @@ run_plan_verify() {
 
     local output
     local rc
-    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode . 2>&1) || rc=$?
+    output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" plan --detailed-exitcode . 2>&1) || rc=$?
     rc=${rc:-0}
 
     if [ $rc -eq 2 ]; then
@@ -106,11 +136,11 @@ cleanup() {
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    if (cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1); then
+    if (cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1); then
         any_success=true
     fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    if (cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1); then
+    if (cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1); then
         any_success=true
     fi
     set -e
@@ -156,7 +186,7 @@ run_test() {
 
     # Load step1 and initialize (creates backend lock + installs providers)
     swap_crn "$step1" "$work_dir"
-    if ! (cd "$work_dir" && "$CARINA_BIN" init . >/dev/null 2>&1); then
+    if ! (cd "$work_dir" && with_account_creds "$CARINA_BIN" init . >/dev/null 2>&1); then
         echo "  step1: init                                             FAIL"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
         rm -rf "$work_dir"


### PR DESCRIPTION
## Summary

Stop wrapping every carina call in `aws-vault exec` and instead resolve fresh STS credentials per invocation from a single `[sso-session carina]` block in `~/.aws/config`. This lets the AWS CLI/SDK refresh the SSO access token on its own using the refresh token stored in `~/.aws/sso/cache`, so individual long-running operations are no longer capped at the legacy 15-minute SSO window.

Mirrors the companion PR in [carina-rs/carina-provider-awscc](https://github.com/carina-rs/carina-provider-awscc/pull/159).

## Mechanism

A small `with_account_creds` helper runs `aws configure export-credentials --profile "$ACCOUNT" --format env-no-export`, then `eval`s the result inside a subshell before exec'ing the requested command. Each carina invocation therefore pulls the current sso-session access token (auto-refreshed if close to expiry), exchanges it for a fresh STS session (~1h lifetime), and passes the env-var triple into the process. The WASM plugin sandbox still only allowlists those env vars — no sandbox changes.

## Operator setup

Same as the awscc side: migrate `~/.aws/config` to the sso-session form and run `aws sso login --sso-session carina` once per session. The script headers document both steps.

## Changes

- `acceptance-tests/run-tests.sh` — introduce `with_account_creds`; swap all `aws-vault exec "$ACCOUNT" -- ...` call sites to `with_account_creds "$ACCOUNT" ...`; update the header comments and the pre-authenticate block (now runs `aws sts get-caller-identity`).
- `acceptance-tests/tag_deletion/run.sh` — same helper, resolves creds from `AWS_PROFILE` per carina call.
- `acceptance-tests/in_place_update/run.sh` — same helper wrapping carina invocations.

## Out of scope

- `in_place_update/run.sh` still carries the legacy step-directory structure from before the backend-lock `init` requirement landed. Its `full`-style end-to-end runs will need the same refactor the other two multi-step runners already got (see carina-provider-aws#146 and carina-provider-awscc#154 for the pattern); that's intentionally out of scope for this PR.

## Test plan

- [x] `./acceptance-tests/run-tests.sh full s3_bucket/basic` → 1 passed, 0 failed.
- [ ] Full `run-acceptance-tests` cadence (next run) to confirm no regressions.

Refs carina-rs/carina-provider-awscc#157
