### PR TITLE
codegen: emit types::email() for email attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
+source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
 dependencies = [
  "argon2",
  "futures",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
+source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
+source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -2572,56 +2572,33 @@ fn generate_data_source(ds: &resource_defs::DataSourceDef, model: &SmithyModel) 
     let type_overrides: HashMap<&str, &str> = ds.type_overrides.iter().copied().collect();
     let exclude: HashSet<&str> = ds.exclude_fields.iter().copied().collect();
 
-    let mut code = String::new();
-    code.push_str(&format!(
-        "//! {} schema definition for AWS Cloud Control\n\
-         //!\n\
-         //! Auto-generated from Smithy model: {}\n\
-         //!\n\
-         //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen\n\n\
-         use super::AwsSchemaConfig;\n\
-         use carina_core::schema::{{AttributeSchema, AttributeType, ResourceSchema}};\n\n\
-         /// Returns the schema config for {} (Smithy: {})\n\
-         pub fn {}() -> AwsSchemaConfig {{\n\
-         \x20   AwsSchemaConfig {{\n\
-         \x20       aws_type_name: \"{}\",\n\
-         \x20       resource_type_name: \"{}\",\n\
-         \x20       has_tags: false,\n\
-         \x20       schema: ResourceSchema::new(\"{}\")\n\
-         \x20       .as_data_source()\n",
-        ds.name.split('.').next_back().unwrap_or(ds.name),
-        ns,
-        ds.name,
-        ns,
-        config_fn,
-        cf_type,
-        ds.name,
-        namespace,
-    ));
-
-    // Add input attributes (writable)
+    // Build all attribute type strings up-front so we can compute imports.
+    struct DsAttr {
+        name: String,
+        provider_name: String,
+        type_str: String,
+        description: String,
+        required: bool,
+        read_only: bool,
+    }
+    let mut ds_attrs: Vec<DsAttr> = Vec::new();
     for input in &ds.inputs {
         let type_str = if let Some(t) = input.type_override {
             t.to_string()
+        } else if is_email_property(input.provider_name) {
+            "types::email()".to_string()
         } else {
             "AttributeType::String".to_string()
         };
-        let required = if input.required {
-            "\n            .required()"
-        } else {
-            ""
-        };
-        code.push_str(&format!(
-            "\x20       .attribute(\n\
-             \x20           AttributeSchema::new(\"{}\", {}){}\n\
-             \x20               .with_description(\"{}\")\n\
-             \x20               .with_provider_name(\"{}\"),\n\
-             \x20       )\n",
-            input.name, type_str, required, input.description, input.provider_name,
-        ));
+        ds_attrs.push(DsAttr {
+            name: input.name.to_string(),
+            provider_name: input.provider_name.to_string(),
+            type_str,
+            description: input.description.to_string(),
+            required: input.required,
+            read_only: false,
+        });
     }
-
-    // Add output attributes from read_ops (read-only)
     for read_op in &ds.read_ops {
         let op_id = format!("{}#{}", ns, read_op.operation);
         let output = model
@@ -2635,8 +2612,9 @@ fn generate_data_source(ds: &resource_defs::DataSourceDef, model: &SmithyModel) 
             }
             let type_str = if let Some(t) = type_overrides.get(effective_name) {
                 t.to_string()
+            } else if is_email_property(effective_name) {
+                "types::email()".to_string()
             } else {
-                // Default to String for data source outputs; use type_overrides for non-string types
                 "AttributeType::String".to_string()
             };
             let desc = output
@@ -2649,13 +2627,83 @@ fn generate_data_source(ds: &resource_defs::DataSourceDef, model: &SmithyModel) 
                     truncated.replace('"', "\\\"").replace('\n', " ")
                 })
                 .unwrap_or_default();
