### PR TITLE
codegen: declarative ListFirst projection for read-back extraction (#184)

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -2226,6 +2226,100 @@ fn generate_provider_code(
             }
         }
 
+        // Emit derived attributes (DerivedSource projections). These are
+        // attributes whose value comes from a non-trivial walk of the read
+        // structure (e.g. `nat_gateway_addresses[0].allocation_id`); the
+        // regular fields_to_extract loop above can only handle direct member
+        // accessors.
+        for derived in &res.derived_attributes {
+            match &derived.source {
+                resource_defs::DerivedSource::ListFirst {
+                    list_member,
+                    child_member,
+                } => {
+                    // Locate the list member on the read structure, follow
+                    // its target shape to a List, then to the list element
+                    // (a Structure), then look up the child member to
+                    // determine the right unwrap pattern.
+                    let Some(list_ref) = read_struct.members.get(*list_member) else {
+                        eprintln!(
+                            "warning: derived_attributes for {}: list member '{}' not found on read structure",
+                            res.name, list_member
+                        );
+                        continue;
+                    };
+                    let element_struct_id = match model.get_shape(&list_ref.target) {
+                        Some(carina_smithy::Shape::List(list_shape)) => {
+                            list_shape.member.target.as_str()
+                        }
+                        _ => {
+                            eprintln!(
+                                "warning: derived_attributes for {}: '{}' is not a list shape",
+                                res.name, list_member
+                            );
+                            continue;
+                        }
+                    };
+                    let Some(element_struct) = model.get_structure(element_struct_id) else {
+                        eprintln!(
+                            "warning: derived_attributes for {}: list element '{}' is not a structure",
+                            res.name, element_struct_id
+                        );
+                        continue;
+                    };
+                    let Some(child_ref) = element_struct.members.get(*child_member) else {
+                        eprintln!(
+                            "warning: derived_attributes for {}: child member '{}' not found on '{}'",
+                            res.name, child_member, element_struct_id
+                        );
+                        continue;
+                    };
+
+                    let attr_snake = derived.attr.to_snake_case();
+                    let list_snake = escape_rust_keyword(&list_member.to_snake_case());
+                    let child_snake = escape_rust_keyword(&child_member.to_snake_case());
+                    let child_kind = model.shape_kind(&child_ref.target);
+                    // Today's two call sites (NatGateway, EgressOnlyInternetGateway)
+                    // both project an optional String off the list element. Other
+                    // shape kinds and required-child variants will appear when
+                    // future ResourceDefs use ListFirst with a different child
+                    // type — surface them loudly so we extend the emitter
+                    // instead of silently emitting wrong code.
+                    if !matches!(child_kind, Some(carina_smithy::ShapeKind::String)) {
+                        eprintln!(
+                            "warning: derived_attributes for {}: ListFirst child '{}' is not a String; skipping (extend the emitter when this shape ships)",
+                            res.name, child_member
+                        );
+                        continue;
+                    }
+                    if SmithyModel::is_required(child_ref) {
+                        eprintln!(
+                            "warning: derived_attributes for {}: ListFirst child '{}' is required; skipping (extend the emitter when this shape ships)",
+                            res.name, child_member
+                        );
+                        continue;
+                    }
+
+                    code.push_str(&format!(
+                        "\x20       if let Some(addr) = obj.{}().first()\n\
+                         \x20           && let Some(v) = addr.{}()\n\
+                         \x20       {{\n\
+                         \x20           attributes.insert(\"{}\".to_string(), Value::String(v.to_string()));\n\
+                         \x20       }}\n",
+                        list_snake, child_snake, attr_snake
+                    ));
+                }
+                // DerivedSource is #[non_exhaustive]; new variants land in
+                // sub-issues B-3 / B-4 and require this match to grow.
+                // Skip with a loud message instead of silent ignore so the
+                // missing emitter surfaces at codegen time.
+                _ => eprintln!(
+                    "warning: derived_attributes for {}: unhandled DerivedSource variant; teach the emitter when adding a new projection",
+                    res.name
+                ),
+            }
+        }
+
         // Return identifier value (only if identifier exists in read_structure)
         if !res.identifier.is_empty() && read_struct.members.contains_key(res.identifier) {
             let id_snake = escape_rust_keyword(&res.identifier.to_snake_case());
@@ -3801,6 +3895,68 @@ mod tests {
         assert!(
             code.contains("Some(obj.name().to_string())"),
             "required identifier name must Some(.to_string()): {code}"
+        );
+    }
+
+    #[test]
+    fn extract_ec2_nat_gateway_emits_list_first_for_allocation_id() {
+        let res = resource_defs::ec2_resources()
+            .into_iter()
+            .find(|r| r.name == "ec2.NatGateway")
+            .expect("ec2.NatGateway missing");
+        let Some(code) = provider_code_for_single_resource(res, "ec2.json") else {
+            return;
+        };
+
+        // The hand-written extractor reads `obj.nat_gateway_addresses().first()`
+        // and projects `.allocation_id()` from the inner struct. The codegen
+        // must reproduce that walk for the DSL `allocation_id` attribute.
+        assert!(
+            code.contains("if let Some(addr) = obj.nat_gateway_addresses().first()"),
+            "must walk nat_gateway_addresses().first(): {code}"
+        );
+        assert!(
+            code.contains("addr.allocation_id()"),
+            "must project allocation_id from the list element: {code}"
+        );
+        assert!(
+            code.contains("attributes.insert(\"allocation_id\".to_string()"),
+            "must insert allocation_id attribute: {code}"
+        );
+        // Regression guard: the regular pass must not also emit
+        // `obj.allocation_id()` (NatGateway has no top-level allocation_id getter,
+        // so that would be a compile error).
+        assert!(
+            !code.contains("if let Some(v) = obj.allocation_id()"),
+            "must not emit obj.allocation_id() at the top level: {code}"
+        );
+    }
+
+    #[test]
+    fn extract_ec2_egress_only_internet_gateway_emits_list_first_for_vpc_id() {
+        let res = resource_defs::ec2_resources()
+            .into_iter()
+            .find(|r| r.name == "ec2.EgressOnlyInternetGateway")
+            .expect("ec2.EgressOnlyInternetGateway missing");
+        let Some(code) = provider_code_for_single_resource(res, "ec2.json") else {
+            return;
+        };
+
+        assert!(
+            code.contains("if let Some(addr) = obj.attachments().first()"),
+            "must walk attachments().first(): {code}"
+        );
+        assert!(
+            code.contains("addr.vpc_id()"),
+            "must project vpc_id from the list element: {code}"
+        );
+        assert!(
+            code.contains("attributes.insert(\"vpc_id\".to_string()"),
+            "must insert vpc_id attribute: {code}"
+        );
+        assert!(
+            !code.contains("if let Some(v) = obj.vpc_id()"),
+            "must not emit obj.vpc_id() at the top level (EgressOnlyInternetGateway has no top-level vpc_id getter): {code}"
         );
     }
 

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -85,6 +85,39 @@ pub struct ResourceDef {
     /// Fields to mark as identity (contribute to anonymous resource identifier hashing).
     /// Use for attributes that distinguish same-type resources sharing create-only values.
     pub identity_overrides: Vec<&'static str>,
+    /// Read-back projections for attributes that are not direct members of
+    /// the read structure. The DSL attribute already lives in the schema
+    /// (typically because the create input already contains it); this only
+    /// tells the extraction emitter how to recover the value from the
+    /// response shape — see `DerivedSource`.
+    pub derived_attributes: Vec<DerivedAttribute>,
+}
+
+/// One read-back projection for `extract_*_attributes`.
+///
+/// `attr` is the DSL-side attribute name in the same spelling used
+/// elsewhere in `ResourceDef` (PascalCase or pre-snake_cased member name);
+/// the emitter snake_cases it for the attribute key.
+pub struct DerivedAttribute {
+    pub attr: &'static str,
+    pub source: DerivedSource,
+}
+
+/// Where the value for a `DerivedAttribute` lives in the SDK response.
+///
+/// Marked `#[non_exhaustive]` so adding a new projection in a future
+/// sub-issue (B-3, B-4) does not silently force every external match arm
+/// to compile. `carina-codegen-aws` is currently the only consumer.
+#[non_exhaustive]
+pub enum DerivedSource {
+    /// `obj.<list_member>().first().and_then(|x| x.<child_member>())`.
+    /// Used for SDK responses whose top-level field is a `Vec<Struct>` and
+    /// the resource convention is to read only the first element
+    /// (e.g. `NatGateway.NatGatewayAddresses[0].AllocationId`).
+    ListFirst {
+        list_member: &'static str,
+        child_member: &'static str,
+    },
 }
 
 /// How fields are passed to an update API operation.
@@ -210,6 +243,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.subnet
         ResourceDef {
@@ -244,6 +278,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.internet_gateway
         ResourceDef {
@@ -275,6 +310,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                 ),
             }],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.route_table
         ResourceDef {
@@ -300,6 +336,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.route
         ResourceDef {
@@ -343,6 +380,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.security_group
         ResourceDef {
@@ -368,6 +406,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.security_group_ingress
         ResourceDef {
@@ -422,6 +461,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.security_group_egress
         ResourceDef {
@@ -476,6 +516,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.egress_only_internet_gateway
         ResourceDef {
@@ -501,6 +542,15 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            // VpcId lives on Attachments[0].VpcId in the read response;
+            // there is no top-level VpcId getter on EgressOnlyInternetGateway.
+            derived_attributes: vec![DerivedAttribute {
+                attr: "VpcId",
+                source: DerivedSource::ListFirst {
+                    list_member: "Attachments",
+                    child_member: "VpcId",
+                },
+            }],
         },
         // ec2.eip
         ResourceDef {
@@ -532,6 +582,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.flow_log
         ResourceDef {
@@ -566,6 +617,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.nat_gateway
         ResourceDef {
@@ -598,6 +650,16 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            // AllocationId lives on NatGatewayAddresses[0].AllocationId in the
+            // read response; there is no top-level AllocationId getter on
+            // NatGateway.
+            derived_attributes: vec![DerivedAttribute {
+                attr: "AllocationId",
+                source: DerivedSource::ListFirst {
+                    list_member: "NatGatewayAddresses",
+                    child_member: "AllocationId",
+                },
+            }],
         },
         // ec2.subnet_route_table_association
         ResourceDef {
@@ -623,6 +685,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.transit_gateway
         ResourceDef {
@@ -651,6 +714,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.transit_gateway_attachment
         ResourceDef {
@@ -676,6 +740,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.vpc_endpoint
         ResourceDef {
@@ -711,6 +776,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.vpc_gateway_attachment
         ResourceDef {
@@ -747,6 +813,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.vpc_peering_connection
         ResourceDef {
@@ -772,6 +839,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // ec2.vpn_gateway
         ResourceDef {
@@ -797,6 +865,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
     ]
 }
@@ -933,6 +1002,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
         // organizations.account
         ResourceDef {
@@ -963,6 +1033,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
     ]
 }
@@ -1028,6 +1099,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_writable: vec![],
             identity_overrides: vec![],
+            derived_attributes: vec![],
         },
     ]
 }
@@ -1152,6 +1224,7 @@ pub fn route53_resources() -> Vec<ResourceDef> {
                 description: Some("The ID of the hosted zone that contains this record set."),
             }],
             identity_overrides: vec!["Type"],
+            derived_attributes: vec![],
         },
     ]
 }
@@ -1190,6 +1263,7 @@ pub fn iam_resources() -> Vec<ResourceDef> {
         read_only_overrides: vec![],
         extra_writable: vec![],
         identity_overrides: vec![],
+        derived_attributes: vec![],
     }]
 }
 
@@ -1234,6 +1308,7 @@ pub fn logs_resources() -> Vec<ResourceDef> {
             ),
         }],
         identity_overrides: vec![],
