### PR TITLE
refactor: migrate to SchemaRegistry API (carina#2330)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#c9e54236d1155915f08069476a159aa45ca73ac7"
+source = "git+https://github.com/carina-rs/carina#8dc3a8f0381dd2fc8c7b0c60bad9929974be3ee9"
 dependencies = [
  "argon2",
  "futures",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#c9e54236d1155915f08069476a159aa45ca73ac7"
+source = "git+https://github.com/carina-rs/carina#8dc3a8f0381dd2fc8c7b0c60bad9929974be3ee9"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#c9e54236d1155915f08069476a159aa45ca73ac7"
+source = "git+https://github.com/carina-rs/carina#8dc3a8f0381dd2fc8c7b0c60bad9929974be3ee9"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -804,7 +804,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         cf_type_name(res.name),
         res.name,
         res.has_tags,
-        namespace,
+        res.name,
     ));
 
     // Description from read structure (or create input for multi-op resources)
@@ -2568,7 +2568,6 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
 /// Generate Rust schema code for a data source.
 fn generate_data_source(ds: &resource_defs::DataSourceDef, model: &SmithyModel) -> Result<String> {
     let ns = ds.service_namespace;
-    let namespace = format!("aws.{}", ds.name);
     let config_fn = format!("{}_config", module_name(ds.name));
     let cf_type = cf_type_name(ds.name);
 
@@ -2680,7 +2679,7 @@ fn generate_data_source(ds: &resource_defs::DataSourceDef, model: &SmithyModel) 
         config_fn,
         cf_type,
         ds.name,
-        namespace,
+        ds.name,
     ));
 
     // Emit attributes.

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -13,14 +13,14 @@ use carina_core::resource::{
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
     OperationConfig as CoreOperationConfig, ResourceSchema as CoreResourceSchema,
-    StructField as CoreStructField, noop_validator,
+    SchemaKind as CoreSchemaKind, StructField as CoreStructField, noop_validator,
 };
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
     LifecycleConfig as ProtoLifecycle, OperationConfig as ProtoOperationConfig,
     Resource as ProtoResource, ResourceId as ProtoResourceId,
-    ResourceSchema as ProtoResourceSchema, State as ProtoState, StructField as ProtoStructField,
-    Value as ProtoValue,
+    ResourceSchema as ProtoResourceSchema, SchemaKind as ProtoSchemaKind, State as ProtoState,
+    StructField as ProtoStructField, Value as ProtoValue,
 };
 
 // -- ResourceId --
@@ -237,7 +237,7 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
             .collect(),
         description: s.description.clone(),
         validator: None,
-        data_source: s.data_source,
+        kind: proto_to_core_schema_kind(s.kind),
         name_attribute: s.name_attribute.clone(),
         force_replace: s.force_replace,
         operation_config: s.operation_config.as_ref().map(|c| CoreOperationConfig {
@@ -247,6 +247,20 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
             create_max_retries: c.create_max_retries,
         }),
         exclusive_required: s.exclusive_required.clone(),
+    }
+}
+
+fn proto_to_core_schema_kind(k: ProtoSchemaKind) -> CoreSchemaKind {
+    match k {
+        ProtoSchemaKind::Managed => CoreSchemaKind::Managed,
+        ProtoSchemaKind::DataSource => CoreSchemaKind::DataSource,
+    }
+}
+
+fn core_to_proto_schema_kind(k: CoreSchemaKind) -> ProtoSchemaKind {
+    match k {
+        CoreSchemaKind::Managed => ProtoSchemaKind::Managed,
+        CoreSchemaKind::DataSource => ProtoSchemaKind::DataSource,
     }
 }
 
@@ -331,7 +345,7 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
             .map(|(k, v)| (k.clone(), core_to_proto_attribute_schema(v)))
             .collect(),
         description: s.description.clone(),
