### PR TITLE
ci: extend codegen-check to gate provider_generated.rs round-trip (#189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run schema codegen
         run: ./scripts/generate-schemas-smithy.sh
+      - name: Run provider codegen
+        run: ./scripts/generate-provider.sh
       - name: Verify no uncommitted changes
         run: |
           if ! git diff --exit-code; then
-            echo "::error::Schema codegen produced uncommitted changes. Run './scripts/generate-schemas-smithy.sh' locally and commit the results."
+            echo "::error::Codegen produced uncommitted changes. Run './scripts/generate-schemas-smithy.sh' and './scripts/generate-provider.sh' locally and commit the results."
             exit 1
           fi


### PR DESCRIPTION
## Summary

Sub-issue C of #182 — the final sub-issue. Extends the existing `codegen-check` CI job to also run `scripts/generate-provider.sh` and fail the build on any `git diff`. The Schema codegen half of the gate already exists; this adds the provider half so the round-trip on both files is enforced.

Without this gate, `provider_generated.rs` was a generated/hand-written hybrid — running the script silently regressed four resources (the bug that opened #182). #183–#188 reproduced every prior hand patch declaratively or moved it to `services/`, and the regen now produces a byte-for-byte (modulo `cargo fmt`) copy of the on-disk file. This PR locks that contract in.

## What this catches in future

- A contributor edits `provider_generated.rs` by hand → CI red with the pointer to run the regen scripts.
- A codegen change in `carina-codegen-aws` that doesn't update the on-disk artefact → CI red.
- A schema-driving change (`ResourceDef`, `DataSourceDef`) that doesn't run regen → CI red.

## Verified locally

```
$ bash scripts/download-smithy-models.sh
$ bash scripts/generate-schemas-smithy.sh
$ bash scripts/generate-provider.sh
$ git diff --stat
 .github/workflows/ci.yml | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```

Only the `ci.yml` change shows up — the regen produces no other diff.

## Test plan

- [x] Local: both regen scripts run cleanly with no `git diff` to artefacts.
- [x] CI: this PR itself exercises the new step (the new `generate-provider.sh` invocation must succeed and produce no diff for the PR to merge).

Closes #189
Refs #182
