### PR TITLE
feat(provider): DataSourceLookups trait + s3.Bucket lookup (Phases 5+6+7)

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -286,7 +286,8 @@ fn main() -> Result<()> {
         }
         "provider" => {
             let manual_methods = scan_manual_methods(&args.output_dir.join("services"));
-            let code = generate_provider_code(&all_resources, &models, &manual_methods);
+            let code =
+                generate_provider_code(&all_resources, &all_data_sources, &models, &manual_methods);
             let output_path = args.output_dir.join("provider_generated.rs");
             std::fs::write(&output_path, &code)
                 .with_context(|| format!("Failed to write {}", output_path.display()))?;
@@ -1674,6 +1675,7 @@ fn scan_manual_methods(services_dir: &std::path::Path) -> std::collections::Hash
 /// Uses Smithy models to resolve types for read/write helper generation.
 fn generate_provider_code(
     all_resources: &[ResourceDef],
+    all_data_sources: &[resource_defs::DataSourceDef],
     models: &HashMap<&str, SmithyModel>,
     manual_methods: &std::collections::HashSet<String>,
 ) -> String {
@@ -1686,7 +1688,7 @@ fn generate_provider_code(
          //! DO NOT EDIT MANUALLY - regenerate with:\n\
          //!   ./carina-provider-aws/scripts/generate-provider.sh\n\n\
          use std::collections::HashMap;\n\n\
-         use carina_core::provider::{ProviderError, ProviderResult};\n\
+         use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};\n\
          use carina_core::resource::{Resource, ResourceId, State, Value};\n\
          use carina_core::utils::extract_enum_value;\n\n\
          use crate::AwsProvider;\n\
@@ -1750,7 +1752,7 @@ fn generate_provider_code(
                  \x20       from: &State,\n\
                  \x20       to: Resource,\n\
                  \x20   ) -> ProviderResult<State> {{\n\
-                 \x20       self.apply_ec2_tags(&id, identifier, &to.attributes, Some(&from.attributes))\n\
+                 \x20       self.apply_ec2_tags(&id, identifier, &to.resolved_attributes(), Some(&from.attributes))\n\
                  \x20           .await?;\n\
                  \x20       self.{}(&id, Some(identifier)).await\n\
                  \x20   }}\n\n",
@@ -2197,7 +2199,63 @@ fn generate_provider_code(
         code.push_str("\x20   }\n\n");
     }
 
-    code.push_str("}\n");
+    code.push_str("}\n\n");
+
+    // ===== DataSourceLookups trait =====
+    code.push_str("// ===== Generated DataSourceLookups Trait =====\n\n");
+    code.push_str(
+        "/// One method per `DataSourceDef`. AwsProvider must implement all of\n\
+         /// them; the codegen-emitted dispatcher below routes by\n\
+         /// `resource.id.resource_type`.\n",
+    );
+    code.push_str("pub trait DataSourceLookups {\n");
+    for ds in all_data_sources {
+        let module = module_name(ds.name);
+        code.push_str(&format!(
+            "\x20   fn read_{}_data_source(\n\
+             \x20       &self,\n\
+             \x20       resource: &Resource,\n\
+             \x20   ) -> BoxFuture<'_, ProviderResult<State>>;\n\n",
+            module,
+        ));
+    }
+    code.push_str("}\n\n");
+
+    // ===== read_data_source dispatcher =====
+    code.push_str("// ===== Generated read_data_source dispatcher =====\n\n");
+    code.push_str(
+        "/// Routes `Provider::read_data_source` calls to the matching\n\
+         /// `DataSourceLookups` trait method. The default arm refuses\n\
+         /// to drop user-supplied inputs silently.\n",
+    );
+    code.push_str(
+        "pub(crate) fn dispatch_read_data_source<'a>(\n\
+         \x20   provider: &'a AwsProvider,\n\
+         \x20   resource: &'a Resource,\n\
+         ) -> BoxFuture<'a, ProviderResult<State>> {\n\
+         \x20   match resource.id.resource_type.as_str() {\n",
+    );
+    for ds in all_data_sources {
+        let module = module_name(ds.name);
+        code.push_str(&format!(
+            "\x20       \"{}\" => provider.read_{}_data_source(resource),\n",
+            ds.name, module,
+        ));
+    }
+    code.push_str(
+        "\x20       _ => {\n\
+         \x20           let id = resource.id.clone();\n\
+         \x20           let resource_type = resource.id.resource_type.clone();\n\
+         \x20           Box::pin(async move {\n\
+         \x20               Err(ProviderError::new(format!(\n\
+         \x20                   \"aws provider does not implement read_data_source for '{}'\",\n\
+         \x20                   resource_type\n\
+         \x20               )).for_resource(id))\n\
+         \x20           })\n\
+         \x20       }\n\
+         \x20   }\n\
+         }\n",
+    );
 
     code
 }

--- a/carina-provider-aws/src/data_source_lookups.rs
+++ b/carina-provider-aws/src/data_source_lookups.rs
@@ -1,0 +1,49 @@
+//! `DataSourceLookups` impl on `AwsProvider`.
+//!
+//! Each method delegates to a `do_read_<name>_data_source` inherent
+//! method that lives next to the rest of that service's hand-written
+//! code (under `services/<service>/<resource>.rs`). Splitting it this
+//! way keeps Rust's "one impl Trait for Type" rule happy while letting
+//! the lookup logic stay near its owning service.
+
+use carina_core::provider::{BoxFuture, ProviderResult};
+use carina_core::resource::{Resource, State};
+
+use crate::AwsProvider;
+use crate::provider_generated::DataSourceLookups;
+
+impl DataSourceLookups for AwsProvider {
+    fn read_sts_caller_identity_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        self.do_read_sts_caller_identity_data_source(resource)
+    }
+
+    fn read_identitystore_user_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        self.do_read_identitystore_user_data_source(resource)
+    }
+
+    fn read_s3_bucket_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        self.do_read_s3_bucket_data_source(resource)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Compile-time assertion: `AwsProvider` implements every method
+    /// declared on the codegen-generated `DataSourceLookups` trait.
+    /// If `carina-codegen-aws` adds a new `DataSourceDef`, this fails
+    /// until the corresponding `do_read_..._data_source` is wired.
+    #[test]
+    fn aws_provider_implements_all_data_source_lookups() {
+        fn assert_impl<T: crate::provider_generated::DataSourceLookups>() {}
+        assert_impl::<crate::AwsProvider>();
+    }
+}

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! AWS Provider implementation
 
