### PR TITLE
s3.Bucket: retry CreateBucket on OperationAborted

### DIFF
--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -133,6 +133,10 @@ fn is_retryable_error(error_msg: &str) -> bool {
         "InternalError",
         "InternalServerError",
         "ServiceException",
+        // S3 returns this with HTTP 409 when CreateBucket races against a
+        // recent DeleteBucket for the same name; the control plane clears
+        // after ~60–90s, so backoff is the right response.
+        "OperationAborted",
     ];
     PATTERNS.iter().any(|p| error_msg.contains(p))
 }
@@ -287,11 +291,51 @@ mod tests {
         assert!(!is_retryable_error("InvalidParameterValue"));
     }
 
+    #[test]
+    fn test_is_retryable_error_s3_operation_aborted() {
+        // S3 CreateBucket can return OperationAborted shortly after the same
+        // name was deleted; the right behavior is to back off and retry, not
+        // propagate. See carina-rs/carina-provider-aws#156.
+        assert!(is_retryable_error(
+            "OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again."
+        ));
+        assert!(is_retryable_error(
+            "service error: unhandled error (OperationAborted): ..."
+        ));
+    }
+
     #[tokio::test]
     async fn test_retry_aws_operation_succeeds_first_try() {
         let result: Result<&str, String> =
             retry_aws_operation("test op", 3, 1, || async { Ok("success") }).await;
         assert_eq!(result.unwrap(), "success");
+    }
+
+    #[tokio::test]
+    async fn test_retry_aws_operation_retries_operation_aborted_then_succeeds() {
+        // Models the S3 CreateBucket / DeleteBucket race from #156: the first
+        // attempt sees OperationAborted, the second one goes through once the
+        // control plane has cleared the prior delete.
+        let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let counter = attempt_count.clone();
+        let result: Result<&str, String> = retry_aws_operation("create S3 bucket", 3, 1, || {
+            let counter = counter.clone();
+            async move {
+                let n = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if n == 0 {
+                    Err("OperationAborted: A conflicting conditional operation is currently in progress against this resource. Please try again.".to_string())
+                } else {
+                    Ok("created")
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), "created");
+        assert_eq!(
+            attempt_count.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "should retry once after OperationAborted"
+        );
     }
 
     #[tokio::test]

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value}
 use carina_core::utils::{convert_enum_value, extract_enum_value};
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::helpers::{retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
     /// Read an S3 bucket
@@ -141,10 +141,21 @@ impl AwsProvider {
             req = req.grant_write_acp(val);
         }
 
-        req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create bucket", &e))
-                .for_resource(resource.id.clone())
-        })?;
+        // Retry transient errors such as OperationAborted (HTTP 409) which
+        // S3 returns when CreateBucket races a recent DeleteBucket for the
+        // same name — the control plane clears after ~60–90s. See #156.
+        let rid = resource.id.clone();
+        retry_aws_operation("create S3 bucket", 5, 5, || {
+            let req = req.clone();
+            let rid = rid.clone();
+            async move {
+                req.send().await.map_err(|e| {
+                    ProviderError::new(sdk_error_message("Failed to create bucket", &e))
+                        .for_resource(rid)
+                })
+            }
+        })
+        .await?;
 
         // Configure versioning
         let attrs = resource.resolved_attributes();


### PR DESCRIPTION
## Summary

Make `s3.Bucket` CreateBucket retry on S3's `OperationAborted` race. Uses the existing `retry_aws_operation` helper (same one `ec2.Vpc` / `ec2.VpcEndpoint` / `ec2.SecurityGroup` already go through): 5 attempts, exponential backoff capped at 120s.

## Why

S3 returns `OperationAborted` with HTTP 409 when `CreateBucket` races against a recent `DeleteBucket` for the same bucket name. The control plane clears the prior delete after ~60–90s, so backoff is the right response — the bucket name becomes usable on its own. Surfacing the error to the caller forces every user to handle this transient AWS-internal state themselves, and was the cause of the `acceptance-tests/s3_bucket/basic` flake noted in #156.

Option 1 in the issue was "randomize the fixture". This PR does option 2 instead, because it fixes the underlying race for any user workload that recreates a bucket by name (which is a common CI/IaC pattern), not just our one test.

## Changes

- `carina-provider-aws/src/helpers.rs`: add `OperationAborted` to `is_retryable_error`'s pattern list. Two unit tests cover the new pattern and one end-to-end retry scenario.
- `carina-provider-aws/src/services/s3/bucket.rs`: wrap `create_bucket` in `retry_aws_operation("create S3 bucket", 5, 5, ...)`. Matches the existing `ec2.Vpc` call site exactly.

## Test plan

- [x] `cargo test -p carina-provider-aws` → 11 + 4 helpers passed, 0 failed.
- [x] `cargo clippy -p carina-provider-aws --all-targets -- -D warnings` clean.
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` succeeds.
- [x] `./acceptance-tests/run-tests.sh full s3_bucket/basic` → 1 passed, 0 failed.
- [x] Back-to-back `./acceptance-tests/run-tests.sh full s3_bucket/basic` → 1 passed, 0 failed. The race didn't land this time, but the unit test `test_retry_aws_operation_retries_operation_aborted_then_succeeds` proves the retry path is taken when the error is actually seen.

Closes #156