+            ds_attrs.push(DsAttr {
+                name: dsl_name,
+                provider_name: effective_name.to_string(),
+                type_str,
+                description: format!("{} (read-only)", desc),
+                required: false,
+                read_only: true,
+            });
+        }
+    }
+
+    // Determine needed imports based on actual type strings used.
+    let needs_types = ds_attrs.iter().any(|a| a.type_str.contains("types::"));
+    let needs_attribute_type = ds_attrs
+        .iter()
+        .any(|a| a.type_str.contains("AttributeType::"));
+    let mut schema_imports = vec!["AttributeSchema", "ResourceSchema"];
+    if needs_attribute_type {
+        schema_imports.insert(1, "AttributeType");
+    }
+    if needs_types {
+        schema_imports.push("types");
+    }
+    let schema_imports_str = schema_imports.join(", ");
+
+    let mut code = String::new();
+    code.push_str(&format!(
+        "//! {} schema definition for AWS Cloud Control\n\
+         //!\n\
+         //! Auto-generated from Smithy model: {}\n\
+         //!\n\
+         //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen\n\n\
+         use super::AwsSchemaConfig;\n\
+         use carina_core::schema::{{{}}};\n\n\
+         /// Returns the schema config for {} (Smithy: {})\n\
+         pub fn {}() -> AwsSchemaConfig {{\n\
+         \x20   AwsSchemaConfig {{\n\
+         \x20       aws_type_name: \"{}\",\n\
+         \x20       resource_type_name: \"{}\",\n\
+         \x20       has_tags: false,\n\
+         \x20       schema: ResourceSchema::new(\"{}\")\n\
+         \x20       .as_data_source()\n",
+        ds.name.split('.').next_back().unwrap_or(ds.name),
+        ns,
+        schema_imports_str,
+        ds.name,
+        ns,
+        config_fn,
+        cf_type,
+        ds.name,
+        namespace,
+    ));
+
+    // Emit attributes.
+    for attr in &ds_attrs {
+        if attr.read_only {
             code.push_str(&format!(
                 "\x20       .attribute(\n\
                  \x20           AttributeSchema::new(\"{}\", {})\n\
-                 \x20               .with_description(\"{} (read-only)\")\n\
+                 \x20               .with_description(\"{}\")\n\
                  \x20               .with_provider_name(\"{}\"),\n\
                  \x20       )\n",
-                dsl_name, type_str, desc, effective_name,
+                attr.name, attr.type_str, attr.description, attr.provider_name,
+            ));
+        } else {
+            let required = if attr.required {
+                "\n            .required()"
+            } else {
+                ""
+            };
+            code.push_str(&format!(
+                "\x20       .attribute(\n\
+                 \x20           AttributeSchema::new(\"{}\", {}){}\n\
+                 \x20               .with_description(\"{}\")\n\
+                 \x20               .with_provider_name(\"{}\"),\n\
+                 \x20       )\n",
+                attr.name, attr.type_str, required, attr.description, attr.provider_name,
             ));
         }
     }