+mod data_source_lookups;
 mod ec2_security_group_rules;
 mod ec2_tags;
 mod factory;

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -84,7 +84,6 @@ impl Provider for AwsProvider {
                     self.read_route53_record_set(&id, identifier.as_deref())
                         .await
                 }
-                "sts.CallerIdentity" => self.read_sts_caller_identity(&id).await,
                 _ => Err(ProviderError::new(format!(
                     "Unknown resource type: {}",
                     id.resource_type
@@ -104,38 +103,11 @@ impl Provider for AwsProvider {
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
         let resource = resource.clone();
         Box::pin(async move {
-            let mut state = match resource.id.resource_type.as_str() {
-                "identitystore.User" => self.read_identitystore_user(&resource).await?,
-                _ => {
-                    // Fallback for data sources this provider doesn't dispatch
-                    // explicitly. Route zero-input cases (e.g. `sts.caller_identity`)
-                    // through the regular read path so existing dispatch handles
-                    // them. Refuse to drop user-supplied inputs silently — if a
-                    // future data source has inputs but no override here, fail
-                    // loud instead of calling `read(&id, None)` and losing them
-                    // (matches the trait-default safety rail in `Provider::read_data_source`).
-                    let user_input_count = resource
-                        .attributes
-                        .keys()
-                        .filter(|k| !k.starts_with('_'))
-                        .count();
-                    if user_input_count > 0 {
-                        return Err(ProviderError::new(format!(
-                            "aws provider does not implement read_data_source for '{}' \
-                             but the resource has {user_input_count} user-supplied input \
-                             attribute(s); refusing to drop them",
-                            resource.id.resource_type
-                        ))
-                        .for_resource(resource.id.clone()));
-                    }
-                    self.read(&resource.id, None).await?
-                }
-            };
-
+            let mut state =
+                crate::provider_generated::dispatch_read_data_source(self, &resource).await?;
             if state.exists {
                 normalize_state_enums(&resource.id.resource_type, &mut state.attributes);
             }
-
             Ok(state)
         })
     }

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -6,7 +6,7 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
@@ -810,5 +810,54 @@ impl AwsProvider {
             attributes.insert("to_port".to_string(), Value::Int(v as i64));
         }
         obj.security_group_rule_id().map(String::from)
+    }
+}
+
+// ===== Generated DataSourceLookups Trait =====
+
+/// One method per `DataSourceDef`. AwsProvider must implement all of
+/// them; the codegen-emitted dispatcher below routes by
+/// `resource.id.resource_type`.
+pub trait DataSourceLookups {
+    fn read_sts_caller_identity_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>>;
+
+    fn read_identitystore_user_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>>;
+
+    fn read_s3_bucket_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>>;
+}
+
+// ===== Generated read_data_source dispatcher =====
+
+/// Routes `Provider::read_data_source` calls to the matching
+/// `DataSourceLookups` trait method. The default arm refuses
+/// to drop user-supplied inputs silently.
+pub(crate) fn dispatch_read_data_source<'a>(
+    provider: &'a AwsProvider,
+    resource: &'a Resource,
+) -> BoxFuture<'a, ProviderResult<State>> {
+    match resource.id.resource_type.as_str() {
+        "sts.CallerIdentity" => provider.read_sts_caller_identity_data_source(resource),
+        "identitystore.User" => provider.read_identitystore_user_data_source(resource),
+        "s3.Bucket" => provider.read_s3_bucket_data_source(resource),
+        _ => {
+            let id = resource.id.clone();
+            let resource_type = resource.id.resource_type.clone();
+            Box::pin(async move {
+                Err(ProviderError::new(format!(
+                    "aws provider does not implement read_data_source for '{}'",
+                    resource_type
+                ))
+                .for_resource(id))
+            })
+        }
     }
 }