+        derived_attributes: vec![],
     }]
 }
 


### PR DESCRIPTION
## Summary

Sub-issue B-1 of #182. Adds a declarative way for `ResourceDef` to express "read this attribute from `<list_member>[0].<child_member>`" so the codegen no longer drops the hand-written extraction logic for `ec2.NatGateway.NatGatewayAddresses[0].AllocationId` and `ec2.EgressOnlyInternetGateway.Attachments[0].VpcId` on regen.

## Type design

After surfacing three options to the user (Option-soup on `ExtraField`, parallel Vecs of tuples on `ResourceDef`, named-field struct + enum), the named-field shape was chosen for long-term type safety and future B-3 / B-4 extension:

```rust
pub struct ResourceDef {
    ...
    pub derived_attributes: Vec<DerivedAttribute>,
}

pub struct DerivedAttribute {
    pub attr: &'static str,
    pub source: DerivedSource,
}

#[non_exhaustive]
pub enum DerivedSource {
    ListFirst {
        list_member: &'static str,
        child_member: &'static str,
    },
}
```

- Each projection is one variant — adding `ListAll` (#185) and `Struct` (#186) in future PRs is a single variant addition with no unrepresentable-state risk.
- Named fields prevent argument-order mistakes (`("Foo", "Bar")` ambiguity).
- `#[non_exhaustive]` makes the in-crate match grow visibly when new variants land; the bin's match has a `_` arm that emits a loud warning so an unhandled variant never silently produces wrong code.

## Codegen emission

Walks the read structure → list shape → list element struct → child member, validates the child shape (today: optional `String` only — emits a warning + skips for unsupported kinds, deferring richer cases to when they ship), and produces the existing hand-written pattern:

```rust
if let Some(addr) = obj.<list>().first()
    && let Some(v) = addr.<child>()
{
    attributes.insert("<attr>".to_string(), Value::String(v.to_string()));
}
```

`ec2.NatGateway` and `ec2.EgressOnlyInternetGateway` declare:

```rust
derived_attributes: vec![DerivedAttribute {
    attr: "AllocationId",
    source: DerivedSource::ListFirst {
        list_member: "NatGatewayAddresses",
        child_member: "AllocationId",
    },
}],
```

## Tests

- `extract_ec2_nat_gateway_emits_list_first_for_allocation_id` — pins the walk and the inserted attribute, plus a regression guard that no top-level `obj.allocation_id()` is emitted (the getter does not exist on the read structure, so emitting it would not compile).
- `extract_ec2_egress_only_internet_gateway_emits_list_first_for_vpc_id` — same shape, `attachments` / `vpc_id`.

## Why provider_generated.rs is unchanged

Regenerating the file with this PR's codegen also rewrites extractors whose other hand edits are not yet replaced (list-of-string in `ec2.VpcEndpoint`, struct-nested in `ec2.TransitGateway`/`VpcPeeringConnection`/`Subnet`, JSON-parsed policy in `iam.Role`/`ec2.VpcEndpoint`, and the `flow_log_status == "ACTIVE"` derivation in `ec2.FlowLog`), which in turn breaks the runtime tests that depend on those. Rewriting the on-disk file is deferred until #185–#188 also ship; #189 then turns the CI gate on so the file can never drift back to the hybrid state.

## Test plan

- [x] `cargo nextest run --workspace` — 311 passed (2 new tests, 309 unchanged)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/generate-provider.sh` post-change reproduces the hand-written list[0] walks for `ec2.NatGateway.allocation_id` and `ec2.EgressOnlyInternetGateway.vpc_id` (verified locally before reverting).

Closes #184
Refs #182