@@ -2719,7 +2767,12 @@ fn generate_markdown_data_source(
                 let effective_name = rename.unwrap_or(field_name);
                 let dsl_name = effective_name.to_snake_case();
                 md.push_str(&format!("### `{}`\n\n", dsl_name));
-                md.push_str("- **Type:** String\n");
+                let type_display = if is_email_property(effective_name) {
+                    "Email".to_string()
+                } else {
+                    "String".to_string()
+                };
+                md.push_str(&format!("- **Type:** {}\n", type_display));
                 md.push_str("- **Read-only**\n\n");
                 if let Some(member_ref) = output.members.get(*field_name)
                     && let Some(doc_val) = member_ref.traits.get("smithy.api#documentation")
@@ -2890,6 +2943,7 @@ fn type_code_to_display(type_code: &str) -> String {
         s if s.contains("aws_resource_id") => "AwsResourceId".to_string(),
         s if s.contains("availability_zone_id") => "AvailabilityZoneId".to_string(),
         s if s.contains("availability_zone") => "AvailabilityZone".to_string(),
+        s if s.contains("email") => "Email".to_string(),
         _ => type_code
             .trim_start_matches("super::")
             .trim_end_matches("()")
@@ -3094,7 +3148,29 @@ fn infer_string_type(prop_name: &str) -> Option<String> {
         return Some("super::aws_account_id()".to_string());
     }
 
+    // Email address fields. Match conservatively: only when the field IS the
+    // email value itself, not arbitrary names that happen to contain "email"
+    // (e.g. EmailEnabled, EmailNotificationConfig).
+    if is_email_property(prop_name) {
+        return Some("types::email()".to_string());
+    }
+
     None
+}
+
+/// Returns true if a property name represents an email address value.
+///
+/// Conservative match: the name must be exactly "Email"/"EmailAddress" (or
+/// a plural form), or end with "Email"/"EmailAddress" preceded by a word
+/// boundary (typically PascalCase, e.g. "MasterAccountEmail",
+/// "ContactEmailAddress"). Names like "EmailEnabled" or
+/// "EmailNotificationConfig" are intentionally NOT matched.
+fn is_email_property(prop_name: &str) -> bool {
+    let lower = prop_name.to_lowercase();
+    lower.ends_with("email")
+        || lower.ends_with("emails")
+        || lower.ends_with("emailaddress")
+        || lower.ends_with("emailaddresses")
 }
 
 fn is_aws_resource_id_property(prop_name: &str) -> bool {
@@ -3425,6 +3501,80 @@ mod tests {
         assert!(
             generated.contains("if resource_type == \"iam.Role\""),
             "orphaned iam.Role enum_alias_reverse should be included: {generated}"
+        );
+    }
+
+    #[test]
+    fn infer_string_type_emits_email_for_email_props() {
+        // Exact and plural matches.
+        assert_eq!(
+            infer_string_type("Email"),
+            Some("types::email()".to_string())
+        );
+        assert_eq!(
+            infer_string_type("Emails"),
+            Some("types::email()".to_string())
+        );
+        assert_eq!(
+            infer_string_type("EmailAddress"),
+            Some("types::email()".to_string())
+        );
+        assert_eq!(
+            infer_string_type("EmailAddresses"),
+            Some("types::email()".to_string())
+        );
+        // PascalCase suffix.
+        assert_eq!(
+            infer_string_type("MasterAccountEmail"),
+            Some("types::email()".to_string())
+        );
+        assert_eq!(
+            infer_string_type("ContactEmailAddress"),
+            Some("types::email()".to_string())
+        );
+    }
+
+    #[test]
+    fn infer_string_type_does_not_emit_email_for_unrelated_names() {
+        // Names that contain "email" but are not email values.
+        assert_ne!(
+            infer_string_type("EmailEnabled"),
+            Some("types::email()".to_string())
+        );
+        assert_ne!(
+            infer_string_type("EmailNotificationConfig"),
+            Some("types::email()".to_string())
+        );
+    }
+
+    #[test]
+    fn organizations_account_email_is_email_type() {
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../carina-provider-aws/tests/fixtures/smithy/organizations.json");
+        if !fixture.exists() {
+            eprintln!(
+                "Skipping: Smithy fixture not found: {}\nRun scripts/download-smithy-models.sh to enable this test",
+                fixture.display()
+            );
+            return;
+        }
+        let file = std::fs::File::open(&fixture).expect("failed to open Smithy fixture");
+        let model = carina_smithy::parse_reader(std::io::BufReader::new(file))
+            .expect("failed to parse Smithy fixture");
+        let resource = resource_defs::organizations_resources()
+            .into_iter()
+            .find(|res| res.name == "organizations.Account")
+            .expect("missing organizations.Account resource def");
+
+        let generated = generate_resource(&resource, &model).expect("failed to generate resource");
+
+        assert!(
+            generated.contains("\"email\", types::email()"),
+            "organizations.account.email should be types::email(): {generated}"
+        );
+        assert!(
+            !generated.contains("\"email\", AttributeType::String"),
+            "organizations.account.email should NOT be AttributeType::String: {generated}"
         );
     }
 

--- a/carina-provider-aws/src/schemas/generated/identitystore/user.rs
+++ b/carina-provider-aws/src/schemas/generated/identitystore/user.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 /// Returns the schema config for identitystore.User (Smithy: com.amazonaws.identitystore)
 pub fn identitystore_user_config() -> AwsSchemaConfig {
@@ -39,7 +39,7 @@ pub fn identitystore_user_config() -> AwsSchemaConfig {
                     .with_provider_name("DisplayName"),
             )
             .attribute(
-                AttributeSchema::new("emails", AttributeType::String)
+                AttributeSchema::new("emails", types::email())
                     .with_description("<p>The email address of the user.</p> (read-only)")
                     .with_provider_name("Emails"),
             ),

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_IAM_USER_ACCESS_TO_BILLING: &[&str] = &["ALLOW", "DENY"];
 
@@ -31,7 +31,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
                 .with_provider_name("AccountName"),
         )
         .attribute(
-            AttributeSchema::new("email", AttributeType::String)
+            AttributeSchema::new("email", types::email())
                 .required()
                 .create_only()
                 .with_description("The email address of the owner to assign to the new member account. This email address must not already be associated with another Amazon Web Services...")

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING"];
 
@@ -44,7 +44,7 @@ pub fn organizations_organization_config() -> AwsSchemaConfig {
                 .with_provider_name("MasterAccountArn"),
         )
         .attribute(
-            AttributeSchema::new("master_account_email", AttributeType::String)
+            AttributeSchema::new("master_account_email", types::email())
                 .with_description("The email address that is associated with the Amazon Web Services account that is designated as the management account for the organization. (read-only)")
                 .with_provider_name("MasterAccountEmail"),
         )

--- a/generated-docs/aws/identitystore/user.md
+++ b/generated-docs/aws/identitystore/user.md
@@ -39,7 +39,7 @@ The user's user name. Provide either user_id or user_name.
 
 ### `emails`
 
-- **Type:** String
+- **Type:** Email
 - **Read-only**
 
 <p>The email address of the user.</p>


### PR DESCRIPTION
## Summary

- Update `carina-codegen-aws` so attributes identified as emails emit `carina_core::schema::types::email()` instead of `AttributeType::String`.
- Detection is conservative: matches `Email`, `Emails`, `EmailAddress`, `EmailAddresses`, and PascalCase suffixes (e.g. `MasterAccountEmail`, `ContactEmailAddress`). Does not match unrelated names that merely contain `email` (e.g. `EmailEnabled`, `EmailNotificationConfig`).
- Bumps the `carina` git dependency to `8d09acb3` so the new `types::email()` constructor (carina-rs/carina#2282) is available.

## Email-typed fields rewritten

| File | Field |
|------|-------|
| `carina-provider-aws/src/schemas/generated/organizations/account.rs:34` | `email` (writable, required, create-only) |
| `carina-provider-aws/src/schemas/generated/organizations/organization.rs:47` | `master_account_email` (read-only) |
| `carina-provider-aws/src/schemas/generated/identitystore/user.rs:42` | `emails` (read-only) |

## Codegen changes (`carina-codegen-aws/src/main.rs`)

- New `is_email_property()` predicate.
- `infer_string_type()` returns `types::email()` for email-named props (covers the resource generator and the resource-side markdown generator via `type_code_to_display`).
- `generate_data_source()` checks `is_email_property` for both inputs and read_op outputs and now computes its `carina_core::schema` imports (`AttributeType`, `types`) dynamically based on the actual type strings used, instead of hard-coding the import line.
- `generate_markdown_data_source()` renders email outputs as `Email` rather than `String`.
- `type_code_to_display()` adds an `email` arm.

## Tests added

- `infer_string_type_emits_email_for_email_props` - exact, plural and PascalCase-suffix cases.
- `infer_string_type_does_not_emit_email_for_unrelated_names` - guards against the `EmailEnabled` / `EmailNotificationConfig` regressions.
- `organizations_account_email_is_email_type` - end-to-end schema generation snapshot for `aws.organizations.account.email`.

## Docs

`generated-docs/aws/identitystore/user.md` was regenerated and now shows `**Type:** Email` for `emails`. The other email-bearing resource doc files (`organizations/account.md`, `organizations/organization.md`) are gitignored and not currently tracked, so no update is needed for them.

## Test plan

- [x] `cargo build` (workspace) - passes
- [x] `cargo test --workspace` - all suites green (including the 3 new email tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` - clean
- [x] Pre-commit (`fmt` + `clippy`) - passes
- [x] Verified the regenerated schemas compile and are byte-identical except for the email fields and the corresponding `types` import additions
- [x] Verified `examples/` has no `.crn` references to email fields, so no example breakage

Closes #93