--- a/carina-provider-aws/src/services/identitystore/user.rs
+++ b/carina-provider-aws/src/services/identitystore/user.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use aws_sdk_identitystore::types::{AlternateIdentifier, UniqueAttribute};
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{Resource, State, Value};
 
 use crate::AwsProvider;
@@ -16,39 +16,43 @@ use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
     /// Read `identitystore.user` given a `Resource` with user-supplied
-    /// lookup inputs.
-    pub(crate) async fn read_identitystore_user(
+    /// lookup inputs. Wired into `DataSourceLookups` via
+    /// `data_source_lookups::DataSourceLookups`.
+    pub(crate) fn do_read_identitystore_user_data_source(
         &self,
         resource: &Resource,
-    ) -> ProviderResult<State> {
-        let identity_store_id = resource
-            .get_attr("identity_store_id")
-            .and_then(value_as_str)
-            .ok_or_else(|| {
-                ProviderError::new("identitystore.user requires `identity_store_id`")
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let resource = resource.clone();
+        Box::pin(async move {
+            let identity_store_id = resource
+                .get_attr("identity_store_id")
+                .and_then(value_as_str)
+                .ok_or_else(|| {
+                    ProviderError::new("identitystore.user requires `identity_store_id`")
+                        .for_resource(resource.id.clone())
+                })?;
+
+            let user_id =
+                resolve_user_id(&self.identitystore_client, identity_store_id, &resource).await?;
+
+            let describe = self
+                .identitystore_client
+                .describe_user()
+                .identity_store_id(identity_store_id)
+                .user_id(&user_id)
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::new(sdk_error_message(
+                        &format!("Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'"),
+                        &e,
+                    ))
                     .for_resource(resource.id.clone())
-            })?;
+                })?;
 
-        let user_id =
-            resolve_user_id(&self.identitystore_client, identity_store_id, resource).await?;
-
-        let describe = self
-            .identitystore_client
-            .describe_user()
-            .identity_store_id(identity_store_id)
-            .user_id(&user_id)
-            .send()
-            .await
-            .map_err(|e| {
-                ProviderError::new(sdk_error_message(
-                    &format!("Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'"),
-                    &e,
-                ))
-                .for_resource(resource.id.clone())
-            })?;
-
-        let attributes = extract_identitystore_user(&describe);
-        Ok(State::existing(resource.id.clone(), attributes))
+            let attributes = extract_identitystore_user(&describe);
+            Ok(State::existing(resource.id.clone(), attributes))
+        })
     }
 }
 

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::utils::{convert_enum_value, extract_enum_value};
 
