### PR TITLE
deps: bump carina-plugin-wit + carina-* to pick up secret-val (carina#2390)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#f212dae37fa6582dab349808167b38120db013b8"
+source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
 dependencies = [
  "argon2",
  "futures",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#f212dae37fa6582dab349808167b38120db013b8"
+source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f212dae37fa6582dab349808167b38120db013b8"
+source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
## Summary

Bumps `carina-plugin-wit` submodule to `origin/main` and refreshes `Cargo.lock` so the carina git deps (`carina-core`, `carina-plugin-sdk`, `carina-provider-protocol`) resolve to `45ac4edb` or later — the commit where the SDK gained the `SecretVal` decode arm and the host emits the `secret-val` WIT variant for `Value::Secret` (carina#2391).

After this PR, this provider can be loaded by an updated carina host. Without it, instantiation fails at the wasi:http linker layer because the prebuilt `.wasm` references the old WIT shape.

No provider-side logic changes — the SDK macro inside this crate gets the new `SecretVal` decode arm automatically from the bumped SDK source.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo nextest run --workspace` (317 passed)
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` (verifies the WASM component still compiles)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

## Refs

- Host PR: carina#2391
- WIT PR: carina-plugin-wit#2
- Original boundary report: carina#1848 (resolved by RFC carina#2371 + this rebuild)

Closes #207
