### PR TITLE
docs: regen logs.LogGroup reference for retention_in_days (#177)

### DIFF
--- a/generated-docs/aws/logs/log_group.md
+++ b/generated-docs/aws/logs/log_group.md
@@ -38,6 +38,13 @@ Use this parameter to specify the log group class for this log group. There are 
 
 A name for the log group.
 
+### `retention_in_days`
+
+- **Type:** Int
+- **Required:** No
+
+The number of days to retain the log events in the log group. If unset, events never expire. The provider applies changes via PutRetentionPolicy / DeleteRetentionPolicy.
+
 ### `tags`
 
 - **Type:** Map


### PR DESCRIPTION
## Summary

Schema commit 16105d3 (`logs.LogGroup: add retention_in_days attribute to schema`) added the `retention_in_days` field to the resource schema but did not regenerate `generated-docs/aws/logs/log_group.md`. The docs and the schema have been out of sync on `main` since then. Re-running `bash scripts/generate-docs.sh` produces only this file's diff; commit the result.

## Diff

```
+ ### `retention_in_days`
+
+ - **Type:** Int
+ - **Required:** No
+
+ The number of days to retain the log events in the log group. If unset, events never expire. The provider applies changes via PutRetentionPolicy / DeleteRetentionPolicy.
```

## Test plan

- [x] `bash scripts/generate-docs.sh` produces only `generated-docs/aws/logs/log_group.md` as a diff (verified locally).
- [x] No Rust changes — pre-commit clippy/fmt skipped.

Closes #177
