### PR TITLE
refactor: adopt closure-capable Custom validator from carina-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
+source = "git+https://github.com/carina-rs/carina#c9e54236d1155915f08069476a159aa45ca73ac7"
 dependencies = [
  "argon2",
  "futures",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
+source = "git+https://github.com/carina-rs/carina#c9e54236d1155915f08069476a159aa45ca73ac7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
+source = "git+https://github.com/carina-rs/carina#c9e54236d1155915f08069476a159aa45ca73ac7"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -5,7 +5,7 @@
 //! schema config structs) remain in their respective crates.
 
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeType, CompletionValue, StructField};
+use carina_core::schema::{AttributeType, CompletionValue, StructField, legacy_validator};
 
 // ========== Enum helpers ==========
 
@@ -207,14 +207,14 @@ pub fn aws_resource_id() -> AttributeType {
         pattern: Some("^[a-z-]+-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_aws_resource_id(s)
                     .map_err(|reason| format!("Invalid resource ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -227,14 +227,14 @@ pub fn vpc_id() -> AttributeType {
         pattern: Some("^vpc-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "vpc")
                     .map_err(|reason| format!("Invalid VPC ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -247,14 +247,14 @@ pub fn subnet_id() -> AttributeType {
         pattern: Some("^subnet-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "subnet")
                     .map_err(|reason| format!("Invalid Subnet ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -267,14 +267,14 @@ pub fn security_group_id() -> AttributeType {
         pattern: Some("^sg-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "sg")
                     .map_err(|reason| format!("Invalid Security Group ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -287,14 +287,14 @@ pub fn internet_gateway_id() -> AttributeType {
         pattern: Some("^igw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "igw")
                     .map_err(|reason| format!("Invalid Internet Gateway ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -307,14 +307,14 @@ pub fn route_table_id() -> AttributeType {
         pattern: Some("^rtb-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "rtb")
                     .map_err(|reason| format!("Invalid Route Table ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -327,14 +327,14 @@ pub fn nat_gateway_id() -> AttributeType {
         pattern: Some("^nat-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "nat")
                     .map_err(|reason| format!("Invalid NAT Gateway ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -347,7 +347,7 @@ pub fn vpc_peering_connection_id() -> AttributeType {
         pattern: Some("^pcx-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "pcx").map_err(|reason| {
                     format!("Invalid VPC Peering Connection ID '{}': {}", s, reason)
@@ -355,7 +355,7 @@ pub fn vpc_peering_connection_id() -> AttributeType {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -368,14 +368,14 @@ pub fn transit_gateway_id() -> AttributeType {
         pattern: Some("^tgw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "tgw")
                     .map_err(|reason| format!("Invalid Transit Gateway ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -388,7 +388,7 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
         pattern: Some("^vpc-cidr-assoc-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "vpc-cidr-assoc").map_err(|reason| {
                     format!("Invalid VPC CIDR Block Association ID '{}': {}", s, reason)
@@ -396,7 +396,7 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -409,14 +409,14 @@ pub fn tgw_route_table_id() -> AttributeType {
         pattern: Some("^tgw-rtb-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "tgw-rtb")
                     .map_err(|reason| format!("Invalid TGW Route Table ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -429,14 +429,14 @@ pub fn vpn_gateway_id() -> AttributeType {
         pattern: Some("^vgw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "vgw")
                     .map_err(|reason| format!("Invalid VPN Gateway ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -454,7 +454,7 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
         pattern: Some("^eigw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "eigw").map_err(|reason| {
                     format!(
@@ -465,7 +465,7 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -478,14 +478,14 @@ pub fn vpc_endpoint_id() -> AttributeType {
         pattern: Some("^vpce-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "vpce")
                     .map_err(|reason| format!("Invalid VPC Endpoint ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -498,14 +498,14 @@ pub fn instance_id() -> AttributeType {
         pattern: Some("^i-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "i")
                     .map_err(|reason| format!("Invalid Instance ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -518,14 +518,14 @@ pub fn network_interface_id() -> AttributeType {
         pattern: Some("^eni-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "eni")
                     .map_err(|reason| format!("Invalid Network Interface ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -539,14 +539,14 @@ pub fn allocation_id() -> AttributeType {
         pattern: Some("^eipalloc-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "eipalloc")
                     .map_err(|reason| format!("Invalid Allocation ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -559,14 +559,14 @@ pub fn prefix_list_id() -> AttributeType {
         pattern: Some("^pl-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "pl")
                     .map_err(|reason| format!("Invalid Prefix List ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -579,14 +579,14 @@ pub fn carrier_gateway_id() -> AttributeType {
         pattern: Some("^cagw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "cagw")
                     .map_err(|reason| format!("Invalid Carrier Gateway ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -599,14 +599,14 @@ pub fn local_gateway_id() -> AttributeType {
         pattern: Some("^lgw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "lgw")
                     .map_err(|reason| format!("Invalid Local Gateway ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -620,14 +620,14 @@ pub fn network_acl_id() -> AttributeType {
         pattern: Some("^acl-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "acl")
                     .map_err(|reason| format!("Invalid Network ACL ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -640,7 +640,7 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
         pattern: Some("^tgw-attach-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "tgw-attach").map_err(|reason| {
                     format!("Invalid Transit Gateway Attachment ID '{}': {}", s, reason)
@@ -648,7 +648,7 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -661,14 +661,14 @@ pub fn flow_log_id() -> AttributeType {
         pattern: Some("^fl-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "fl")
                     .map_err(|reason| format!("Invalid Flow Log ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -681,14 +681,14 @@ pub fn ipam_id() -> AttributeType {
         pattern: Some("^ipam-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "ipam")
                     .map_err(|reason| format!("Invalid IPAM ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -701,7 +701,7 @@ pub fn subnet_route_table_association_id() -> AttributeType {
         pattern: Some("^rtbassoc-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "rtbassoc").map_err(|reason| {
                     format!(
@@ -712,7 +712,7 @@ pub fn subnet_route_table_association_id() -> AttributeType {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -725,14 +725,14 @@ pub fn security_group_rule_id() -> AttributeType {
         pattern: Some("^sgr-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_prefixed_resource_id(s, "sgr")
                     .map_err(|reason| format!("Invalid Security Group Rule ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -759,14 +759,14 @@ pub fn iam_role_id() -> AttributeType {
         pattern: Some("^AROA[A-Z0-9]+$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_iam_role_id(s)
                     .map_err(|reason| format!("Invalid IAM Role ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -795,14 +795,14 @@ pub fn aws_account_id() -> AttributeType {
         pattern: Some("^\\d{12}$".to_string()),
         length: Some((Some(12), Some(12))),
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_aws_account_id(s)
                     .map_err(|reason| format!("Invalid AWS Account ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -934,13 +934,13 @@ pub fn arn() -> AttributeType {
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):[^:]+:.*$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_arn(s).map_err(|reason| format!("Invalid ARN '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -954,14 +954,14 @@ pub fn iam_role_arn() -> AttributeType {
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$".to_string()),
         length: None,
         base: Box::new(arn()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_iam_arn(s, "role/")
                     .map_err(|reason| format!("Invalid IAM Role ARN '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -975,14 +975,14 @@ pub fn iam_policy_arn() -> AttributeType {
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
         length: None,
         base: Box::new(arn()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_iam_arn(s, "policy/")
                     .map_err(|reason| format!("Invalid IAM Policy ARN '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -996,14 +996,14 @@ pub fn kms_key_arn() -> AttributeType {
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:key/.+$".to_string()),
         length: None,
         base: Box::new(arn()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_service_arn(s, "kms", Some("key/"))
                     .map_err(|reason| format!("Invalid KMS Key ARN '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -1066,14 +1066,14 @@ pub fn kms_key_id() -> AttributeType {
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_kms_key_id(s)
                     .map_err(|reason| format!("Invalid KMS key identifier '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -1102,14 +1102,14 @@ pub fn ipam_pool_id() -> AttributeType {
         pattern: Some("^ipam-pool-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_ipam_pool_id(s)
                     .map_err(|reason| format!("Invalid IPAM Pool ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -1211,14 +1211,14 @@ pub fn availability_zone_id() -> AttributeType {
         pattern: Some("^[a-z]+[0-9]+-az[0-9]+$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_availability_zone_id(s)
                     .map_err(|reason| format!("Invalid availability zone ID '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -1264,7 +1264,7 @@ fn iam_policy_effect() -> AttributeType {
         pattern: Some("^(Allow|Deny)$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 match s.as_str() {
                     "Allow" | "Deny" => Ok(()),
@@ -1276,7 +1276,7 @@ fn iam_policy_effect() -> AttributeType {
             } else {
                 Err(format!("Expected string, got {:?}", value))
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }
@@ -1290,7 +1290,7 @@ fn iam_policy_version() -> AttributeType {
         pattern: Some("^(2012-10-17|2008-10-17)$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 match s.as_str() {
                     "2012-10-17" | "2008-10-17" => Ok(()),
@@ -1302,7 +1302,7 @@ fn iam_policy_version() -> AttributeType {
             } else {
                 Err(format!("Expected string, got {:?}", value))
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -715,6 +715,9 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     if needs_types {
         schema_imports.push("types");
     }
+    if has_ranged_ints {
+        schema_imports.push("legacy_validator");
+    }
     let schema_imports_str = schema_imports.join(", ");
 
     code.push_str(&format!(
@@ -1104,7 +1107,7 @@ fn resolve_type(
                          \x20               pattern: None,\n\
                          \x20               length: {},\n\
                          \x20               base: Box::new(AttributeType::Int),\n\
-                         \x20               validate: {},\n\
+                         \x20               validate: legacy_validator({}),\n\
                          \x20               namespace: None,\n\
                          \x20               to_dsl: None,\n\
                          \x20           }}",

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -13,7 +13,7 @@ use carina_core::resource::{
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
     OperationConfig as CoreOperationConfig, ResourceSchema as CoreResourceSchema,
-    StructField as CoreStructField,
+    StructField as CoreStructField, noop_validator,
 };
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
@@ -131,12 +131,11 @@ pub fn core_to_proto_lifecycle(l: &CoreLifecycle) -> ProtoLifecycle {
 // -- proto_to_core_resource (reverse of core_to_proto_resource) --
 
 pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
-    use carina_core::resource::Expr;
     let mut resource = CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name);
     resource.attributes = r
         .attributes
         .iter()
-        .map(|(k, v)| (k.clone(), Expr(proto_to_core_value(v))))
+        .map(|(k, v)| (k.clone(), proto_to_core_value(v)))
         .collect();
     resource.lifecycle = CoreLifecycle {
         force_delete: r.lifecycle.force_delete,
@@ -192,7 +191,7 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             pattern: None,
             length: None,
             base: Box::new(proto_to_core_attribute_type(base)),
-            validate: |_| Ok(()),
+            validate: noop_validator(),
             namespace: namespace.clone(),
             to_dsl: None,
         },

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -180,12 +180,11 @@ mod tests {
     use super::*;
 
     fn make_test_resource(attrs: Vec<(&str, &str)>) -> Resource {
-        use carina_core::resource::Expr;
         let mut resource = Resource::new("route53.RecordSet", "test");
         for (k, v) in attrs {
             resource
                 .attributes
-                .insert(k.to_string(), Expr(Value::String(v.to_string())));
+                .insert(k.to_string(), Value::String(v.to_string()));
         }
         resource
     }

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -6,7 +6,9 @@
 
 use super::AwsSchemaConfig;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
+};
 
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
 
@@ -74,7 +76,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                         pattern: None,
                         length: None,
                         base: Box::new(AttributeType::Int),
-                        validate: validate_from_port_range,
+                        validate: legacy_validator(validate_from_port_range),
                         namespace: None,
                         to_dsl: None,
                     },
@@ -135,7 +137,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                         pattern: None,
                         length: None,
                         base: Box::new(AttributeType::Int),
-                        validate: validate_to_port_range,
+                        validate: legacy_validator(validate_to_port_range),
                         namespace: None,
                         to_dsl: None,
                     },

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -6,7 +6,9 @@
 
 use super::AwsSchemaConfig;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
+};
 
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
 
@@ -66,7 +68,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
-                validate: validate_from_port_range,
+                validate: legacy_validator(validate_from_port_range),
                 namespace: None,
                 to_dsl: None,
             })
@@ -122,7 +124,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
-                validate: validate_to_port_range,
+                validate: legacy_validator(validate_to_port_range),
                 namespace: None,
                 to_dsl: None,
             })

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -8,7 +8,9 @@ use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator, types,
+};
 
 const VALID_HOSTNAME_TYPE: &[&str] = &["ip-name", "resource-name"];
 
@@ -89,7 +91,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 pattern: None,
                 length: Some((Some(0), Some(32))),
                 base: Box::new(AttributeType::Int),
-                validate: validate_ipv4_netmask_length_range,
+                validate: legacy_validator(validate_ipv4_netmask_length_range),
                 namespace: None,
                 to_dsl: None,
             })
@@ -121,7 +123,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 pattern: None,
                 length: Some((Some(0), Some(128))),
                 base: Box::new(AttributeType::Int),
-                validate: validate_ipv6_netmask_length_range,
+                validate: legacy_validator(validate_ipv6_netmask_length_range),
                 namespace: None,
                 to_dsl: None,
             })

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -8,7 +8,9 @@ use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
+};
 
 const VALID_INSTANCE_TENANCY: &[&str] = &["dedicated", "default", "host"];
 
@@ -71,7 +73,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
                 pattern: None,
                 length: Some((Some(0), Some(32))),
                 base: Box::new(AttributeType::Int),
-                validate: validate_ipv4_netmask_length_range,
+                validate: legacy_validator(validate_ipv4_netmask_length_range),
                 namespace: None,
                 to_dsl: None,
             })

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -8,7 +8,7 @@ use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
 fn validate_max_session_duration_range(value: &Value) -> Result<(), String> {
     if let Value::Int(n) = value {
@@ -49,7 +49,7 @@ pub fn iam_role_config() -> AwsSchemaConfig {
                 pattern: None,
                 length: Some((Some(3600), Some(43200))),
                 base: Box::new(AttributeType::Int),
-                validate: validate_max_session_duration_range,
+                validate: legacy_validator(validate_max_session_duration_range),
                 namespace: None,
                 to_dsl: None,
             })

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -6,7 +6,9 @@
 
 use super::AwsSchemaConfig;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
+};
 
 const VALID_TYPE: &[&str] = &[
     "A", "AAAA", "CAA", "CNAME", "DS", "HTTPS", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF", "SRV",
@@ -63,7 +65,7 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
                 pattern: None,
                 length: Some((Some(0), Some(2147483647))),
                 base: Box::new(AttributeType::Int),
-                validate: validate_ttl_range,
+                validate: legacy_validator(validate_ttl_range),
                 namespace: None,
                 to_dsl: None,
             })

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -8,7 +8,7 @@ pub use carina_aws_types::*;
 use std::collections::HashMap;
 
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeType, ResourceSchema, legacy_validator};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 
 /// AWS schema configuration
@@ -36,7 +36,7 @@ pub fn aws_region() -> AttributeType {
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_enum_namespace(s, "Region", "aws")
                     .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
@@ -54,7 +54,7 @@ pub fn aws_region() -> AttributeType {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: Some("aws".to_string()),
         to_dsl: Some(|s: &str| s.replace('-', "_")),
     }
@@ -71,7 +71,7 @@ pub fn availability_zone() -> AttributeType {
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 validate_enum_namespace(s, "AvailabilityZone", "aws")
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
@@ -82,7 +82,7 @@ pub fn availability_zone() -> AttributeType {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: Some("aws".to_string()),
         to_dsl: Some(|s: &str| s.replace('-', "_")),
     }
@@ -102,7 +102,7 @@ pub fn s3_grantee() -> AttributeType {
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 if s.is_empty() {
                     return Err("Grantee specification must not be empty".to_string());
@@ -125,7 +125,7 @@ pub fn s3_grantee() -> AttributeType {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     }


### PR DESCRIPTION
## Summary

- Wraps every `validate: <expr>` literal in `AttributeType::Custom` with `legacy_validator(...)` (or `noop_validator()` for placeholders) so the crate compiles against the new `Arc<dyn Fn(&Value) -> Result<(), TypeError> + Send + Sync>` shape introduced by carina-rs/carina#2316.
- Updates the codegen template in ``carina-codegen-aws`` and regenerates 6 affected schemas under ``carina-provider-aws/src/schemas/generated/``.
- Bumps Cargo.lock carina dep pin to ``c9e54236`` (the merged PR 1).

## Bundled drift fix

The dep bump exposed an unrelated upstream change: ``carina_core::resource::Expr`` was removed (``Resource.attributes`` is now ``IndexMap<String, Value>`` directly). Two callers were wrapping ``Value`` in ``Expr(...)`` — both wraps are dropped. Pure mechanical, no behavior change. Bundling avoids a no-op intermediate PR that does nothing but unblock this one.

## PR 2 of 3

This is PR 2 of the 3-PR train for carina-rs/carina#2217. PR 3 (``carina-provider-awscc``) follows. Refs carina-rs/carina#2217.

## Test plan

- [x] ``cargo check --all-targets`` clean
- [x] ``cargo test`` — all 294 tests pass across crates
- [x] ``cargo clippy --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --check`` clean
- [x] ``cargo build -p carina-provider-aws --target wasm32-wasip2 --release`` succeeds
- [x] ``./scripts/generate-schemas-smithy.sh`` is idempotent (re-running produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)