@@ -690,6 +690,142 @@ impl AwsProvider {
 
         Ok(())
     }
+
+    /// Read `s3.Bucket` as a data source. Looks the bucket up by name (the
+    /// required `bucket` input) via `HeadBucket` + `GetBucketLocation`,
+    /// then computes the Terraform-parity attributes (`arn`,
+    /// `bucket_domain_name`, `bucket_regional_domain_name`,
+    /// `hosted_zone_id`).
+    ///
+    /// Wired into `DataSourceLookups` via
+    /// `data_source_lookups::DataSourceLookups`.
+    pub(crate) fn do_read_s3_bucket_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let resource = resource.clone();
+        Box::pin(async move {
+            let bucket = match resource.get_attr("bucket") {
+                Some(Value::String(s)) => s.clone(),
+                _ => {
+                    return Err(ProviderError::new("`bucket` is required")
+                        .for_resource(resource.id.clone()));
+                }
+            };
+
+            // 1. HeadBucket — existence check. Reuses the Managed-side
+            //    classifier so the access-denied / not-found / other split
+            //    is consistent. For a DataSource lookup the user explicitly
+            //    asked to read this bucket, so missing bucket is an error
+            //    (unlike read_s3_bucket which returns State::not_found).
+            self.s3_client
+                .head_bucket()
+                .bucket(&bucket)
+                .send()
+                .await
+                .map_err(|err| {
+                    use aws_sdk_s3::error::SdkError;
+                    let kind = match &err {
+                        SdkError::ServiceError(svc) => classify_head_bucket_status(
+                            svc.raw().status().as_u16(),
+                            svc.err().is_not_found(),
+                        ),
+                        _ => HeadBucketErrorKind::Other,
+                    };
+                    match kind {
+                        HeadBucketErrorKind::NotFound => {
+                            ProviderError::new(format!("Bucket '{bucket}' not found"))
+                                .for_resource(resource.id.clone())
+                        }
+                        HeadBucketErrorKind::AccessDenied => ProviderError::new(format!(
+                            "Access denied for bucket '{bucket}'. This may indicate \
+                             insufficient IAM permissions or the bucket is owned by a \
+                             different AWS account."
+                        ))
+                        .for_resource(resource.id.clone()),
+                        HeadBucketErrorKind::Other => {
+                            ProviderError::new(sdk_error_message("Failed to head bucket", &err))
+                                .for_resource(resource.id.clone())
+                        }
+                    }
+                })?;
+
+            // 2. GetBucketLocation — region. Empty / missing
+            //    LocationConstraint means us-east-1 per S3's protocol.
+            let region = self
+                .s3_client
+                .get_bucket_location()
+                .bucket(&bucket)
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::new(sdk_error_message("Failed to get bucket location", &e))
+                        .for_resource(resource.id.clone())
+                })?
+                .location_constraint()
+                .map(|c| c.as_str().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "us-east-1".to_string());
+
+            // 3. Computed attributes.
+            let arn = format!("arn:aws:s3:::{}", bucket);
+            let bucket_domain_name = format!("{}.s3.amazonaws.com", bucket);
+            let bucket_regional_domain_name = format!("{}.s3.{}.amazonaws.com", bucket, region);
+            let hosted_zone_id = s3_hosted_zone_id(&region)
+                .map_err(|m| ProviderError::new(m).for_resource(resource.id.clone()))?;
+
+            let mut attrs = HashMap::new();
+            attrs.insert("bucket".into(), Value::String(bucket.clone()));
+            attrs.insert("arn".into(), Value::String(arn));
+            attrs.insert("region".into(), Value::String(region));
+            attrs.insert(
+                "bucket_domain_name".into(),
+                Value::String(bucket_domain_name),
+            );
+            attrs.insert(
+                "bucket_regional_domain_name".into(),
+                Value::String(bucket_regional_domain_name),
+            );
+            attrs.insert(
+                "hosted_zone_id".into(),
+                Value::String(hosted_zone_id.to_string()),
+            );
+
+            Ok(State::existing(resource.id.clone(), attrs).with_identifier(&bucket))
+        })
+    }
+}
+
+/// Map AWS region → S3 website-endpoint hosted zone ID.
+///
+/// Source: https://docs.aws.amazon.com/general/latest/gr/s3.html
+/// Limited to commercial regions; isolated partitions (GovCloud, China)
+/// are out of scope.
+pub(crate) fn s3_hosted_zone_id(region: &str) -> Result<&'static str, String> {
+    let id = match region {
+        "us-east-1" => "Z3AQBSTGFYJSTF",
+        "us-east-2" => "Z2O1EMRO9K5GLX",
+        "us-west-1" => "Z2F56UZL2M1ACD",
+        "us-west-2" => "Z3BJ6K6RIION7M",
+        "ap-east-1" => "ZNB98KWMFR0R6",
+        "ap-south-1" => "Z11RGJOFQNVJUP",
+        "ap-northeast-1" => "Z2M4EHUR26P7ZW",
+        "ap-northeast-2" => "Z3W03O7B5YMIYP",
+        "ap-northeast-3" => "Z2YQB5RD63NC85",
+        "ap-southeast-1" => "Z3O0J2DXBE1FTB",
+        "ap-southeast-2" => "Z1WCIGYICN2BYD",
+        "ca-central-1" => "Z1QDHH18159H29",
+        "eu-central-1" => "Z21DNDUVLTQW6Q",
+        "eu-west-1" => "Z1BKCTXD74EZPE",
+        "eu-west-2" => "Z3GKZC51ZF0DB4",
+        "eu-west-3" => "Z3R1K369G5AVDG",
+        "eu-north-1" => "Z3BAZG2TWCNX0D",
+        "eu-south-1" => "Z30OZKI7KPW7MI",
+        "me-south-1" => "Z1MPMWCPA7YB62",
+        "sa-east-1" => "Z7KQH4QJS55SO",
+        _ => return Err(format!("Unknown S3 region: '{region}'")),
+    };
+    Ok(id)
 }
 
 /// Result of classifying an S3 HeadBucket error.
