### PR TITLE
test(acceptance): s3.Bucket dual-registration smoke test (Phase 8/8)

### DIFF
--- a/acceptance-tests/s3_bucket_data_source/basic.crn
+++ b/acceptance-tests/s3_bucket_data_source/basic.crn
@@ -1,0 +1,21 @@
+# s3.Bucket dual-registration smoke test (aws#163)
+#
+# Exercises:
+# - aws.s3.Bucket as Managed (Carina creates and destroys it)
+# - aws.s3.Bucket as DataSource (Carina reads a pre-existing bucket)
+#
+# The pre-existing bucket is created/destroyed by run.sh outside Carina.
+# Bucket names are templated via envsubst before apply because S3 bucket
+# names are globally unique.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let new_bucket = aws.s3.Bucket {
+  bucket = '${NEW_BUCKET}'
+}
+
+let existing = read aws.s3.Bucket {
+  bucket = '${PRE_BUCKET}'
+}

--- a/acceptance-tests/s3_bucket_data_source/run.sh
+++ b/acceptance-tests/s3_bucket_data_source/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Runs s3_bucket_data_source acceptance tests
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER="${1:-}"
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+TESTS_RUN=0
+
+echo "s3_bucket_data_source acceptance tests"
+echo "════════════════════════════════════════"
+
+for test_file in "$SCRIPT_DIR"/tests/*.sh; do
+    [ "$(basename "$test_file")" = "_helpers.sh" ] && continue
+    test_name="$(basename "$test_file" .sh)"
+    if [ -n "$FILTER" ] && ! echo "$test_name" | grep -q "$FILTER"; then
+        continue
+    fi
+    echo ""
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if bash "$test_file"; then
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    else
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+    fi
+done
+
+echo ""
+echo "════════════════════════════════════════"
+echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+echo "════════════════════════════════════════"
+
+[ "$TOTAL_FAILED" -gt 0 ] && exit 1

--- a/acceptance-tests/s3_bucket_data_source/tests/basic.sh
+++ b/acceptance-tests/s3_bucket_data_source/tests/basic.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Test: s3.Bucket dual-registration (Managed + DataSource in one apply)
+source "$(dirname "$0")/../../shared/_helpers.sh"
+
+echo "Test: s3_bucket_data_source dual apply"
+echo ""
+
+REGION="ap-northeast-1"
+SUFFIX="$(uuidgen | tr -d - | tr 'A-Z' 'a-z' | head -c 8)"
+NEW_BUCKET="carina-acc-test-aws-s3-ds-new-${SUFFIX}"
+PRE_BUCKET="carina-acc-test-aws-s3-ds-pre-${SUFFIX}"
+export NEW_BUCKET PRE_BUCKET
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+
+# Pre-create the bucket Carina will `read`. Cleanup on EXIT (in addition
+# to the helper-trap which destroys Carina-managed resources).
+cleanup_pre_bucket() {
+    aws s3api delete-bucket --bucket "$PRE_BUCKET" --region "$REGION" 2>/dev/null || true
+}
+trap 'cleanup_pre_bucket; cleanup' EXIT
+
+printf "  %-50s" "setup: pre-create $PRE_BUCKET"
+if aws s3api create-bucket \
+    --bucket "$PRE_BUCKET" \
+    --region "$REGION" \
+    --create-bucket-configuration "LocationConstraint=$REGION" > /dev/null 2>&1; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL"
+    TEST_FAILED=$((TEST_FAILED + 1))
+    finish_test
+fi
+
+# Substitute env vars into the .crn template.
+envsubst < "$SCRIPT_DIR/basic.crn" > "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+# `carina init` resolves `source = "file://..."` into a staged provider
+# under `.carina/providers/`. The release CLI requires it before any
+# apply/plan/destroy.
+prepare_work_dir "$WORK_DIR"
+run_step "step0: init (resolve provider)" "$CARINA_BIN" init .
+
+run_step "step1: apply (creates new + reads existing)" "$CARINA_BIN" apply --auto-approve .
+
+# State should hold both resources: new_bucket (Managed) + existing (DataSource).
+assert_state_resource_count "assert: 2 resources in state" "2" "$WORK_DIR"
+
+# Locate the data source entry by binding name and verify the computed
+# attributes (arn, region, bucket_domain_name, bucket_regional_domain_name,
+# hosted_zone_id) match what the lookup table promises.
+DS_PATH=".resources[] | select(.binding == \"existing\")"
+
+printf "  %-50s" "assert: existing.bucket = $PRE_BUCKET"
+ACTUAL=$(jq -r "$DS_PATH | .attributes.bucket" "$WORK_DIR/carina.state.json" 2>/dev/null)
+if [ "$ACTUAL" = "$PRE_BUCKET" ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (got '$ACTUAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+printf "  %-50s" "assert: existing.region = $REGION"
+ACTUAL=$(jq -r "$DS_PATH | .attributes.region" "$WORK_DIR/carina.state.json" 2>/dev/null)
+if [ "$ACTUAL" = "$REGION" ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (got '$ACTUAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+printf "  %-50s" "assert: existing.arn formatted"
+ACTUAL=$(jq -r "$DS_PATH | .attributes.arn" "$WORK_DIR/carina.state.json" 2>/dev/null)
+if [ "$ACTUAL" = "arn:aws:s3:::$PRE_BUCKET" ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (got '$ACTUAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+printf "  %-50s" "assert: existing.bucket_domain_name"
+ACTUAL=$(jq -r "$DS_PATH | .attributes.bucket_domain_name" "$WORK_DIR/carina.state.json" 2>/dev/null)
+if [ "$ACTUAL" = "$PRE_BUCKET.s3.amazonaws.com" ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (got '$ACTUAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+printf "  %-50s" "assert: existing.bucket_regional_domain_name"
+ACTUAL=$(jq -r "$DS_PATH | .attributes.bucket_regional_domain_name" "$WORK_DIR/carina.state.json" 2>/dev/null)
+if [ "$ACTUAL" = "$PRE_BUCKET.s3.$REGION.amazonaws.com" ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (got '$ACTUAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Hosted zone for ap-northeast-1 per
+# https://docs.aws.amazon.com/general/latest/gr/s3.html
+printf "  %-50s" "assert: existing.hosted_zone_id (ap-northeast-1)"
+ACTUAL=$(jq -r "$DS_PATH | .attributes.hosted_zone_id" "$WORK_DIR/carina.state.json" 2>/dev/null)
+if [ "$ACTUAL" = "Z2M4EHUR26P7ZW" ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (got '$ACTUAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Verify the Managed-side bucket is also recorded.
+printf "  %-50s" "assert: new_bucket present in state"
+ACTUAL=$(jq -r ".resources[] | select(.binding == \"new_bucket\") | .attributes.bucket" "$WORK_DIR/carina.state.json" 2>/dev/null)
+if [ "$ACTUAL" = "$NEW_BUCKET" ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (got '$ACTUAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+run_step "step2: destroy (only the Managed bucket)" "$CARINA_BIN" destroy --auto-approve .
+ACTIVE_WORK_DIR=""
+rm -rf "$WORK_DIR"
+
+# pre-bucket cleanup is handled by the EXIT trap.
+
+finish_test


### PR DESCRIPTION
## Summary

Phase 8 of 8 — final PR in the aws#163 chain. Closes the chain by exercising the dual-registered `aws.s3.Bucket` end-to-end against real AWS.

See plan: `docs/specs/2026-05-03-s3-bucket-dual-registered-plan.md` (Phase 8).

## What it does

- `run.sh` discovers `tests/*.sh` in the same shape as the other acceptance tests in this repo.
- `basic.crn` declares two resources sharing the DSL type `aws.s3.Bucket` but different `SchemaKind`s: a Managed bucket Carina creates and a read-only DataSource lookup against a bucket pre-created by the test harness. Bucket names are env-substituted because S3 bucket names are globally unique.
- `tests/basic.sh` creates the lookup target, runs `carina init` + `apply`, asserts the computed attributes match what the design and lookup table promise (`arn`, `region`, `bucket_domain_name`, `bucket_regional_domain_name`, `hosted_zone_id`), then destroys the Managed bucket and removes the pre-created one.

## Manual verification

Run from this branch with a built WASM provider and the carina release CLI:

```
cd .worktrees/issue-174-acceptance-test
cargo build -p carina-provider-aws --target wasm32-wasip2 --release
CARINA_BIN=/path/to/carina aws-vault exec <profile> -- \
    bash acceptance-tests/s3_bucket_data_source/run.sh
```

Output captured against `aws-vault exec mizzy --` against my AWS account in `ap-northeast-1`:

```
s3_bucket_data_source acceptance tests
════════════════════════════════════════

Test: s3_bucket_data_source dual apply

  setup: pre-create carina-acc-test-aws-s3-ds-pre-e429d4cf  OK
  step0: init (resolve provider)                            OK
  step1: apply (creates new + reads existing)               OK
  assert: 2 resources in state                              OK
  assert: existing.bucket = carina-acc-test-aws-s3-ds-pre-e429d4cf  OK
  assert: existing.region = ap-northeast-1                  OK
  assert: existing.arn formatted                            OK
  assert: existing.bucket_domain_name                       OK
  assert: existing.bucket_regional_domain_name              OK
  assert: existing.hosted_zone_id (ap-northeast-1)          OK
  assert: new_bucket present in state                       OK
  step2: destroy (only the Managed bucket)                  OK

  Results: 12 passed, 0 failed

════════════════════════════════════════
Tests run: 1, 1 passed, 0 failed
════════════════════════════════════════
```

State after `apply` (excerpt — confirms one Managed entry and one DataSource entry sharing `s3.Bucket`):

```json
{
  "resources": [
    {
      "resource_type": "s3.Bucket",
      "name": "new_bucket",
      "identifier": "carina-acc-test-aws-s3-ds-new-...",
      "attributes": { "bucket": "...", "object_ownership": "BucketOwnerEnforced", ... }
    },
    {
      "resource_type": "s3.Bucket",
      "name": "existing",
      "identifier": "carina-acc-test-aws-s3-ds-pre-...",
      "attributes": {
        "bucket": "carina-acc-test-aws-s3-ds-pre-...",
        "region": "ap-northeast-1",
        "arn": "arn:aws:s3:::carina-acc-test-aws-s3-ds-pre-...",
        "bucket_domain_name": "...s3.amazonaws.com",
        "bucket_regional_domain_name": "...s3.ap-northeast-1.amazonaws.com",
        "hosted_zone_id": "Z2M4EHUR26P7ZW"
      }
    }
  ]
}
```

Both buckets were cleaned up after the run (Carina's destroy removes the Managed one; the test's EXIT trap removes the pre-created one).

## Test plan

- [x] `cargo nextest run --workspace` — 307 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual end-to-end run against real AWS — 12/12 assertions passing

Closes #163
Closes #174
