### PR TITLE
provider-aws: move policy-parse extractors to services/ (#187)

### DIFF
--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -204,53 +204,6 @@ impl AwsProvider {
         Ok(())
     }
 
-    /// Extract iam.role attributes from SDK response type (generated)
-    pub(crate) fn extract_iam_role_attributes(
-        obj: &aws_sdk_iam::types::Role,
-        attributes: &mut HashMap<String, Value>,
-    ) -> Option<String> {
-        // arn, path, role_id, role_name return &str (always present)
-        let arn = obj.arn();
-        if !arn.is_empty() {
-            attributes.insert("arn".to_string(), Value::String(arn.to_string()));
-        }
-        if let Some(v) = obj.assume_role_policy_document() {
-            // The SDK URL-encodes the policy document
-            let decoded = urlencoding::decode(v).unwrap_or_else(|_| v.into());
-            // Convert JSON string to Value::Map with snake_case keys for struct comparison
-            let policy_value = crate::services::iam::role::iam_policy_json_to_value(&decoded)
-                .unwrap_or_else(|_| {
-                    // Fallback to raw string if JSON parsing fails
-                    Value::String(decoded.into_owned())
-                });
-            attributes.insert("assume_role_policy_document".to_string(), policy_value);
-        }
-        if let Some(v) = obj.description() {
-            attributes.insert("description".to_string(), Value::String(v.to_string()));
-        }
-        if let Some(v) = obj.max_session_duration() {
-            attributes.insert("max_session_duration".to_string(), Value::Int(v as i64));
-        }
-        let path = obj.path();
-        if !path.is_empty() {
-            attributes.insert("path".to_string(), Value::String(path.to_string()));
-        }
-        let role_id = obj.role_id();
-        if !role_id.is_empty() {
-            attributes.insert("role_id".to_string(), Value::String(role_id.to_string()));
-        }
-        let role_name = obj.role_name();
-        if !role_name.is_empty() {
-            attributes.insert(
-                "role_name".to_string(),
-                Value::String(role_name.to_string()),
-            );
-            Some(role_name.to_string())
-        } else {
-            None
-        }
-    }
-
     /// Extract ec2.eip attributes from SDK response type (generated)
     pub(crate) fn extract_ec2_eip_attributes(
         obj: &aws_sdk_ec2::types::Address,
@@ -498,65 +451,6 @@ impl AwsProvider {
             attributes.insert("to_port".to_string(), Value::Int(v as i64));
         }
         obj.security_group_rule_id().map(String::from)
-    }
-
-    /// Extract ec2.vpc_endpoint attributes from SDK response type (generated)
-    pub(crate) fn extract_ec2_vpc_endpoint_attributes(
-        obj: &aws_sdk_ec2::types::VpcEndpoint,
-        attributes: &mut HashMap<String, Value>,
-    ) -> Option<String> {
-        if let Some(v) = obj.vpc_endpoint_id() {
-            attributes.insert("vpc_endpoint_id".to_string(), Value::String(v.to_string()));
-        }
-        if let Some(v) = obj.vpc_endpoint_type() {
-            attributes.insert(
-                "vpc_endpoint_type".to_string(),
-                Value::String(v.as_str().to_string()),
-            );
-        }
-        if let Some(v) = obj.vpc_id() {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
-        }
-        if let Some(v) = obj.service_name() {
-            attributes.insert("service_name".to_string(), Value::String(v.to_string()));
-        }
-        if let Some(v) = obj.private_dns_enabled() {
-            attributes.insert("private_dns_enabled".to_string(), Value::Bool(v));
-        }
-        if let Some(v) = obj.policy_document() {
-            // Try to parse the policy document JSON into a Value::Map
-            let policy_value = crate::services::iam::role::iam_policy_json_to_value(v)
-                .unwrap_or_else(|_| Value::String(v.to_string()));
-            attributes.insert("policy_document".to_string(), policy_value);
-        }
-        {
-            let ids = obj.route_table_ids();
-            if !ids.is_empty() {
-                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
-                attributes.insert("route_table_ids".to_string(), Value::List(list));
-            }
-        }
-        {
-            let ids = obj.subnet_ids();
-            if !ids.is_empty() {
-                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
-                attributes.insert("subnet_ids".to_string(), Value::List(list));
-            }
-        }
-        // Extract security group IDs from groups
-        {
-            let groups = obj.groups();
-            if !groups.is_empty() {
-                let list: Vec<Value> = groups
-                    .iter()
-                    .filter_map(|g| g.group_id().map(|id| Value::String(id.to_string())))
-                    .collect();
-                if !list.is_empty() {
-                    attributes.insert("security_group_ids".to_string(), Value::List(list));
-                }
-            }
-        }
-        obj.vpc_endpoint_id().map(String::from)
     }
 
     /// Extract ec2.flow_log attributes from SDK response type (generated)

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -361,4 +361,73 @@ impl AwsProvider {
 
         Ok(())
     }
+
+    /// Extract ec2.VpcEndpoint attributes from the SDK response.
+    ///
+    /// Lives here (not in `provider_generated.rs`) because
+    /// `policy_document` is parsed JSON → `Value::Map` via
+    /// `iam_policy_json_to_value`, which the codegen template can't
+    /// express. `scan_manual_methods` picks this up by name and the
+    /// codegen skips emitting a duplicate stub. The list-typed members
+    /// (route_table_ids / subnet_ids / Groups[*].group_id) are also
+    /// extracted here for the same reason — keeping the extractor
+    /// whole reads cleaner than re-deriving half of it from
+    /// `derived_attributes`.
+    pub(crate) fn extract_ec2_vpc_endpoint_attributes(
+        obj: &aws_sdk_ec2::types::VpcEndpoint,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.vpc_endpoint_id() {
+            attributes.insert("vpc_endpoint_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.vpc_endpoint_type() {
+            attributes.insert(
+                "vpc_endpoint_type".to_string(),
+                Value::String(v.as_str().to_string()),
+            );
+        }
+        if let Some(v) = obj.vpc_id() {
+            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.service_name() {
+            attributes.insert("service_name".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.private_dns_enabled() {
+            attributes.insert("private_dns_enabled".to_string(), Value::Bool(v));
+        }
+        if let Some(v) = obj.policy_document() {
+            // Try to parse the policy document JSON into a Value::Map.
+            let policy_value = crate::services::iam::role::iam_policy_json_to_value(v)
+                .unwrap_or_else(|_| Value::String(v.to_string()));
+            attributes.insert("policy_document".to_string(), policy_value);
+        }
+        {
+            let ids = obj.route_table_ids();
+            if !ids.is_empty() {
+                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
+                attributes.insert("route_table_ids".to_string(), Value::List(list));
+            }
+        }
+        {
+            let ids = obj.subnet_ids();
+            if !ids.is_empty() {
+                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
+                attributes.insert("subnet_ids".to_string(), Value::List(list));
+            }
+        }
+        // Extract security group IDs from Groups[*].group_id.
+        {
+            let groups = obj.groups();
+            if !groups.is_empty() {
+                let list: Vec<Value> = groups
+                    .iter()
+                    .filter_map(|g| g.group_id().map(|id| Value::String(id.to_string())))
+                    .collect();
+                if !list.is_empty() {
+                    attributes.insert("security_group_ids".to_string(), Value::List(list));
+                }
+            }
+        }
+        obj.vpc_endpoint_id().map(String::from)
+    }
 }

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -294,6 +294,61 @@ impl AwsProvider {
 
         Ok(())
     }
+
+    /// Extract iam.Role attributes from the SDK response.
+    ///
+    /// Lives here (not in `provider_generated.rs`) because
+    /// `assume_role_policy_document` needs URL-decoding and a JSON →
+    /// `Value::Map` parse step that the codegen template can't express;
+    /// `scan_manual_methods` picks it up by name and the codegen skips
+    /// emitting a duplicate stub. Returns the role name as the
+    /// state identifier.
+    pub(crate) fn extract_iam_role_attributes(
+        obj: &aws_sdk_iam::types::Role,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        // arn, path, role_id, role_name return &str (always present per
+        // Smithy `@required`); skip the empty-string sentinel the SDK
+        // sometimes uses when the field is absent on the wire.
+        let arn = obj.arn();
+        if !arn.is_empty() {
+            attributes.insert("arn".to_string(), Value::String(arn.to_string()));
+        }
+        if let Some(v) = obj.assume_role_policy_document() {
+            // The SDK URL-encodes the policy document.
+            let decoded = urlencoding::decode(v).unwrap_or_else(|_| v.into());
+            // Convert JSON string to Value::Map with snake_case keys for
+            // struct comparison; fall back to the raw string if the
+            // policy is malformed.
+            let policy_value = iam_policy_json_to_value(&decoded)
+                .unwrap_or_else(|_| Value::String(decoded.into_owned()));
+            attributes.insert("assume_role_policy_document".to_string(), policy_value);
+        }
+        if let Some(v) = obj.description() {
+            attributes.insert("description".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.max_session_duration() {
+            attributes.insert("max_session_duration".to_string(), Value::Int(v as i64));
+        }
+        let path = obj.path();
+        if !path.is_empty() {
+            attributes.insert("path".to_string(), Value::String(path.to_string()));
+        }
+        let role_id = obj.role_id();
+        if !role_id.is_empty() {
+            attributes.insert("role_id".to_string(), Value::String(role_id.to_string()));
+        }
+        let role_name = obj.role_name();
+        if !role_name.is_empty() {
+            attributes.insert(
+                "role_name".to_string(),
+                Value::String(role_name.to_string()),
+            );
+            Some(role_name.to_string())
+        } else {
+            None
+        }
+    }
 }
 
 /// Convert a Carina Value (Map with snake_case keys) to a JSON string


### PR DESCRIPTION
## Summary

Sub-issue B-5 of #182. Moves the two extractors with JSON-parsed `policy_document` (URL-decoded then run through `iam_policy_json_to_value`) out of `provider_generated.rs` into the natural per-service files. The codegen template can't express that transform; living as a hand patch on a "generated" file made every regen lose it silently.

## Changes

- `extract_iam_role_attributes` → `services/iam/role.rs` (the file already houses `iam_policy_json_to_value` and the rest of the IAM Role read path).
- `extract_ec2_vpc_endpoint_attributes` → `services/ec2/vpc_endpoint.rs`.
- The two duplicate methods are removed from `provider_generated.rs`. `scan_manual_methods` walks `services/` and feeds the resulting names to the codegen, so any future regen now skips emitting them automatically.

`ec2.VpcEndpoint`'s list extractions (`route_table_ids` / `subnet_ids` / `Groups[*].group_id`) come along with the move. They could have stayed codegen-side via #185's `derived_attributes`, but splitting the extractor across two files for one resource read worse than keeping it whole.

## What still hangs

`ec2.FlowLog`'s `flow_log_status == "ACTIVE"` derivation is still hand-edited in `provider_generated.rs`; it lands in #188. Final regen + CI gate is #189.

## Test plan

- [x] `cargo nextest run --workspace` — 317 passed, no regressions
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/generate-provider.sh` post-change does **not** re-emit `extract_iam_role_attributes` / `extract_ec2_vpc_endpoint_attributes` (verified locally via `manual_methods` skipping). The resulting file compiles and tests pass.
- [x] iam.Role and VpcEndpoint extractor tests (`test_extract_iam_role_attributes*`, `test_extract_ec2_vpc_endpoint_attributes*`) all pass.

Closes #187
Refs #182
