### PR TITLE
refactor: switch ProviderFactory trait impls to &IndexMap (#2255 lockstep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ name = "carina-aws-types"
 version = "0.4.0"
 dependencies = [
  "carina-core",
+ "indexmap",
 ]
 
 [[package]]
@@ -640,10 +641,11 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
+source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
 dependencies = [
  "argon2",
  "futures",
+ "indexmap",
  "pest",
  "pest_derive",
  "semver",
@@ -656,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
+source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -688,6 +690,7 @@ dependencies = [
  "carina-plugin-sdk",
  "carina-provider-protocol",
  "heck",
+ "indexmap",
  "serde",
  "serde_json",
  "thiserror",
@@ -700,7 +703,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
+source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -10,5 +10,8 @@ description = "AWS type definitions for Carina infrastructure management tool"
 [lib]
 doctest = false
 
+[dev-dependencies]
+indexmap = "2"
+
 [dependencies]
 carina-core = { git = "https://github.com/carina-rs/carina" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -2460,7 +2460,7 @@ mod tests {
                         Value::Map(
                             vec![(
                                 "StringEquals".to_string(),
-                                Value::Map(std::collections::HashMap::new()),
+                                Value::Map(indexmap::IndexMap::new()),
                             )]
                             .into_iter()
                             .collect(),
@@ -2489,12 +2489,9 @@ mod tests {
                     vec![(
                         "condition".to_string(),
                         Value::Map(
-                            vec![(
-                                "foo_bar".to_string(),
-                                Value::Map(std::collections::HashMap::new()),
-                            )]
-                            .into_iter()
-                            .collect(),
+                            vec![("foo_bar".to_string(), Value::Map(indexmap::IndexMap::new()))]
+                                .into_iter()
+                                .collect(),
                         ),
                     )]
                     .into_iter()
@@ -2518,7 +2515,7 @@ mod tests {
                         Value::Map(
                             vec![(
                                 "string_equals_if_exists".to_string(),
-                                Value::Map(std::collections::HashMap::new()),
+                                Value::Map(indexmap::IndexMap::new()),
                             )]
                             .into_iter()
                             .collect(),

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -23,6 +23,7 @@ carina-core = { git = "https://github.com/carina-rs/carina" }
 carina-aws-types = { path = "../carina-aws-types" }
 carina-plugin-sdk = { git = "https://github.com/carina-rs/carina" }
 carina-provider-protocol = { git = "https://github.com/carina-rs/carina" }
+indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 aws-smithy-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -29,7 +29,7 @@ pub fn core_to_proto_resource_id(id: &CoreResourceId) -> ProtoResourceId {
     ProtoResourceId {
         provider: id.provider.clone(),
         resource_type: id.resource_type.clone(),
-        name: id.name.clone(),
+        name: id.name.to_string(),
     }
 }
 

--- a/carina-provider-aws/src/ec2_tags.rs
+++ b/carina-provider-aws/src/ec2_tags.rs
@@ -1,5 +1,6 @@
 //! EC2 tag helper functions
 
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -11,7 +12,7 @@ use crate::helpers::sdk_error_message;
 impl AwsProvider {
     /// Extract tags from EC2 tag list into a Value::Map
     pub(crate) fn ec2_tags_to_value(tags: &[aws_sdk_ec2::types::Tag]) -> Option<Value> {
-        let mut tag_map = HashMap::new();
+        let mut tag_map: IndexMap<String, Value> = IndexMap::new();
         for tag in tags {
             if let (Some(key), Some(value)) = (tag.key(), tag.value()) {
                 tag_map.insert(key.to_string(), Value::String(value.to_string()));
@@ -162,7 +163,7 @@ mod tests {
 
     #[test]
     fn test_value_to_ec2_tags_from_map() {
-        let value = Value::Map(HashMap::from([
+        let value = Value::Map(IndexMap::from([
             ("Name".to_string(), Value::String("test".to_string())),
             ("Env".to_string(), Value::String("prod".to_string())),
         ]));
@@ -191,7 +192,7 @@ mod tests {
 
     #[test]
     fn test_value_to_ec2_tags_non_string_values_skipped() {
-        let value = Value::Map(HashMap::from([
+        let value = Value::Map(IndexMap::from([
             ("Name".to_string(), Value::String("test".to_string())),
             ("Count".to_string(), Value::Int(42)),
         ]));
@@ -203,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_value_to_ec2_tags_empty_map() {
-        let value = Value::Map(HashMap::new());
+        let value = Value::Map(IndexMap::new());
         let tags = AwsProvider::value_to_ec2_tags(&value);
         assert!(tags.is_empty());
     }

--- a/carina-provider-aws/src/factory.rs
+++ b/carina-provider-aws/src/factory.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
+
 use carina_core::provider::{BoxFuture, ProviderFactory, ProviderNormalizer};
 use carina_core::resource::Value;
 
@@ -39,14 +41,14 @@ impl ProviderFactory for AwsProviderFactory {
         types
     }
 
-    fn validate_config(&self, _attributes: &HashMap<String, Value>) -> Result<(), String> {
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
         // Region format/value validation is handled by the host via
         // `provider_config_attribute_types`. No provider-specific semantic
         // checks are needed beyond that for now.
         Ok(())
     }
 
-    fn extract_region(&self, attributes: &HashMap<String, Value>) -> String {
+    fn extract_region(&self, attributes: &IndexMap<String, Value>) -> String {
         if let Some(Value::String(region)) = attributes.get("region") {
             return carina_core::utils::convert_region_value(region);
         }
@@ -55,7 +57,7 @@ impl ProviderFactory for AwsProviderFactory {
 
     fn create_provider(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn carina_core::provider::Provider>> {
         let region = self.extract_region(attributes);
         Box::pin(async move {
@@ -65,7 +67,7 @@ impl ProviderFactory for AwsProviderFactory {
 
     fn create_normalizer(
         &self,
-        _attributes: &HashMap<String, Value>,
+        _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         Box::pin(async { Box::new(AwsNormalizer) as Box<dyn ProviderNormalizer> })
     }

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -2,7 +2,7 @@
 //!
 //! These reduce boilerplate across EC2 (and other) service implementations.
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::future::Future;
 use std::time::Duration;
 
@@ -49,9 +49,9 @@ pub fn build_tag_specification(
     }
 }
 
-/// Build an EC2 `TagSpecification` from a `HashMap` of tags.
+/// Build an EC2 `TagSpecification` from a tag map.
 fn build_tag_specification_from_map(
-    tags: &HashMap<String, Value>,
+    tags: &IndexMap<String, Value>,
     resource_type: ResourceType,
 ) -> TagSpecification {
     let mut tag_spec = TagSpecification::builder().resource_type(resource_type);

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -256,7 +256,10 @@ impl CarinaProvider for AwsProcessProvider {
             .iter()
             .map(convert::proto_to_core_resource)
             .collect();
-        let core_tags = convert::proto_to_core_value_map(default_tags);
+        let core_tags: indexmap::IndexMap<String, _> = default_tags
+            .iter()
+            .map(|(k, v)| (k.clone(), convert::proto_to_core_value(v)))
+            .collect();
         let core_schemas: HashMap<String, ResourceSchema> = proto_schemas
             .iter()
             .map(|s| (s.resource_type.clone(), convert::proto_to_core_schema(s)))

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
+
 use carina_core::provider::{self, ProviderNormalizer};
 use carina_core::resource::{Resource, Value};
 use carina_core::schema::ResourceSchema;
@@ -19,7 +21,7 @@ impl ProviderNormalizer for AwsNormalizer {
     fn merge_default_tags(
         &self,
         resources: &mut [Resource],
-        default_tags: &HashMap<String, Value>,
+        default_tags: &IndexMap<String, Value>,
         schemas: &HashMap<String, ResourceSchema>,
     ) {
         provider::merge_default_tags_for_provider("aws", resources, default_tags, schemas);
@@ -365,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_normalize_state_enums_struct_field_enum() {
-        let mut inner = HashMap::new();
+        let mut inner = IndexMap::new();
         inner.insert(
             "hostname_type".to_string(),
             Value::String("ip-name".to_string()),

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -3,6 +3,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with:
 //!   ./carina-provider-aws/scripts/generate-provider.sh
 
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -358,7 +359,7 @@ impl AwsProvider {
             attributes.insert("outpost_arn".to_string(), Value::String(v.to_string()));
         }
         if let Some(dns_opts) = obj.private_dns_name_options_on_launch() {
-            let mut fields = HashMap::new();
+            let mut fields = IndexMap::new();
             if let Some(ht) = dns_opts.hostname_type() {
                 fields.insert(
                     "hostname_type".to_string(),

--- a/carina-provider-aws/src/services/ec2/route_table.rs
+++ b/carina-provider-aws/src/services/ec2/route_table.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -44,7 +45,7 @@ impl AwsProvider {
             // Convert routes to list (complex nested structure)
             let mut routes_list = Vec::new();
             for route in rt.routes() {
-                let mut route_map = HashMap::new();
+                let mut route_map: IndexMap<String, Value> = IndexMap::new();
                 if let Some(dest) = route.destination_cidr_block() {
                     route_map.insert("destination".to_string(), Value::String(dest.to_string()));
                 }

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -72,7 +72,7 @@ impl AwsProvider {
         // group_name is required for CreateSecurityGroup API
         let group_name = match resource.get_attr("group_name") {
             Some(Value::String(s)) => s.clone(),
-            _ => resource.id.name.clone(),
+            _ => resource.id.name.to_string(),
         };
 
         // Create Security Group

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -34,7 +35,7 @@ impl AwsProvider {
                     // Extract tags
                     let tags = role.tags();
                     if !tags.is_empty() {
-                        let mut tag_map = HashMap::new();
+                        let mut tag_map = IndexMap::new();
                         for tag in tags {
                             let key = tag.key();
                             let val = tag.value();
@@ -233,11 +234,11 @@ impl AwsProvider {
     ) -> ProviderResult<()> {
         let desired_tags = match desired.get("tags") {
             Some(Value::Map(m)) => m.clone(),
-            _ => HashMap::new(),
+            _ => IndexMap::new(),
         };
         let current_tags = match current.and_then(|c| c.get("tags")) {
             Some(Value::Map(m)) => m.clone(),
-            _ => HashMap::new(),
+            _ => IndexMap::new(),
         };
 
         // Tags to remove
@@ -348,7 +349,7 @@ fn json_to_value_snake(json: &serde_json::Value) -> Value {
             Value::List(items.iter().map(json_to_value_snake).collect())
         }
         serde_json::Value::Object(obj) => {
-            let map: HashMap<String, Value> = obj
+            let map: IndexMap<String, Value> = obj
                 .iter()
                 .map(|(k, v)| (pascal_to_snake(k), json_to_value_snake(v)))
                 .collect();

--- a/carina-provider-aws/src/services/identitystore/user.rs
+++ b/carina-provider-aws/src/services/identitystore/user.rs
@@ -4,6 +4,7 @@
 //! `user_id` (via `DescribeUser` directly). One of the two must be set.
 //! `identity_store_id` is always required.
 
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use aws_sdk_identitystore::types::{AlternateIdentifier, UniqueAttribute};
@@ -132,7 +133,7 @@ pub(crate) fn extract_identitystore_user(
         );
     }
     if let Some(name) = resp.name() {
-        let mut name_fields: HashMap<String, Value> = HashMap::new();
+        let mut name_fields: IndexMap<String, Value> = IndexMap::new();
         if let Some(v) = name.formatted() {
             name_fields.insert("formatted".to_string(), Value::String(v.to_string()));
         }

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -76,7 +77,7 @@ impl AwsProvider {
                     if let Some(tags) = tags_output.tags()
                         && !tags.is_empty()
                     {
-                        let mut tag_map = HashMap::new();
+                        let mut tag_map = IndexMap::new();
                         for (key, val) in tags {
                             tag_map.insert(key.to_string(), Value::String(val.to_string()));
                         }
@@ -251,11 +252,11 @@ impl AwsProvider {
     ) -> ProviderResult<()> {
         let desired_tags = match desired.get("tags") {
             Some(Value::Map(m)) => m.clone(),
-            _ => HashMap::new(),
+            _ => IndexMap::new(),
         };
         let current_tags = match current.and_then(|c| c.get("tags")) {
             Some(Value::Map(m)) => m.clone(),
-            _ => HashMap::new(),
+            _ => IndexMap::new(),
         };
 
         // Tags to remove

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -102,7 +103,7 @@ impl AwsProvider {
                     {
                         let tags = tags_response.tags();
                         if !tags.is_empty() {
-                            let mut tag_map = HashMap::new();
+                            let mut tag_map = IndexMap::new();
                             for tag in tags {
                                 tag_map.insert(
                                     tag.key().to_string(),
@@ -372,11 +373,11 @@ impl AwsProvider {
     ) -> ProviderResult<()> {
         let desired_tags = match desired.get("tags") {
             Some(Value::Map(m)) => m.clone(),
-            _ => HashMap::new(),
+            _ => IndexMap::new(),
         };
         let current_tags = match current.and_then(|c| c.get("tags")) {
             Some(Value::Map(m)) => m.clone(),
-            _ => HashMap::new(),
+            _ => IndexMap::new(),
         };
 
         // Tags to remove

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -3,6 +3,7 @@
 //! Uses ChangeResourceRecordSets (UPSERT/DELETE) and ListResourceRecordSets
 //! for CRUD operations. Cloud Control does not support Route 53 records.
 
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use aws_sdk_route53::types::{
@@ -64,7 +65,7 @@ fn build_resource_records(records: &[Value]) -> Vec<ResourceRecord> {
 }
 
 fn build_alias_target_from_map(
-    alias: &HashMap<String, Value>,
+    alias: &IndexMap<String, Value>,
     id: &ResourceId,
 ) -> ProviderResult<AliasTarget> {
     let dns_name = alias
@@ -196,7 +197,7 @@ fn extract_attributes(hosted_zone_id: &str, rrs: &ResourceRecordSet) -> HashMap<
     }
 
     if let Some(alias) = rrs.alias_target() {
-        let mut alias_map = HashMap::new();
+        let mut alias_map: IndexMap<String, Value> = IndexMap::new();
         alias_map.insert(
             "dns_name".to_string(),
             Value::String(strip_trailing_dot(alias.dns_name())),

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -623,7 +624,7 @@ impl AwsProvider {
             .await
         {
             Ok(output) => {
-                let mut tag_map = HashMap::new();
+                let mut tag_map: IndexMap<String, Value> = IndexMap::new();
                 for tag in output.tag_set() {
                     tag_map.insert(
                         tag.key().to_string(),

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
+
 use carina_core::resource::Value;
 use carina_core::schema::AttributeType;
 
@@ -423,7 +425,7 @@ fn test_route_table_routes_extraction() {
     // Replicate route extraction logic from read_ec2_route_table
     let mut routes_list = Vec::new();
     for route in rt.routes() {
-        let mut route_map = HashMap::new();
+        let mut route_map = IndexMap::new();
         if let Some(dest) = route.destination_cidr_block() {
             route_map.insert("destination".to_string(), Value::String(dest.to_string()));
         }


### PR DESCRIPTION
## Summary

Companion to carina-rs/carina#2257 (Stage 2 of #2222).

carina-core's host-side ``ProviderFactory`` trait now takes ``&IndexMap<String, Value>`` instead of ``&HashMap<String, Value>`` for ``validate_config``, ``extract_region``, ``create_provider``, ``create_normalizer``, and ``merge_default_tags`` (on ``ProviderNormalizer`` and the free ``merge_default_tags_for_provider``).

This PR lifts every consumer of ``Value::Map`` payloads in the AWS provider to ``IndexMap`` so it builds against the new carina-core. The behavioural change is "user-authored attribute order survives parse → provider", same story as the core PR.

Side effects already on ``main`` since this branch was last bumped:

- ``ResourceId::name`` is now ``ResourceName`` (enum), so ``.id.name.clone()`` becomes ``.id.name.to_string()`` in conversion paths.

The ``provider_config_attribute_types`` return type stays ``HashMap`` — attribute types are name→type, not user-authored, so order doesn't matter.

## Test plan

- [x] ``cargo build`` (lib + bin)
- [x] ``cargo test --lib``
- [x] ``cargo clippy --all-targets -- -D warnings``
- [x] ``cargo fmt --check``

Refs carina-rs/carina#2255

🤖 Generated with [Claude Code](https://claude.com/claude-code)