-        data_source: s.data_source,
+        kind: core_to_proto_schema_kind(s.kind),
         name_attribute: s.name_attribute.clone(),
         force_replace: s.force_replace,
         operation_config: s.operation_config.as_ref().map(|c| ProtoOperationConfig {

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -6,7 +6,7 @@ use carina_provider_protocol::types as proto;
 
 use carina_core::provider::{Provider, ProviderError as CoreProviderError, ProviderNormalizer};
 use carina_core::resource::Value as CoreValue;
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 
 use carina_provider_aws::AwsNormalizer;
 use carina_provider_aws::AwsProvider;
@@ -260,12 +260,12 @@ impl CarinaProvider for AwsProcessProvider {
             .iter()
             .map(|(k, v)| (k.clone(), convert::proto_to_core_value(v)))
             .collect();
-        let core_schemas: HashMap<String, ResourceSchema> = proto_schemas
-            .iter()
-            .map(|s| (s.resource_type.clone(), convert::proto_to_core_schema(s)))
-            .collect();
+        let mut registry = SchemaRegistry::new();
+        for s in proto_schemas {
+            registry.insert("aws", convert::proto_to_core_schema(s));
+        }
         self.normalizer
-            .merge_default_tags(&mut core_resources, &core_tags, &core_schemas);
+            .merge_default_tags(&mut core_resources, &core_tags, &registry);
         *resources = core_resources
             .iter()
             .map(convert::core_to_proto_resource)
@@ -295,7 +295,7 @@ mod tests {
         let schemas = provider.schemas();
         let bucket = schemas
             .iter()
-            .find(|s| s.resource_type == "aws.s3.Bucket")
+            .find(|s| s.resource_type == "s3.Bucket")
             .expect("s3.bucket schema should exist");
         assert!(
             bucket
@@ -313,7 +313,7 @@ mod tests {
         if let Some(untagged) = configs.iter().find(|c| !c.has_tags) {
             let schema = schemas
                 .iter()
-                .find(|s| s.resource_type == format!("aws.{}", untagged.resource_type_name))
+                .find(|s| s.resource_type == untagged.resource_type_name)
                 .expect("untagged schema should exist");
             assert!(
                 !schema
@@ -329,14 +329,12 @@ mod tests {
         let provider = AwsProcessProvider::new();
         let schemas = provider.schemas();
         assert!(
-            schemas.iter().any(|s| s.resource_type == "aws.iam.Role"),
-            "aws.iam.Role schema should be registered"
+            schemas.iter().any(|s| s.resource_type == "iam.Role"),
+            "iam.Role schema should be registered"
         );
         assert!(
-            schemas
-                .iter()
-                .any(|s| s.resource_type == "aws.logs.LogGroup"),
-            "aws.logs.LogGroup schema should be registered"
+            schemas.iter().any(|s| s.resource_type == "logs.LogGroup"),
+            "logs.LogGroup schema should be registered"
         );
     }
 

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 
 use carina_core::provider::{self, ProviderNormalizer};
 use carina_core::resource::{Resource, Value};
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 
 /// Schema extension for the AWS provider.
 ///
@@ -22,9 +22,9 @@ impl ProviderNormalizer for AwsNormalizer {
         &self,
         resources: &mut [Resource],
         default_tags: &IndexMap<String, Value>,
-        schemas: &HashMap<String, ResourceSchema>,
+        registry: &SchemaRegistry,
     ) {
-        provider::merge_default_tags_for_provider("aws", resources, default_tags, schemas);
+        provider::merge_default_tags_for_provider("aws", resources, default_tags, registry);
     }
 }
 
@@ -42,13 +42,9 @@ pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
         }
 
         // Find the matching schema config
-        let config = configs.iter().find(|c| {
-            c.schema
-                .resource_type
-                .strip_prefix("aws.")
-                .map(|t| t == resource.id.resource_type)
-                .unwrap_or(false)
-        });
+        let config = configs
+            .iter()
+            .find(|c| c.schema.resource_type == resource.id.resource_type);
         let config = match config {
             Some(c) => c,
             None => continue,
@@ -78,13 +74,9 @@ pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
 /// to match the resolved DSL values.
 pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMap<String, Value>) {
     let configs = crate::schemas::generated::configs();
-    let config = configs.iter().find(|c| {
-        c.schema
-            .resource_type
-            .strip_prefix("aws.")
-            .map(|t| t == resource_type)
-            .unwrap_or(false)
-    });
+    let config = configs
+        .iter()
+        .find(|c| c.schema.resource_type == resource_type);
     let config = match config {
         Some(c) => c,
         None => return,

--- a/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
@@ -15,7 +15,7 @@ pub fn ec2_egress_only_internet_gateway_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::EgressOnlyInternetGateway",
         resource_type_name: "ec2.EgressOnlyInternetGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.EgressOnlyInternetGateway")
+        schema: ResourceSchema::new("ec2.EgressOnlyInternetGateway")
             .with_description("Describes an egress-only internet gateway.")
             .attribute(
                 AttributeSchema::new("vpc_id", super::vpc_id())

--- a/carina-provider-aws/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/eip.rs
@@ -17,7 +17,7 @@ pub fn ec2_eip_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::EIP",
         resource_type_name: "ec2.Eip",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.Eip")
+        schema: ResourceSchema::new("ec2.Eip")
         .with_description("Describes an Elastic IP address, or a carrier IP address.")
         .attribute(
             AttributeSchema::new("address", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -28,7 +28,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::FlowLog",
         resource_type_name: "ec2.FlowLog",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.FlowLog")
+        schema: ResourceSchema::new("ec2.FlowLog")
         .with_description("Describes a flow log.")
         .attribute(
             AttributeSchema::new("deliver_logs_permission_arn", super::iam_role_arn())

--- a/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
@@ -15,7 +15,7 @@ pub fn ec2_internet_gateway_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::InternetGateway",
         resource_type_name: "ec2.InternetGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.InternetGateway")
+        schema: ResourceSchema::new("ec2.InternetGateway")
         .with_description("Describes an internet gateway.")
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())

--- a/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
@@ -19,7 +19,7 @@ pub fn ec2_nat_gateway_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::NatGateway",
         resource_type_name: "ec2.NatGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.NatGateway")
+        schema: ResourceSchema::new("ec2.NatGateway")
         .with_description("Describes a NAT gateway.")
         .attribute(
             AttributeSchema::new("allocation_id", super::allocation_id())

--- a/carina-provider-aws/src/schemas/generated/ec2/route.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route.rs
@@ -13,7 +13,7 @@ pub fn ec2_route_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::Route",
         resource_type_name: "ec2.Route",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.Route")
+        schema: ResourceSchema::new("ec2.Route")
         .with_description("Describes a route in a route table.")
         .attribute(
             AttributeSchema::new("destination_cidr_block", types::ipv4_cidr())

--- a/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
@@ -15,7 +15,7 @@ pub fn ec2_route_table_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::RouteTable",
         resource_type_name: "ec2.RouteTable",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.RouteTable")
+        schema: ResourceSchema::new("ec2.RouteTable")
             .with_description("Describes a route table.")
             .attribute(
                 AttributeSchema::new("vpc_id", super::vpc_id())

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
@@ -15,7 +15,7 @@ pub fn ec2_security_group_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroup",
         resource_type_name: "ec2.SecurityGroup",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.SecurityGroup")
+        schema: ResourceSchema::new("ec2.SecurityGroup")
         .with_description("Describes a security group.")
         .attribute(
             AttributeSchema::new("description", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -42,7 +42,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupEgress",
         resource_type_name: "ec2.SecurityGroupEgress",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.SecurityGroupEgress")
+        schema: ResourceSchema::new("ec2.SecurityGroupEgress")
             .with_description("Describes a security group rule.")
             .attribute(
                 AttributeSchema::new("cidr_ip", types::ipv4_cidr())

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -42,7 +42,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupIngress",
         resource_type_name: "ec2.SecurityGroupIngress",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.SecurityGroupIngress")
+        schema: ResourceSchema::new("ec2.SecurityGroupIngress")
         .with_description("Describes a security group rule.")
         .attribute(
             AttributeSchema::new("cidr_ip", types::ipv4_cidr())

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -44,7 +44,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::Subnet",
         resource_type_name: "ec2.Subnet",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.Subnet")
+        schema: ResourceSchema::new("ec2.Subnet")
         .with_description("Describes a subnet.")
         .attribute(
             AttributeSchema::new("assign_ipv6_address_on_creation", AttributeType::Bool)

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet_route_table_association.rs
@@ -13,7 +13,7 @@ pub fn ec2_subnet_route_table_association_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SubnetRouteTableAssociation",
         resource_type_name: "ec2.SubnetRouteTableAssociation",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.SubnetRouteTableAssociation")
+        schema: ResourceSchema::new("ec2.SubnetRouteTableAssociation")
         .with_description("Describes an association between a route table and a subnet or gateway.")
         .attribute(
             AttributeSchema::new("public_ipv4_pool", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
@@ -29,7 +29,7 @@ pub fn ec2_transit_gateway_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::TransitGateway",
         resource_type_name: "ec2.TransitGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.TransitGateway")
+        schema: ResourceSchema::new("ec2.TransitGateway")
         .with_description("Describes a transit gateway.")
         .attribute(
             AttributeSchema::new("description", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -23,7 +23,7 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::TransitGatewayAttachment",
         resource_type_name: "ec2.TransitGatewayAttachment",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.TransitGatewayAttachment")
+        schema: ResourceSchema::new("ec2.TransitGatewayAttachment")
         .with_description("Describes a VPC attachment.")
         .attribute(
             AttributeSchema::new("options", AttributeType::Struct {

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -32,7 +32,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPC",
         resource_type_name: "ec2.Vpc",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.Vpc")
+        schema: ResourceSchema::new("ec2.Vpc")
         .with_description("Describes a VPC.")
         .attribute(
             AttributeSchema::new("cidr_block", types::ipv4_cidr())

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -23,7 +23,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPCEndpoint",
         resource_type_name: "ec2.VpcEndpoint",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.VpcEndpoint")
+        schema: ResourceSchema::new("ec2.VpcEndpoint")
         .with_description("Describes a VPC endpoint.")
         .attribute(
             AttributeSchema::new("policy_document", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_gateway_attachment.rs
@@ -13,7 +13,7 @@ pub fn ec2_vpc_gateway_attachment_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPCGatewayAttachment",
         resource_type_name: "ec2.VpcGatewayAttachment",
         has_tags: false,
-        schema: ResourceSchema::new("aws.ec2.VpcGatewayAttachment")
+        schema: ResourceSchema::new("ec2.VpcGatewayAttachment")
             .attribute(
                 AttributeSchema::new("internet_gateway_id", super::internet_gateway_id())
                     .required()

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -15,7 +15,7 @@ pub fn ec2_vpc_peering_connection_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPCPeeringConnection",
         resource_type_name: "ec2.VpcPeeringConnection",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.VpcPeeringConnection")
+        schema: ResourceSchema::new("ec2.VpcPeeringConnection")
         .with_description("Describes a VPC peering connection.")
         .attribute(
             AttributeSchema::new("peer_owner_id", super::aws_account_id())

--- a/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
@@ -17,7 +17,7 @@ pub fn ec2_vpn_gateway_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPNGateway",
         resource_type_name: "ec2.VpnGateway",
         has_tags: true,
-        schema: ResourceSchema::new("aws.ec2.VpnGateway")
+        schema: ResourceSchema::new("ec2.VpnGateway")
         .with_description("Describes a virtual private gateway.")
         .attribute(
             AttributeSchema::new("amazon_side_asn", AttributeType::Int)

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -28,7 +28,7 @@ pub fn iam_role_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::IAM::Role",
         resource_type_name: "iam.Role",
         has_tags: true,
-        schema: ResourceSchema::new("aws.iam.Role")
+        schema: ResourceSchema::new("iam.Role")
         .with_description("Contains information about an IAM role. This structure is returned as a response element in several API operations that interact with roles.")
         .attribute(
             AttributeSchema::new("assume_role_policy_document", super::iam_policy_document())

--- a/carina-provider-aws/src/schemas/generated/identitystore/user.rs
+++ b/carina-provider-aws/src/schemas/generated/identitystore/user.rs
@@ -13,7 +13,7 @@ pub fn identitystore_user_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::IdentityStore::User",
         resource_type_name: "identitystore.User",
         has_tags: false,
-        schema: ResourceSchema::new("aws.identitystore.User")
+        schema: ResourceSchema::new("identitystore.User")
             .as_data_source()
             .attribute(
                 AttributeSchema::new("identity_store_id", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-aws/src/schemas/generated/logs/log_group.rs
@@ -17,7 +17,7 @@ pub fn logs_log_group_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::Logs::LogGroup",
         resource_type_name: "logs.LogGroup",
         has_tags: true,
-        schema: ResourceSchema::new("aws.logs.LogGroup")
+        schema: ResourceSchema::new("logs.LogGroup")
         .with_description("Represents a log group.")
         .attribute(
             AttributeSchema::new("deletion_protection_enabled", AttributeType::Bool)

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -21,7 +21,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::Organizations::Account",
         resource_type_name: "organizations.Account",
         has_tags: true,
-        schema: ResourceSchema::new("aws.organizations.Account")
+        schema: ResourceSchema::new("organizations.Account")
         .with_description("Contains information about an Amazon Web Services account that is a member of an organization.")
         .attribute(
             AttributeSchema::new("account_name", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -15,7 +15,7 @@ pub fn organizations_organization_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::Organizations::Organization",
         resource_type_name: "organizations.Organization",
         has_tags: false,
-        schema: ResourceSchema::new("aws.organizations.Organization")
+        schema: ResourceSchema::new("organizations.Organization")
         .with_description("Contains details about an organization. An organization is a collection of accounts that are centrally managed together using consolidated billing, organized hierarchically with organizational units (...")
         .attribute(
             AttributeSchema::new("feature_set", AttributeType::StringEnum {

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -33,7 +33,7 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::Route53::RecordSet",
         resource_type_name: "route53.RecordSet",
         has_tags: false,
-        schema: ResourceSchema::new("aws.route53.RecordSet")
+        schema: ResourceSchema::new("route53.RecordSet")
         .with_description("Information about the resource record set to create or delete.")
         .attribute(
             AttributeSchema::new("alias_target", AttributeType::Struct {

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -32,7 +32,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::S3::Bucket",
         resource_type_name: "s3.Bucket",
         has_tags: true,
-        schema: ResourceSchema::new("aws.s3.Bucket")
+        schema: ResourceSchema::new("s3.Bucket")
         .attribute(
             AttributeSchema::new("acl", AttributeType::StringEnum {
                 name: "ACL".to_string(),

--- a/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
+++ b/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
@@ -13,7 +13,7 @@ pub fn sts_caller_identity_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::STS::CallerIdentity",
         resource_type_name: "sts.CallerIdentity",
         has_tags: false,
-        schema: ResourceSchema::new("aws.sts.CallerIdentity")
+        schema: ResourceSchema::new("sts.CallerIdentity")
         .as_data_source()
         .attribute(
             AttributeSchema::new("account_id", super::aws_account_id())


### PR DESCRIPTION
## Summary

Migrate the AWS provider from the legacy `HashMap<String, ResourceSchema>` + `format_schema_key` model to the new `SchemaRegistry` API introduced in [carina#2330](https://github.com/carina-rs/carina/pull/2330).

## What changed

- `AwsNormalizer::merge_default_tags` now takes `&SchemaRegistry` and forwards to `carina_core::provider::merge_default_tags_for_provider` with the new signature.
- `AwsProcessProvider::merge_default_tags` (the WIT plugin side) builds a `SchemaRegistry` via `insert("aws", schema)` from the proto schemas the host passes in, replacing the old `HashMap<String, ResourceSchema>`.
- `convert::{proto_to_core_schema, core_to_proto_schema}` translate the renamed `kind: SchemaKind` field instead of the removed `data_source: bool`.
- Codegen (`carina-codegen-aws`) now emits `ResourceSchema::new("<service>.<TypeName>")` (un-prefixed) for both managed resources and data sources. The provider name (`"aws"`) is applied separately by the host via `SchemaRegistry::insert("aws", schema)`. Enum `namespace:` fields still carry the `aws.` prefix because they are DSL-visible identifiers (`aws.s3.Bucket.VersioningStatus.Enabled`).
- Regenerated `carina-provider-aws/src/schemas/generated/**` to match the new template.
- Normalizer schema lookups dropped the `strip_prefix("aws.")` matching, since `resource_type` is already un-prefixed.
- Updated `schemas_include_*` tests in `main.rs` to match the new `resource_type` shape (e.g. `"s3.Bucket"`, not `"aws.s3.Bucket"`).

## Verify

- `cargo check --workspace` clean
- `cargo nextest run --workspace` — 294 / 294 passing
- `cargo test --workspace --doc` clean (no doctests)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` clean
- Pre-commit hooks (fmt + clippy) pass

## Related

- Closes #161
- Upstream: [carina#2330](https://github.com/carina-rs/carina/pull/2330) (introduces `SchemaRegistry`)
- Upstream parent: [carina#2328](https://github.com/carina-rs/carina/issues/2328)