@@ -801,6 +937,22 @@ pub(crate) fn infer_canned_acl(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn s3_hosted_zone_id_known_regions() {
+        assert_eq!(
+            s3_hosted_zone_id("ap-northeast-1").unwrap(),
+            "Z2M4EHUR26P7ZW"
+        );
+        assert_eq!(s3_hosted_zone_id("us-east-1").unwrap(), "Z3AQBSTGFYJSTF");
+        assert_eq!(s3_hosted_zone_id("eu-west-1").unwrap(), "Z1BKCTXD74EZPE");
+    }
+
+    #[test]
+    fn s3_hosted_zone_id_unknown_region_errors() {
+        let err = s3_hosted_zone_id("xx-fake-1").unwrap_err();
+        assert!(err.contains("Unknown S3 region"));
+    }
 
     #[test]
     fn test_infer_canned_acl_private() {

--- a/carina-provider-aws/src/services/sts/caller_identity.rs
+++ b/carina-provider-aws/src/services/sts/caller_identity.rs
@@ -1,38 +1,45 @@
 use std::collections::HashMap;
 
-use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ResourceId, State, Value};
+use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
+use carina_core::resource::{Resource, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::sdk_error_message;
 
 impl AwsProvider {
-    /// Read STS caller identity (data source)
+    /// Read STS caller identity (data source).
     ///
-    /// Calls STS GetCallerIdentity and returns account_id, arn, user_id.
-    /// Always succeeds regardless of identifier (STS doesn't need one).
-    pub(crate) async fn read_sts_caller_identity(&self, id: &ResourceId) -> ProviderResult<State> {
-        let response = self
-            .sts_client
-            .get_caller_identity()
-            .send()
-            .await
-            .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to get STS caller identity", &e))
-                    .for_resource(id.clone())
-            })?;
+    /// Calls STS `GetCallerIdentity` and returns `account_id`, `arn`,
+    /// `user_id`. Wired into `DataSourceLookups` via
+    /// `data_source_lookups::DataSourceLookups`.
+    pub(crate) fn do_read_sts_caller_identity_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = resource.id.clone();
+        Box::pin(async move {
+            let response = self
+                .sts_client
+                .get_caller_identity()
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::new(sdk_error_message("Failed to get STS caller identity", &e))
+                        .for_resource(id.clone())
+                })?;
 
-        let mut attributes = HashMap::new();
-        if let Some(account) = response.account() {
-            attributes.insert("account_id".to_string(), Value::String(account.to_string()));
-        }
-        if let Some(arn) = response.arn() {
-            attributes.insert("arn".to_string(), Value::String(arn.to_string()));
-        }
-        if let Some(user_id) = response.user_id() {
-            attributes.insert("user_id".to_string(), Value::String(user_id.to_string()));
-        }
+            let mut attributes = HashMap::new();
+            if let Some(account) = response.account() {
+                attributes.insert("account_id".to_string(), Value::String(account.to_string()));
+            }
+            if let Some(arn) = response.arn() {
+                attributes.insert("arn".to_string(), Value::String(arn.to_string()));
+            }
+            if let Some(user_id) = response.user_id() {
+                attributes.insert("user_id".to_string(), Value::String(user_id.to_string()));
+            }
 
-        Ok(State::existing(id.clone(), attributes))
+            Ok(State::existing(id, attributes))
+        })
     }
 }


### PR DESCRIPTION
## Summary

Combines Phases 5, 6, and 7 of the aws#163 chain into one PR because they form a single atomic change: introduce the trait, wire the existing impls, and add the new `s3.Bucket` impl. Splitting them would leave CI red between PRs — Phase 5 declares a trait method that no service implements yet, and the handoff explicitly bans `unimplemented!()` stubs.

See plan: `docs/specs/2026-05-03-s3-bucket-dual-registered-plan.md` (Phases 5, 6, 7).

## Changes

### Codegen (`carina-codegen-aws`)

- `generate_provider_code` accepts a `&[DataSourceDef]` and emits a `DataSourceLookups` trait (one method per data source) plus a free-function `dispatch_read_data_source(provider, resource)` that routes by `resource.id.resource_type`. The default arm refuses to drop user-supplied inputs silently.
- The tag-update template now passes `&to.resolved_attributes()` to `apply_ec2_tags` so a future regeneration produces code matching the on-disk hand-edited `provider_generated.rs`.

### provider-aws

- `provider_generated.rs` is updated by hand (not regenerated) to add the trait + dispatcher. Regenerating from scratch would lose hand-written extraction logic for `ec2.NatGateway`, `ec2.EgressOnlyInternetGateway`, `ec2.FlowLog`, etc.; bringing the codegen up to parity with those hand-edits is out of scope for this PR.
- `Provider::read_data_source` becomes a one-liner around `dispatch_read_data_source`. The 30-line "drop user inputs" safety rail is gone — the same check now lives in the codegen-emitted default arm.
- `Provider::read` no longer dispatches `sts.CallerIdentity`; that was only reachable via the old `read_data_source` fallback, which has been removed.
- New `data_source_lookups` module: a single `impl DataSourceLookups for AwsProvider` block that delegates each trait method to a `do_read_<name>_data_source` inherent helper. Splitting it this way keeps Rust's "one impl Trait for Type" rule happy while letting the lookup logic stay near its owning service.
- `services/sts/caller_identity.rs` and `services/identitystore/user.rs` rename `read_<name>` → `do_read_<name>_data_source`, take `&Resource` (matching the trait shape), and return `BoxFuture<'_, ...>`.
- `services/s3/bucket.rs` adds `do_read_s3_bucket_data_source` and the `s3_hosted_zone_id(region) -> Result<&'static str, String>` lookup table. The lookup uses `HeadBucket` for existence, `GetBucketLocation` for region (with `us-east-1` fallback for empty `LocationConstraint`), and computes `arn`, `bucket_domain_name`, `bucket_regional_domain_name`, and `hosted_zone_id` in-process.

### Tests

- `data_source_lookups::tests::aws_provider_implements_all_data_source_lookups` is a compile-time assertion that `AwsProvider` satisfies every generated trait method. Adding a new `DataSourceDef` without wiring it now fails the build at this site.
- `services/s3/bucket::tests::s3_hosted_zone_id_known_regions` and `s3_hosted_zone_id_unknown_region_errors` cover the table.

## Test plan

- [x] `cargo nextest run --workspace` — 307 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — builds
- [ ] End-to-end smoke test — runs in Phase 8 (aws#174) against real AWS

Closes #171
Closes #172
Closes #173
Refs #163
