### PR TITLE
Implement aws.s3.BucketPolicy as a standalone resource (split from aws.s3.Bucket per #164)

### DIFF
--- a/acceptance-tests/s3_bucket_policy/basic.crn
+++ b/acceptance-tests/s3_bucket_policy/basic.crn
@@ -1,0 +1,38 @@
+# S3 BucketPolicy - Basic test
+#
+# Tests: standalone aws.s3.BucketPolicy attaching a policy to a bucket
+# created in the same .crn. The policy is written in DSL block syntax
+# and is converted to JSON by the provider before PutBucketPolicy.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-bucket-policy-basic-v1'
+}
+
+aws.s3.BucketPolicy {
+  bucket = bucket.bucket
+
+  policy = {
+    version = '2012-10-17'
+    statement {
+      sid    = 'DenyInsecureTransport'
+      effect = 'Deny'
+      principal = {
+        aws = '*'
+      }
+      action   = 's3:*'
+      resource = [
+        'arn:aws:s3:::carina-acc-test-aws-s3-bucket-policy-basic-v1',
+        'arn:aws:s3:::carina-acc-test-aws-s3-bucket-policy-basic-v1/*',
+      ]
+      condition = {
+        bool = {
+          'aws:SecureTransport' = 'false'
+        }
+      }
+    }
+  }
+}

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3918,6 +3918,7 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "ec2.VpcPeeringConnection" => "AWS::EC2::VPCPeeringConnection",
         "ec2.VpnGateway" => "AWS::EC2::VPNGateway",
         "s3.Bucket" => "AWS::S3::Bucket",
+        "s3.BucketPolicy" => "AWS::S3::BucketPolicy",
         "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
         "organizations.Organization" => "AWS::Organizations::Organization",
         "organizations.Account" => "AWS::Organizations::Account",

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1233,6 +1233,47 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
+        // s3.BucketPolicy — standalone resource that attaches a resource-based
+        // policy to an existing S3 bucket. Maps to PutBucketPolicy /
+        // GetBucketPolicy / DeleteBucketPolicy. First slice of the
+        // Terraform-style decomposition decided in carina-provider-aws#164.
+        ResourceDef {
+            name: "s3.BucketPolicy",
+            service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
+            simple_delete: true,
+            noop_update: false,
+            create_op: "PutBucketPolicy",
+            read_structure: None,
+            read_ops: vec![ReadOp {
+                operation: "GetBucketPolicy",
+                fields: vec![("Policy", None)],
+                defaults: vec![],
+            }],
+            delete_op: "DeleteBucketPolicy",
+            update_ops: vec![UpdateOp {
+                operation: "PutBucketPolicy",
+                fields: FieldLayout::Flat(vec!["Policy"]),
+            }],
+            identifier: "Bucket",
+            has_tags: false,
+            type_overrides: vec![("Policy", "super::iam_policy_document()")],
+            exclude_fields: vec![
+                "ContentMD5",
+                "ChecksumAlgorithm",
+                "ConfirmRemoveSelfBucketAccess",
+                "ExpectedBucketOwner",
+            ],
+            create_only_overrides: vec!["Bucket"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Bucket", "Policy"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![],
+            identity_overrides: vec![],
+            derived_attributes: vec![],
+        },
     ]
 }
 

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1240,7 +1240,11 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             name: "s3.BucketPolicy",
             service_namespace: "com.amazonaws.s3",
             schema_structure: None,
-            simple_delete: true,
+            // Delete is hand-written in services/s3/bucket_policy.rs as
+            // delete_s3_bucket_policy_idempotent, which treats
+            // NoSuchBucketPolicy / NoSuchBucket as success so destroy retries
+            // succeed when the policy or its parent bucket is already gone.
+            simple_delete: false,
             noop_update: false,
             create_op: "PutBucketPolicy",
             read_structure: None,

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1233,10 +1233,9 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
-        // s3.BucketPolicy — standalone resource that attaches a resource-based
-        // policy to an existing S3 bucket. Maps to PutBucketPolicy /
-        // GetBucketPolicy / DeleteBucketPolicy. First slice of the
-        // Terraform-style decomposition decided in carina-provider-aws#164.
+        // s3.BucketPolicy — attaches a resource-based policy to an existing
+        // S3 bucket. Maps to PutBucketPolicy / GetBucketPolicy /
+        // DeleteBucketPolicy.
         ResourceDef {
             name: "s3.BucketPolicy",
             service_namespace: "com.amazonaws.s3",
@@ -1245,11 +1244,10 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             noop_update: false,
             create_op: "PutBucketPolicy",
             read_structure: None,
-            read_ops: vec![ReadOp {
-                operation: "GetBucketPolicy",
-                fields: vec![("Policy", None)],
-                defaults: vec![],
-            }],
+            // Read is hand-written in services/s3/bucket_policy.rs to convert
+            // the JSON policy to a typed Value::Map; the generated per-op read
+            // would emit it as Value::String and bypass that conversion.
+            read_ops: vec![],
             delete_op: "DeleteBucketPolicy",
             update_ops: vec![UpdateOp {
                 operation: "PutBucketPolicy",

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -279,7 +279,10 @@ impl Provider for AwsProvider {
         Box::pin(async move {
             match id.resource_type.as_str() {
                 "s3.Bucket" => self.delete_s3_bucket(id, &identifier, &lifecycle).await,
-                "s3.BucketPolicy" => self.delete_s3_bucket_policy(id, &identifier).await,
+                "s3.BucketPolicy" => {
+                    self.delete_s3_bucket_policy_idempotent(id, &identifier)
+                        .await
+                }
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,
                 "ec2.Vpc" => self.delete_ec2_vpc(id, &identifier).await,
                 "ec2.Subnet" => self.delete_ec2_subnet(id, &identifier).await,

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -21,6 +21,7 @@ impl Provider for AwsProvider {
         Box::pin(async move {
             let mut state = match id.resource_type.as_str() {
                 "s3.Bucket" => self.read_s3_bucket(&id, identifier.as_deref()).await,
+                "s3.BucketPolicy" => self.read_s3_bucket_policy(&id, identifier.as_deref()).await,
                 "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
                 "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
                 "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
@@ -117,6 +118,7 @@ impl Provider for AwsProvider {
         Box::pin(async move {
             match resource.id.resource_type.as_str() {
                 "s3.Bucket" => self.create_s3_bucket(resource).await,
+                "s3.BucketPolicy" => self.create_s3_bucket_policy(resource).await,
                 "ec2.Eip" => self.create_ec2_eip(resource).await,
                 "ec2.Vpc" => self.create_ec2_vpc(resource).await,
                 "ec2.Subnet" => self.create_ec2_subnet(resource).await,
@@ -179,6 +181,10 @@ impl Provider for AwsProvider {
         Box::pin(async move {
             match id.resource_type.as_str() {
                 "s3.Bucket" => self.update_s3_bucket(id, &identifier, &from, to).await,
+                "s3.BucketPolicy" => {
+                    self.update_s3_bucket_policy(id, &identifier, &from, to)
+                        .await
+                }
                 "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
                 "ec2.Vpc" => self.update_ec2_vpc(id, &identifier, &from, to).await,
                 "ec2.Subnet" => self.update_ec2_subnet(id, &identifier, &from, to).await,
@@ -273,6 +279,7 @@ impl Provider for AwsProvider {
         Box::pin(async move {
             match id.resource_type.as_str() {
                 "s3.Bucket" => self.delete_s3_bucket(id, &identifier, &lifecycle).await,
+                "s3.BucketPolicy" => self.delete_s3_bucket_policy(id, &identifier).await,
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,
                 "ec2.Vpc" => self.delete_ec2_vpc(id, &identifier).await,
                 "ec2.Subnet" => self.delete_ec2_subnet(id, &identifier).await,

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -89,6 +89,24 @@ impl AwsProvider {
         Ok(())
     }
 
+    /// Delete s3.BucketPolicy (generated)
+    pub(crate) async fn delete_s3_bucket_policy(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        self.s3_client
+            .delete_bucket_policy()
+            .bucket(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to delete bucket policy", &e))
+                    .for_resource(id.clone())
+            })?;
+        Ok(())
+    }
+
     /// Update ec2.InternetGateway: apply tag changes and read back (generated)
     pub(crate) async fn update_ec2_internet_gateway(
         &self,
@@ -179,6 +197,32 @@ impl AwsProvider {
             .map(|v| v.as_str().to_string())
             .unwrap_or_else(|| "Suspended".to_string());
         attributes.insert("versioning_status".to_string(), Value::String(value));
+        Ok(())
+    }
+
+    /// Read s3.BucketPolicy GetBucketPolicy (generated)
+    pub(crate) async fn read_s3_bucket_policy_policy(
+        &self,
+        id: &ResourceId,
+        identifier: &str,
+        attributes: &mut HashMap<String, Value>,
+    ) -> ProviderResult<()> {
+        let output = self
+            .s3_client
+            .get_bucket_policy()
+            .bucket(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message(
+                    "Failed to read s3.BucketPolicy GetBucketPolicy",
+                    &e,
+                ))
+                .for_resource(id.clone())
+            })?;
+        if let Some(v) = output.policy() {
+            attributes.insert("policy".to_string(), Value::String(v.to_string()));
+        }
         Ok(())
     }
 

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -200,32 +200,6 @@ impl AwsProvider {
         Ok(())
     }
 
-    /// Read s3.BucketPolicy GetBucketPolicy (generated)
-    pub(crate) async fn read_s3_bucket_policy_policy(
-        &self,
-        id: &ResourceId,
-        identifier: &str,
-        attributes: &mut HashMap<String, Value>,
-    ) -> ProviderResult<()> {
-        let output = self
-            .s3_client
-            .get_bucket_policy()
-            .bucket(identifier)
-            .send()
-            .await
-            .map_err(|e| {
-                ProviderError::new(sdk_error_message(
-                    "Failed to read s3.BucketPolicy GetBucketPolicy",
-                    &e,
-                ))
-                .for_resource(id.clone())
-            })?;
-        if let Some(v) = output.policy() {
-            attributes.insert("policy".to_string(), Value::String(v.to_string()));
-        }
-        Ok(())
-    }
-
     /// Write s3.Bucket PutBucketVersioning (generated)
     pub(crate) async fn write_s3_bucket_versioning(
         &self,

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -89,24 +89,6 @@ impl AwsProvider {
         Ok(())
     }
 
-    /// Delete s3.BucketPolicy (generated)
-    pub(crate) async fn delete_s3_bucket_policy(
-        &self,
-        id: ResourceId,
-        identifier: &str,
-    ) -> ProviderResult<()> {
-        self.s3_client
-            .delete_bucket_policy()
-            .bucket(identifier)
-            .send()
-            .await
-            .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete bucket policy", &e))
-                    .for_resource(id.clone())
-            })?;
-        Ok(())
-    }
-
     /// Update ec2.InternetGateway: apply tag changes and read back (generated)
     pub(crate) async fn update_ec2_internet_gateway(
         &self,

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -46,6 +46,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         route53::record_set::route53_record_set_config(),
         s3::bucket::s3_bucket_config(),
         s3::bucket_data_source::s3_bucket_data_source_config(),
+        s3::bucket_policy::s3_bucket_policy_config(),
         sts::caller_identity::sts_caller_identity_config(),
     ]
 }
@@ -87,6 +88,7 @@ pub fn get_enum_valid_values(
         route53::record_set::enum_valid_values(),
         s3::bucket::enum_valid_values(),
         s3::bucket_data_source::enum_valid_values(),
+        s3::bucket_policy::enum_valid_values(),
         sts::caller_identity::enum_valid_values(),
     ];
     for (rt, attrs) in modules {
@@ -183,6 +185,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.Bucket" {
         return s3::bucket::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3.BucketPolicy" {
+        return s3::bucket_policy::enum_alias_reverse(attr_name, value);
     }
     None
 }
@@ -365,6 +370,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket::enum_alias_entries() {
         map.entry("s3.Bucket".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket_policy::enum_alias_entries() {
+        map.entry("s3.BucketPolicy".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_policy.rs
@@ -1,0 +1,51 @@
+//! BucketPolicy schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.s3
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for s3.BucketPolicy (Smithy: com.amazonaws.s3)
+pub fn s3_bucket_policy_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::S3::BucketPolicy",
+        resource_type_name: "s3.BucketPolicy",
+        has_tags: false,
+        schema: ResourceSchema::new("s3.BucketPolicy")
+        .attribute(
+            AttributeSchema::new("bucket", AttributeType::String)
+                .required()
+                .create_only()
+                .with_description("The name of the bucket. Directory buckets - When you use this operation with a directory bucket, you must use path-style requests in the format https:...")
+                .with_provider_name("Bucket"),
+        )
+        .attribute(
+            AttributeSchema::new("policy", super::iam_policy_document())
+                .required()
+                .with_description("The bucket policy as a JSON document. For directory buckets, the only IAM action supported in the bucket policy is s3express:CreateSession.")
+                .with_provider_name("Policy"),
+        )
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("s3.BucketPolicy", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/mod.rs
@@ -8,3 +8,4 @@ pub use super::*;
 
 pub mod bucket;
 pub mod bucket_data_source;
+pub mod bucket_policy;

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -517,11 +517,8 @@ fn scalar_to_json(value: &Value) -> serde_json::Value {
 ///
 /// Mirrors `value_to_iam_policy_json`'s position-aware case conversion:
 /// only IAM standard fields and condition operators are mapped to
-/// snake_case; condition variable keys, ARN values, and other literals
-/// are preserved verbatim. A blanket `pascal_to_snake` would turn
-/// `aws:SecureTransport` → `aws:secure_transport` (wrong), or
-/// `s3:GetObject` (an Action *value*, not a key) is unaffected only
-/// because Action values are not keys.
+/// snake_case; condition variable keys, ARN values, and Action / Resource
+/// literals are preserved verbatim.
 pub fn iam_policy_json_to_value(json_str: &str) -> Result<Value, String> {
     let json: serde_json::Value =
         serde_json::from_str(json_str).map_err(|e| format!("JSON parse failed: {}", e))?;

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -339,8 +339,17 @@ impl AwsProvider {
 
 /// Convert a Carina Value (Map with snake_case keys) to a JSON string
 /// with PascalCase keys suitable for the IAM API.
+///
+/// The conversion is *position-aware*: only IAM standard fields (e.g.
+/// `version` → `Version`, `statement` → `Statement`) and condition
+/// operators (e.g. `bool` → `Bool`, `string_equals` → `StringEquals`)
+/// are case-converted. Condition variable keys (`aws:SecureTransport`,
+/// `s3:prefix`, ...), ARN values, and Action / Resource literals are
+/// passed through verbatim. A blanket `snake_to_pascal` would mangle
+/// them (e.g. `aws:SecureTransport` → `Aws:SecureTransport`), which
+/// AWS treats as an unknown — and therefore unenforced — condition.
 pub fn value_to_iam_policy_json(value: &Value) -> Result<String, String> {
-    let json_value = value_to_json_pascal(value);
+    let json_value = policy_doc_to_json(value);
     serde_json::to_string(&json_value).map_err(|e| format!("JSON serialization failed: {}", e))
 }
 
@@ -365,36 +374,273 @@ pub fn resolve_iam_policy_attr(resource: &Resource, attr_name: &str) -> Provider
     }
 }
 
-/// Recursively convert a Carina Value to serde_json::Value with PascalCase keys.
-fn value_to_json_pascal(value: &Value) -> serde_json::Value {
+/// IAM policy top-level standard fields (snake → PascalCase).
+const POLICY_TOP_FIELDS: &[(&str, &str)] = &[
+    ("version", "Version"),
+    ("id", "Id"),
+    ("statement", "Statement"),
+];
+
+/// IAM policy Statement fields (snake → PascalCase).
+const STATEMENT_FIELDS: &[(&str, &str)] = &[
+    ("sid", "Sid"),
+    ("effect", "Effect"),
+    ("principal", "Principal"),
+    ("not_principal", "NotPrincipal"),
+    ("action", "Action"),
+    ("not_action", "NotAction"),
+    ("resource", "Resource"),
+    ("not_resource", "NotResource"),
+    ("condition", "Condition"),
+];
+
+/// IAM Principal map field names (snake → PascalCase).
+const PRINCIPAL_FIELDS: &[(&str, &str)] = &[
+    ("aws", "AWS"),
+    ("federated", "Federated"),
+    ("service", "Service"),
+    ("canonical_user", "CanonicalUser"),
+];
+
+fn lookup_pascal(
+    table: &'static [(&'static str, &'static str)],
+    snake: &str,
+) -> Option<&'static str> {
+    table.iter().find_map(|(s, p)| (*s == snake).then_some(*p))
+}
+
+fn lookup_snake(
+    table: &'static [(&'static str, &'static str)],
+    pascal: &str,
+) -> Option<&'static str> {
+    table.iter().find_map(|(s, p)| (*p == pascal).then_some(*s))
+}
+
+/// Convert a Carina policy document Value to JSON. Top-level fields are
+/// case-mapped via `POLICY_TOP_FIELDS`; the value of `Statement` is
+/// further converted by `policy_statement_to_json`.
+fn policy_doc_to_json(value: &Value) -> serde_json::Value {
+    let Value::Map(map) = value else {
+        return scalar_to_json(value);
+    };
+    let mut obj = serde_json::Map::new();
+    for (k, v) in map {
+        let pascal_key = lookup_pascal(POLICY_TOP_FIELDS, k).unwrap_or(k.as_str());
+        let json_value = if k == "statement" {
+            match v {
+                Value::List(items) => {
+                    serde_json::Value::Array(items.iter().map(policy_statement_to_json).collect())
+                }
+                Value::Map(_) => policy_statement_to_json(v),
+                _ => scalar_to_json(v),
+            }
+        } else {
+            scalar_or_passthrough_to_json(v)
+        };
+        obj.insert(pascal_key.to_string(), json_value);
+    }
+    serde_json::Value::Object(obj)
+}
+
+fn policy_statement_to_json(value: &Value) -> serde_json::Value {
+    let Value::Map(map) = value else {
+        return scalar_to_json(value);
+    };
+    let mut obj = serde_json::Map::new();
+    for (k, v) in map {
+        let pascal_key = lookup_pascal(STATEMENT_FIELDS, k).unwrap_or(k.as_str());
+        let json_value = match k.as_str() {
+            "principal" | "not_principal" => principal_to_json(v),
+            "condition" => condition_to_json(v),
+            _ => scalar_or_passthrough_to_json(v),
+        };
+        obj.insert(pascal_key.to_string(), json_value);
+    }
+    serde_json::Value::Object(obj)
+}
+
+fn principal_to_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::Map(map) => {
+            let mut obj = serde_json::Map::new();
+            for (k, v) in map {
+                let key = lookup_pascal(PRINCIPAL_FIELDS, k).unwrap_or(k.as_str());
+                obj.insert(key.to_string(), scalar_or_passthrough_to_json(v));
+            }
+            serde_json::Value::Object(obj)
+        }
+        _ => scalar_to_json(value),
+    }
+}
+
+fn condition_to_json(value: &Value) -> serde_json::Value {
+    let Value::Map(operators) = value else {
+        return scalar_to_json(value);
+    };
+    let mut obj = serde_json::Map::new();
+    for (op_key, kv_value) in operators {
+        let op_pascal =
+            carina_aws_types::condition_operator_to_aws(op_key).unwrap_or_else(|| op_key.clone());
+        let kv_json = match kv_value {
+            // Inner map keys are condition variables (e.g. "aws:SecureTransport")
+            // and must pass through verbatim — no case conversion.
+            Value::Map(inner) => {
+                let mut m = serde_json::Map::new();
+                for (var, val) in inner {
+                    m.insert(var.clone(), scalar_or_passthrough_to_json(val));
+                }
+                serde_json::Value::Object(m)
+            }
+            _ => scalar_to_json(kv_value),
+        };
+        obj.insert(op_pascal, kv_json);
+    }
+    serde_json::Value::Object(obj)
+}
+
+/// Scalar-or-list-of-scalars passthrough: used for Action / Resource /
+/// Sid / Effect / condition variable values. No key conversion.
+fn scalar_or_passthrough_to_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::List(items) => {
+            serde_json::Value::Array(items.iter().map(scalar_or_passthrough_to_json).collect())
+        }
+        Value::Map(map) => {
+            // Generic map (e.g. nested condition value map): keys verbatim.
+            let mut obj = serde_json::Map::new();
+            for (k, v) in map {
+                obj.insert(k.clone(), scalar_or_passthrough_to_json(v));
+            }
+            serde_json::Value::Object(obj)
+        }
+        _ => scalar_to_json(value),
+    }
+}
+
+fn scalar_to_json(value: &Value) -> serde_json::Value {
     match value {
         Value::String(s) => serde_json::Value::String(s.clone()),
         Value::Int(n) => serde_json::Value::Number((*n).into()),
         Value::Float(f) => serde_json::json!(*f),
         Value::Bool(b) => serde_json::Value::Bool(*b),
-        Value::List(items) => {
-            serde_json::Value::Array(items.iter().map(value_to_json_pascal).collect())
-        }
-        Value::Map(map) => {
-            let obj: serde_json::Map<String, serde_json::Value> = map
-                .iter()
-                .map(|(k, v)| (snake_to_pascal(k), value_to_json_pascal(v)))
-                .collect();
-            serde_json::Value::Object(obj)
-        }
+        Value::List(_) | Value::Map(_) => scalar_or_passthrough_to_json(value),
         _ => serde_json::Value::Null,
     }
 }
 
 /// Convert an IAM policy JSON string (PascalCase keys) to a Carina Value::Map (snake_case keys).
+///
+/// Mirrors `value_to_iam_policy_json`'s position-aware case conversion:
+/// only IAM standard fields and condition operators are mapped to
+/// snake_case; condition variable keys, ARN values, and other literals
+/// are preserved verbatim. A blanket `pascal_to_snake` would turn
+/// `aws:SecureTransport` → `aws:secure_transport` (wrong), or
+/// `s3:GetObject` (an Action *value*, not a key) is unaffected only
+/// because Action values are not keys.
 pub fn iam_policy_json_to_value(json_str: &str) -> Result<Value, String> {
     let json: serde_json::Value =
         serde_json::from_str(json_str).map_err(|e| format!("JSON parse failed: {}", e))?;
-    Ok(json_to_value_snake(&json))
+    Ok(json_to_policy_doc(&json))
 }
 
-/// Recursively convert serde_json::Value (PascalCase keys) to Carina Value (snake_case keys).
-fn json_to_value_snake(json: &serde_json::Value) -> Value {
+fn json_to_policy_doc(json: &serde_json::Value) -> Value {
+    let serde_json::Value::Object(obj) = json else {
+        return json_scalar_to_value(json);
+    };
+    let mut map = IndexMap::new();
+    for (k, v) in obj {
+        let snake_key = lookup_snake(POLICY_TOP_FIELDS, k).unwrap_or(k.as_str());
+        let value = if snake_key == "statement" {
+            match v {
+                serde_json::Value::Array(items) => {
+                    Value::List(items.iter().map(json_to_policy_statement).collect())
+                }
+                serde_json::Value::Object(_) => json_to_policy_statement(v),
+                _ => json_scalar_to_value(v),
+            }
+        } else {
+            json_scalar_or_passthrough_to_value(v)
+        };
+        map.insert(snake_key.to_string(), value);
+    }
+    Value::Map(map)
+}
+
+fn json_to_policy_statement(json: &serde_json::Value) -> Value {
+    let serde_json::Value::Object(obj) = json else {
+        return json_scalar_to_value(json);
+    };
+    let mut map = IndexMap::new();
+    for (k, v) in obj {
+        let snake_key = lookup_snake(STATEMENT_FIELDS, k).unwrap_or(k.as_str());
+        let value = match snake_key {
+            "principal" | "not_principal" => json_to_principal(v),
+            "condition" => json_to_condition(v),
+            _ => json_scalar_or_passthrough_to_value(v),
+        };
+        map.insert(snake_key.to_string(), value);
+    }
+    Value::Map(map)
+}
+
+fn json_to_principal(json: &serde_json::Value) -> Value {
+    match json {
+        serde_json::Value::Object(obj) => {
+            let mut map = IndexMap::new();
+            for (k, v) in obj {
+                let key = lookup_snake(PRINCIPAL_FIELDS, k).unwrap_or(k.as_str());
+                map.insert(key.to_string(), json_scalar_or_passthrough_to_value(v));
+            }
+            Value::Map(map)
+        }
+        _ => json_scalar_to_value(json),
+    }
+}
+
+fn json_to_condition(json: &serde_json::Value) -> Value {
+    let serde_json::Value::Object(obj) = json else {
+        return json_scalar_to_value(json);
+    };
+    let mut map = IndexMap::new();
+    for (op_key, kv_value) in obj {
+        let op_snake =
+            carina_aws_types::condition_operator_to_snake(op_key).unwrap_or_else(|| op_key.clone());
+        let kv = match kv_value {
+            // Condition variable keys (e.g. "aws:SecureTransport") pass through.
+            serde_json::Value::Object(inner) => {
+                let mut m = IndexMap::new();
+                for (var, val) in inner {
+                    m.insert(var.clone(), json_scalar_or_passthrough_to_value(val));
+                }
+                Value::Map(m)
+            }
+            _ => json_scalar_to_value(kv_value),
+        };
+        map.insert(op_snake, kv);
+    }
+    Value::Map(map)
+}
+
+fn json_scalar_or_passthrough_to_value(json: &serde_json::Value) -> Value {
+    match json {
+        serde_json::Value::Array(items) => Value::List(
+            items
+                .iter()
+                .map(json_scalar_or_passthrough_to_value)
+                .collect(),
+        ),
+        serde_json::Value::Object(obj) => {
+            let mut map = IndexMap::new();
+            for (k, v) in obj {
+                map.insert(k.clone(), json_scalar_or_passthrough_to_value(v));
+            }
+            Value::Map(map)
+        }
+        _ => json_scalar_to_value(json),
+    }
+}
+
+fn json_scalar_to_value(json: &serde_json::Value) -> Value {
     match json {
         serde_json::Value::String(s) => Value::String(s.clone()),
         serde_json::Value::Number(n) => {
@@ -407,48 +653,15 @@ fn json_to_value_snake(json: &serde_json::Value) -> Value {
             }
         }
         serde_json::Value::Bool(b) => Value::Bool(*b),
-        serde_json::Value::Array(items) => {
-            Value::List(items.iter().map(json_to_value_snake).collect())
-        }
-        serde_json::Value::Object(obj) => {
-            let map: IndexMap<String, Value> = obj
-                .iter()
-                .map(|(k, v)| (pascal_to_snake(k), json_to_value_snake(v)))
-                .collect();
-            Value::Map(map)
-        }
+        // JSON null in policy documents is uncommon and has no faithful
+        // Carina counterpart (Value has no Null variant). Map to empty
+        // string only as a last resort; callers should normally treat
+        // null fields as absent.
         serde_json::Value::Null => Value::String(String::new()),
-    }
-}
-
-/// Convert PascalCase to snake_case (e.g., "AssumeRole" -> "assume_role").
-fn pascal_to_snake(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() && i > 0 {
-            // Don't insert underscore between consecutive uppercase (e.g., "AWS" -> "aws")
-            let prev_upper = s.chars().nth(i - 1).is_some_and(|p| p.is_uppercase());
-            let next_lower = s.chars().nth(i + 1).is_some_and(|n| n.is_lowercase());
-            if !prev_upper || next_lower {
-                result.push('_');
-            }
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            json_scalar_or_passthrough_to_value(json)
         }
-        result.push(c.to_lowercase().next().unwrap_or(c));
     }
-    result
-}
-
-/// Convert snake_case to PascalCase (e.g., "assume_role" -> "AssumeRole").
-fn snake_to_pascal(s: &str) -> String {
-    s.split('_')
-        .map(|part| {
-            let mut chars = part.chars();
-            match chars.next() {
-                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
-                None => String::new(),
-            }
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -509,5 +722,170 @@ mod tests {
         let r = make_resource(Some(Value::Bool(true)));
         let err = resolve_iam_policy_attr(&r, "policy").expect_err("invalid type");
         assert!(format!("{}", err).contains("policy is required"));
+    }
+
+    /// A full deny-insecure-transport policy mirroring the acceptance fixture.
+    /// Exercises principal map, list-valued action/resource, and a
+    /// `bool` condition with the `aws:SecureTransport` value key.
+    fn full_deny_policy_value() -> Value {
+        let mut principal = IndexMap::new();
+        principal.insert("aws".to_string(), Value::String("*".to_string()));
+
+        let mut bool_inner = IndexMap::new();
+        bool_inner.insert(
+            "aws:SecureTransport".to_string(),
+            Value::String("false".to_string()),
+        );
+        let mut condition = IndexMap::new();
+        condition.insert("bool".to_string(), Value::Map(bool_inner));
+
+        let mut stmt = IndexMap::new();
+        stmt.insert(
+            "sid".to_string(),
+            Value::String("DenyInsecureTransport".to_string()),
+        );
+        stmt.insert("effect".to_string(), Value::String("Deny".to_string()));
+        stmt.insert("principal".to_string(), Value::Map(principal));
+        stmt.insert("action".to_string(), Value::String("s3:*".to_string()));
+        stmt.insert(
+            "resource".to_string(),
+            Value::List(vec![
+                Value::String("arn:aws:s3:::my-bucket".to_string()),
+                Value::String("arn:aws:s3:::my-bucket/*".to_string()),
+            ]),
+        );
+        stmt.insert("condition".to_string(), Value::Map(condition));
+
+        let mut doc = IndexMap::new();
+        doc.insert(
+            "version".to_string(),
+            Value::String("2012-10-17".to_string()),
+        );
+        doc.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
+        Value::Map(doc)
+    }
+
+    #[test]
+    fn value_to_iam_policy_json_preserves_condition_variable_keys() {
+        let json = value_to_iam_policy_json(&full_deny_policy_value()).expect("ok");
+
+        // Top-level + statement fields PascalCase.
+        assert!(json.contains("\"Version\""));
+        assert!(json.contains("\"Statement\""));
+        assert!(json.contains("\"Effect\""));
+        assert!(json.contains("\"Sid\""));
+        assert!(json.contains("\"Principal\""));
+        assert!(json.contains("\"Condition\""));
+
+        // Principal "aws" is mapped to PascalCase "AWS" (IAM-specific).
+        assert!(json.contains("\"AWS\""));
+
+        // Condition operator "bool" is mapped to "Bool".
+        assert!(json.contains("\"Bool\""));
+
+        // CRITICAL: condition variable keys with ":" must NOT be case-converted.
+        // A blanket snake_to_pascal would produce "Aws:SecureTransport", which
+        // AWS treats as an unknown — and therefore unenforced — key.
+        assert!(
+            json.contains("\"aws:SecureTransport\""),
+            "expected literal 'aws:SecureTransport' in {}",
+            json
+        );
+        assert!(!json.contains("\"Aws:SecureTransport\""));
+    }
+
+    #[test]
+    fn value_to_iam_policy_json_preserves_action_and_resource_literals() {
+        let json = value_to_iam_policy_json(&full_deny_policy_value()).expect("ok");
+        assert!(json.contains("\"s3:*\""));
+        assert!(json.contains("\"arn:aws:s3:::my-bucket\""));
+        assert!(json.contains("\"arn:aws:s3:::my-bucket/*\""));
+    }
+
+    #[test]
+    fn iam_policy_json_to_value_inverts_value_to_iam_policy_json() {
+        let original = full_deny_policy_value();
+        let json = value_to_iam_policy_json(&original).expect("to json");
+        let roundtripped = iam_policy_json_to_value(&json).expect("from json");
+        assert_eq!(original, roundtripped, "round-trip must be lossless");
+    }
+
+    #[test]
+    fn iam_policy_json_to_value_handles_pascal_input() {
+        // Simulates AWS's GetBucketPolicy response shape.
+        let aws_json = r#"{
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Sid": "DenyInsecureTransport",
+                "Effect": "Deny",
+                "Principal": {"AWS": "*"},
+                "Action": "s3:*",
+                "Resource": ["arn:aws:s3:::my-bucket", "arn:aws:s3:::my-bucket/*"],
+                "Condition": {"Bool": {"aws:SecureTransport": "false"}}
+            }]
+        }"#;
+        let value = iam_policy_json_to_value(aws_json).expect("ok");
+        let Value::Map(doc) = &value else {
+            panic!("expected map");
+        };
+        // Top-level snake_case.
+        assert!(doc.contains_key("version"));
+        assert!(doc.contains_key("statement"));
+
+        // Drill into statement[0].condition.bool.
+        let Value::List(stmts) = doc.get("statement").unwrap() else {
+            panic!();
+        };
+        let Value::Map(stmt) = &stmts[0] else {
+            panic!()
+        };
+        let Value::Map(cond) = stmt.get("condition").unwrap() else {
+            panic!()
+        };
+        let Value::Map(bool_inner) = cond.get("bool").unwrap() else {
+            panic!()
+        };
+        // CRITICAL: condition variable key preserved verbatim.
+        assert!(bool_inner.contains_key("aws:SecureTransport"));
+        assert!(!bool_inner.contains_key("aws:secure_transport"));
+
+        // Principal {"AWS"} → snake "aws".
+        let Value::Map(principal) = stmt.get("principal").unwrap() else {
+            panic!()
+        };
+        assert!(principal.contains_key("aws"));
+    }
+
+    #[test]
+    fn condition_operator_is_translated_round_trip() {
+        // string_equals ↔ StringEquals via condition_operator_to_aws/snake.
+        let mut inner = IndexMap::new();
+        inner.insert(
+            "aws:PrincipalOrgID".to_string(),
+            Value::String("o-1234567890".to_string()),
+        );
+        let mut condition = IndexMap::new();
+        condition.insert("string_equals".to_string(), Value::Map(inner));
+        let mut stmt = IndexMap::new();
+        stmt.insert("effect".to_string(), Value::String("Allow".to_string()));
+        stmt.insert(
+            "action".to_string(),
+            Value::String("s3:GetObject".to_string()),
+        );
+        stmt.insert("condition".to_string(), Value::Map(condition));
+        let mut doc = IndexMap::new();
+        doc.insert(
+            "version".to_string(),
+            Value::String("2012-10-17".to_string()),
+        );
+        doc.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
+
+        let original = Value::Map(doc);
+        let json = value_to_iam_policy_json(&original).expect("ok");
+        assert!(json.contains("\"StringEquals\""));
+        assert!(json.contains("\"aws:PrincipalOrgID\""));
+
+        let roundtripped = iam_policy_json_to_value(&json).expect("ok");
+        assert_eq!(original, roundtripped);
     }
 }

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -130,23 +130,8 @@ impl AwsProvider {
         to: Resource,
     ) -> ProviderResult<State> {
         // Update assume role policy document
-        if let Some(policy_value) = to.get_attr("assume_role_policy_document") {
-            let policy_doc = match policy_value {
-                Value::String(s) => s.clone(),
-                Value::Map(_) => value_to_iam_policy_json(policy_value).map_err(|e| {
-                    ProviderError::new(format!(
-                        "Failed to convert assume_role_policy_document: {}",
-                        e
-                    ))
-                    .for_resource(id.clone())
-                })?,
-                _ => {
-                    return Err(ProviderError::new(
-                        "assume_role_policy_document must be a string or map",
-                    )
-                    .for_resource(id.clone()));
-                }
-            };
+        if to.get_attr("assume_role_policy_document").is_some() {
+            let policy_doc = resolve_iam_policy_attr(&to, "assume_role_policy_document")?;
             self.iam_client
                 .update_assume_role_policy()
                 .role_name(identifier)
@@ -549,6 +534,9 @@ fn json_to_policy_doc(json: &serde_json::Value) -> Value {
     };
     let mut map = IndexMap::new();
     for (k, v) in obj {
+        if v.is_null() {
+            continue;
+        }
         let snake_key = lookup_snake(POLICY_TOP_FIELDS, k).unwrap_or(k.as_str());
         let value = if snake_key == "statement" {
             match v {
@@ -572,6 +560,9 @@ fn json_to_policy_statement(json: &serde_json::Value) -> Value {
     };
     let mut map = IndexMap::new();
     for (k, v) in obj {
+        if v.is_null() {
+            continue;
+        }
         let snake_key = lookup_snake(STATEMENT_FIELDS, k).unwrap_or(k.as_str());
         let value = match snake_key {
             "principal" | "not_principal" => json_to_principal(v),
@@ -588,6 +579,9 @@ fn json_to_principal(json: &serde_json::Value) -> Value {
         serde_json::Value::Object(obj) => {
             let mut map = IndexMap::new();
             for (k, v) in obj {
+                if v.is_null() {
+                    continue;
+                }
                 let key = lookup_snake(PRINCIPAL_FIELDS, k).unwrap_or(k.as_str());
                 map.insert(key.to_string(), json_scalar_or_passthrough_to_value(v));
             }
@@ -603,6 +597,9 @@ fn json_to_condition(json: &serde_json::Value) -> Value {
     };
     let mut map = IndexMap::new();
     for (op_key, kv_value) in obj {
+        if kv_value.is_null() {
+            continue;
+        }
         let op_snake =
             carina_aws_types::condition_operator_to_snake(op_key).unwrap_or_else(|| op_key.clone());
         let kv = match kv_value {
@@ -610,6 +607,9 @@ fn json_to_condition(json: &serde_json::Value) -> Value {
             serde_json::Value::Object(inner) => {
                 let mut m = IndexMap::new();
                 for (var, val) in inner {
+                    if val.is_null() {
+                        continue;
+                    }
                     m.insert(var.clone(), json_scalar_or_passthrough_to_value(val));
                 }
                 Value::Map(m)
@@ -854,6 +854,118 @@ mod tests {
             panic!()
         };
         assert!(principal.contains_key("aws"));
+        assert_eq!(
+            principal.get("aws"),
+            Some(&Value::String("*".to_string())),
+            "principal value should round-trip verbatim"
+        );
+    }
+
+    #[test]
+    fn id_field_round_trips() {
+        let mut doc = IndexMap::new();
+        doc.insert(
+            "version".to_string(),
+            Value::String("2012-10-17".to_string()),
+        );
+        doc.insert("id".to_string(), Value::String("MyPolicyId".to_string()));
+        doc.insert("statement".to_string(), Value::List(vec![]));
+
+        let original = Value::Map(doc);
+        let json = value_to_iam_policy_json(&original).expect("ok");
+        assert!(json.contains("\"Id\""));
+        assert!(json.contains("\"MyPolicyId\""));
+
+        let roundtripped = iam_policy_json_to_value(&json).expect("ok");
+        assert_eq!(original, roundtripped);
+    }
+
+    #[test]
+    fn statement_as_single_object_form_is_handled() {
+        // Some tools emit Statement as a single object rather than a list.
+        let aws_json = r#"{
+            "Version": "2012-10-17",
+            "Statement": {
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "*"
+            }
+        }"#;
+        let value = iam_policy_json_to_value(aws_json).expect("ok");
+        let Value::Map(doc) = &value else { panic!() };
+        let Value::Map(stmt) = doc.get("statement").unwrap() else {
+            panic!("statement should be a Map for single-object form")
+        };
+        assert_eq!(
+            stmt.get("effect"),
+            Some(&Value::String("Allow".to_string()))
+        );
+    }
+
+    #[test]
+    fn principal_string_form_is_handled() {
+        // Principal: "*" — wildcard as a bare string, not a map.
+        let aws_json = r#"{
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Deny",
+                "Principal": "*",
+                "Action": "s3:*",
+                "Resource": "*"
+            }]
+        }"#;
+        let value = iam_policy_json_to_value(aws_json).expect("ok");
+        let Value::Map(doc) = &value else { panic!() };
+        let Value::List(stmts) = doc.get("statement").unwrap() else {
+            panic!()
+        };
+        let Value::Map(stmt) = &stmts[0] else {
+            panic!()
+        };
+        assert_eq!(
+            stmt.get("principal"),
+            Some(&Value::String("*".to_string())),
+            "principal string form should pass through verbatim"
+        );
+    }
+
+    #[test]
+    fn condition_qualifier_round_trips() {
+        // ForAllValues:StringEquals + IfExists are handled by
+        // condition_operator_to_aws/snake; verify they round-trip when used
+        // through the policy converters.
+        let mut inner = IndexMap::new();
+        inner.insert(
+            "aws:TagKeys".to_string(),
+            Value::List(vec![Value::String("Environment".to_string())]),
+        );
+        let mut condition = IndexMap::new();
+        condition.insert(
+            "for_all_values_string_equals_if_exists".to_string(),
+            Value::Map(inner),
+        );
+        let mut stmt = IndexMap::new();
+        stmt.insert("effect".to_string(), Value::String("Allow".to_string()));
+        stmt.insert("action".to_string(), Value::String("s3:*".to_string()));
+        stmt.insert("condition".to_string(), Value::Map(condition));
+        let mut doc = IndexMap::new();
+        doc.insert(
+            "version".to_string(),
+            Value::String("2012-10-17".to_string()),
+        );
+        doc.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
+
+        let original = Value::Map(doc);
+        let json = value_to_iam_policy_json(&original).expect("ok");
+        assert!(
+            json.contains("\"ForAllValues:StringEqualsIfExists\""),
+            "expected qualified op in {}",
+            json
+        );
+        assert!(json.contains("\"aws:TagKeys\""));
+
+        let roundtripped = iam_policy_json_to_value(&json).expect("ok");
+        assert_eq!(original, roundtripped);
     }
 
     #[test]

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -75,22 +75,8 @@ impl AwsProvider {
     pub(crate) async fn create_iam_role(&self, resource: Resource) -> ProviderResult<State> {
         let role_name = require_string_attr(&resource, "role_name")?;
 
-        let assume_role_policy_document = match resource.get_attr("assume_role_policy_document") {
-            Some(Value::String(s)) => s.clone(),
-            Some(value @ Value::Map(_)) => value_to_iam_policy_json(value).map_err(|e| {
-                ProviderError::new(format!(
-                    "Failed to convert assume_role_policy_document: {}",
-                    e
-                ))
-                .for_resource(resource.id.clone())
-            })?,
-            _ => {
-                return Err(
-                    ProviderError::new("assume_role_policy_document is required")
-                        .for_resource(resource.id.clone()),
-                );
-            }
-        };
+        let assume_role_policy_document =
+            resolve_iam_policy_attr(&resource, "assume_role_policy_document")?;
 
         let mut req = self
             .iam_client
@@ -358,6 +344,27 @@ pub fn value_to_iam_policy_json(value: &Value) -> Result<String, String> {
     serde_json::to_string(&json_value).map_err(|e| format!("JSON serialization failed: {}", e))
 }
 
+/// Resolve an IAM-style policy attribute (e.g. `assume_role_policy_document`,
+/// `policy`) on a `Resource` into a JSON string suitable for the AWS API.
+///
+/// Accepts either a pre-serialized JSON string or a Carina `Value::Map`
+/// (block-syntax DSL form). Errors when the attribute is missing or has an
+/// unsupported type.
+pub fn resolve_iam_policy_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
+    match resource.get_attr(attr_name) {
+        Some(Value::String(s)) => Ok(s.clone()),
+        Some(value @ Value::Map(_)) => value_to_iam_policy_json(value).map_err(|e| {
+            ProviderError::new(format!("Failed to convert {}: {}", attr_name, e))
+                .for_resource(resource.id.clone())
+        }),
+        _ => Err(ProviderError::new(format!(
+            "{} is required (must be a JSON string or block)",
+            attr_name
+        ))
+        .for_resource(resource.id.clone())),
+    }
+}
+
 /// Recursively convert a Carina Value to serde_json::Value with PascalCase keys.
 fn value_to_json_pascal(value: &Value) -> serde_json::Value {
     match value {
@@ -442,4 +449,65 @@ fn snake_to_pascal(s: &str) -> String {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn make_resource(policy: Option<Value>) -> Resource {
+        let mut r = Resource::new("test.Type", "test");
+        if let Some(v) = policy {
+            r.set_attr("policy", v);
+        }
+        r
+    }
+
+    #[test]
+    fn resolve_iam_policy_attr_accepts_json_string_passthrough() {
+        let json = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        let r = make_resource(Some(Value::String(json.to_string())));
+        let resolved = resolve_iam_policy_attr(&r, "policy").expect("string passthrough");
+        assert_eq!(resolved, json);
+    }
+
+    #[test]
+    fn resolve_iam_policy_attr_serializes_map_to_pascal_case_json() {
+        let mut policy = IndexMap::new();
+        policy.insert(
+            "version".to_string(),
+            Value::String("2012-10-17".to_string()),
+        );
+        let mut stmt = IndexMap::new();
+        stmt.insert("effect".to_string(), Value::String("Allow".to_string()));
+        stmt.insert(
+            "action".to_string(),
+            Value::String("s3:GetObject".to_string()),
+        );
+        policy.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
+
+        let r = make_resource(Some(Value::Map(policy)));
+        let resolved = resolve_iam_policy_attr(&r, "policy").expect("map → JSON");
+
+        assert!(resolved.contains("\"Version\""));
+        assert!(resolved.contains("\"Statement\""));
+        assert!(resolved.contains("\"Effect\""));
+        assert!(resolved.contains("\"Action\""));
+        assert!(!resolved.contains("\"version\""));
+    }
+
+    #[test]
+    fn resolve_iam_policy_attr_errors_when_missing() {
+        let r = make_resource(None);
+        let err = resolve_iam_policy_attr(&r, "policy").expect_err("missing");
+        assert!(format!("{}", err).contains("policy is required"));
+    }
+
+    #[test]
+    fn resolve_iam_policy_attr_errors_on_non_string_non_map() {
+        let r = make_resource(Some(Value::Bool(true)));
+        let err = resolve_iam_policy_attr(&r, "policy").expect_err("invalid type");
+        assert!(format!("{}", err).contains("policy is required"));
+    }
 }

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -853,7 +853,7 @@ fn classify_head_bucket_status(status: u16, is_not_found_error: bool) -> HeadBuc
 }
 
 /// Check if an S3 SDK error is a "not configured" error that should be silently ignored.
-fn is_s3_not_configured_error<E: aws_sdk_s3::error::ProvideErrorMetadata>(
+pub(crate) fn is_s3_not_configured_error<E: aws_sdk_s3::error::ProvideErrorMetadata>(
     err: &aws_sdk_s3::error::SdkError<E>,
     expected_code: &str,
 ) -> bool {

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
-use crate::services::iam::role::{iam_policy_json_to_value, value_to_iam_policy_json};
+use crate::services::iam::role::{iam_policy_json_to_value, resolve_iam_policy_attr};
+use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
     /// Read an S3 BucketPolicy.
@@ -45,9 +45,7 @@ impl AwsProvider {
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
             }
             Err(e) => {
-                if let Some(service_err) = e.as_service_error()
-                    && service_err.code() == Some("NoSuchBucketPolicy")
-                {
+                if is_s3_not_configured_error(&e, "NoSuchBucketPolicy") {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
@@ -64,20 +62,7 @@ impl AwsProvider {
         resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
-        let policy_json = resolve_policy_attr(&resource)?;
-
-        self.s3_client
-            .put_bucket_policy()
-            .bucket(&bucket)
-            .policy(&policy_json)
-            .send()
-            .await
-            .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket policy", &e))
-                    .for_resource(resource.id.clone())
-            })?;
-
-        self.read_s3_bucket_policy(&resource.id, Some(&bucket))
+        self.put_s3_bucket_policy(&resource.id, &bucket, &resource)
             .await
     }
 
@@ -89,98 +74,28 @@ impl AwsProvider {
         _from: &State,
         to: Resource,
     ) -> ProviderResult<State> {
-        let policy_json = resolve_policy_attr(&to)?;
+        self.put_s3_bucket_policy(&id, identifier, &to).await
+    }
+
+    async fn put_s3_bucket_policy(
+        &self,
+        id: &ResourceId,
+        bucket: &str,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let policy_json = resolve_iam_policy_attr(resource, "policy")?;
 
         self.s3_client
             .put_bucket_policy()
-            .bucket(identifier)
+            .bucket(bucket)
             .policy(&policy_json)
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to update bucket policy", &e))
+                ProviderError::new(sdk_error_message("Failed to put bucket policy", &e))
                     .for_resource(id.clone())
             })?;
 
-        self.read_s3_bucket_policy(&id, Some(identifier)).await
-    }
-}
-
-/// Resolve the `policy` attribute on a BucketPolicy resource into a JSON
-/// string suitable for the AWS API. Accepts either a pre-serialized JSON
-/// string or a Carina `Value::Map` (block-syntax DSL form).
-fn resolve_policy_attr(resource: &Resource) -> ProviderResult<String> {
-    match resource.get_attr("policy") {
-        Some(Value::String(s)) => Ok(s.clone()),
-        Some(value @ Value::Map(_)) => value_to_iam_policy_json(value).map_err(|e| {
-            ProviderError::new(format!("Failed to convert policy: {}", e))
-                .for_resource(resource.id.clone())
-        }),
-        _ => Err(
-            ProviderError::new("policy is required (must be a JSON string or block)")
-                .for_resource(resource.id.clone()),
-        ),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use indexmap::IndexMap;
-
-    fn make_resource(policy: Option<Value>) -> Resource {
-        let mut r = Resource::new("s3.BucketPolicy", "test");
-        r.set_attr("bucket", Value::String("my-bucket".to_string()));
-        if let Some(v) = policy {
-            r.set_attr("policy", v);
-        }
-        r
-    }
-
-    #[test]
-    fn resolve_policy_attr_accepts_json_string_passthrough() {
-        let json = r#"{"Version":"2012-10-17","Statement":[]}"#;
-        let r = make_resource(Some(Value::String(json.to_string())));
-        let resolved = resolve_policy_attr(&r).expect("string passthrough");
-        assert_eq!(resolved, json);
-    }
-
-    #[test]
-    fn resolve_policy_attr_serializes_map_to_pascal_case_json() {
-        let mut policy = IndexMap::new();
-        policy.insert(
-            "version".to_string(),
-            Value::String("2012-10-17".to_string()),
-        );
-        let mut stmt = IndexMap::new();
-        stmt.insert("effect".to_string(), Value::String("Allow".to_string()));
-        stmt.insert(
-            "action".to_string(),
-            Value::String("s3:GetObject".to_string()),
-        );
-        policy.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
-
-        let r = make_resource(Some(Value::Map(policy)));
-        let resolved = resolve_policy_attr(&r).expect("map → JSON");
-
-        assert!(resolved.contains("\"Version\""));
-        assert!(resolved.contains("\"Statement\""));
-        assert!(resolved.contains("\"Effect\""));
-        assert!(resolved.contains("\"Action\""));
-        assert!(!resolved.contains("\"version\""));
-    }
-
-    #[test]
-    fn resolve_policy_attr_errors_when_missing() {
-        let r = make_resource(None);
-        let err = resolve_policy_attr(&r).expect_err("missing policy");
-        assert!(format!("{}", err).contains("policy is required"));
-    }
-
-    #[test]
-    fn resolve_policy_attr_errors_on_non_string_non_map() {
-        let r = make_resource(Some(Value::Bool(true)));
-        let err = resolve_policy_attr(&r).expect_err("invalid type");
-        assert!(format!("{}", err).contains("policy is required"));
+        self.read_s3_bucket_policy(id, Some(bucket)).await
     }
 }

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::services::iam::role::{iam_policy_json_to_value, value_to_iam_policy_json};
+
+impl AwsProvider {
+    /// Read an S3 BucketPolicy.
+    ///
+    /// `identifier` is the bucket name. Returns `State::not_found` when the
+    /// bucket has no policy (`NoSuchBucketPolicy`); other errors propagate.
+    pub(crate) async fn read_s3_bucket_policy(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(bucket) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .s3_client
+            .get_bucket_policy()
+            .bucket(bucket)
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                let mut attributes = HashMap::new();
+                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+
+                if let Some(policy_json) = output.policy() {
+                    let policy_value = iam_policy_json_to_value(policy_json).map_err(|e| {
+                        ProviderError::new(format!("Failed to parse bucket policy: {}", e))
+                            .for_resource(id.clone())
+                    })?;
+                    attributes.insert("policy".to_string(), policy_value);
+                }
+
+                Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
+            }
+            Err(e) => {
+                if let Some(service_err) = e.as_service_error()
+                    && service_err.code() == Some("NoSuchBucketPolicy")
+                {
+                    return Ok(State::not_found(id.clone()));
+                }
+                Err(
+                    ProviderError::new(sdk_error_message("Failed to get bucket policy", &e))
+                        .for_resource(id.clone()),
+                )
+            }
+        }
+    }
+
+    /// Create an S3 BucketPolicy via PutBucketPolicy.
+    pub(crate) async fn create_s3_bucket_policy(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let bucket = require_string_attr(&resource, "bucket")?;
+        let policy_json = resolve_policy_attr(&resource)?;
+
+        self.s3_client
+            .put_bucket_policy()
+            .bucket(&bucket)
+            .policy(&policy_json)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to put bucket policy", &e))
+                    .for_resource(resource.id.clone())
+            })?;
+
+        self.read_s3_bucket_policy(&resource.id, Some(&bucket))
+            .await
+    }
+
+    /// Update an S3 BucketPolicy. PutBucketPolicy replaces the existing policy.
+    pub(crate) async fn update_s3_bucket_policy(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        _from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        let policy_json = resolve_policy_attr(&to)?;
+
+        self.s3_client
+            .put_bucket_policy()
+            .bucket(identifier)
+            .policy(&policy_json)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to update bucket policy", &e))
+                    .for_resource(id.clone())
+            })?;
+
+        self.read_s3_bucket_policy(&id, Some(identifier)).await
+    }
+}
+
+/// Resolve the `policy` attribute on a BucketPolicy resource into a JSON
+/// string suitable for the AWS API. Accepts either a pre-serialized JSON
+/// string or a Carina `Value::Map` (block-syntax DSL form).
+fn resolve_policy_attr(resource: &Resource) -> ProviderResult<String> {
+    match resource.get_attr("policy") {
+        Some(Value::String(s)) => Ok(s.clone()),
+        Some(value @ Value::Map(_)) => value_to_iam_policy_json(value).map_err(|e| {
+            ProviderError::new(format!("Failed to convert policy: {}", e))
+                .for_resource(resource.id.clone())
+        }),
+        _ => Err(
+            ProviderError::new("policy is required (must be a JSON string or block)")
+                .for_resource(resource.id.clone()),
+        ),
+    }
+}

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -98,4 +98,30 @@ impl AwsProvider {
 
         self.read_s3_bucket_policy(id, Some(bucket)).await
     }
+
+    /// Delete an S3 BucketPolicy. Treats `NoSuchBucketPolicy` as success
+    /// so destroy is idempotent when the policy was already removed
+    /// (e.g. out-of-band cleanup or a destroy retry after partial success).
+    pub(crate) async fn delete_s3_bucket_policy_idempotent(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let result = self
+            .s3_client
+            .delete_bucket_policy()
+            .bucket(identifier)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if is_s3_not_configured_error(&e, "NoSuchBucketPolicy") => Ok(()),
+            Err(e) => Err(ProviderError::new(sdk_error_message(
+                "Failed to delete bucket policy",
+                &e,
+            ))
+            .for_resource(id.clone())),
+        }
+    }
 }

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -99,9 +99,12 @@ impl AwsProvider {
         self.read_s3_bucket_policy(id, Some(bucket)).await
     }
 
-    /// Delete an S3 BucketPolicy. Treats `NoSuchBucketPolicy` as success
-    /// so destroy is idempotent when the policy was already removed
-    /// (e.g. out-of-band cleanup or a destroy retry after partial success).
+    /// Delete an S3 BucketPolicy idempotently.
+    ///
+    /// Treats both `NoSuchBucketPolicy` (no policy was attached) and
+    /// `NoSuchBucket` (the parent bucket itself was deleted out-of-band)
+    /// as success. The policy cannot exist without the bucket, so either
+    /// signal means the destroy goal is satisfied.
     pub(crate) async fn delete_s3_bucket_policy_idempotent(
         &self,
         id: ResourceId,
@@ -116,7 +119,12 @@ impl AwsProvider {
 
         match result {
             Ok(_) => Ok(()),
-            Err(e) if is_s3_not_configured_error(&e, "NoSuchBucketPolicy") => Ok(()),
+            Err(e)
+                if is_s3_not_configured_error(&e, "NoSuchBucketPolicy")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket") =>
+            {
+                Ok(())
+            }
             Err(e) => Err(ProviderError::new(sdk_error_message(
                 "Failed to delete bucket policy",
                 &e,

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -122,3 +122,65 @@ fn resolve_policy_attr(resource: &Resource) -> ProviderResult<String> {
         ),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn make_resource(policy: Option<Value>) -> Resource {
+        let mut r = Resource::new("s3.BucketPolicy", "test");
+        r.set_attr("bucket", Value::String("my-bucket".to_string()));
+        if let Some(v) = policy {
+            r.set_attr("policy", v);
+        }
+        r
+    }
+
+    #[test]
+    fn resolve_policy_attr_accepts_json_string_passthrough() {
+        let json = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        let r = make_resource(Some(Value::String(json.to_string())));
+        let resolved = resolve_policy_attr(&r).expect("string passthrough");
+        assert_eq!(resolved, json);
+    }
+
+    #[test]
+    fn resolve_policy_attr_serializes_map_to_pascal_case_json() {
+        let mut policy = IndexMap::new();
+        policy.insert(
+            "version".to_string(),
+            Value::String("2012-10-17".to_string()),
+        );
+        let mut stmt = IndexMap::new();
+        stmt.insert("effect".to_string(), Value::String("Allow".to_string()));
+        stmt.insert(
+            "action".to_string(),
+            Value::String("s3:GetObject".to_string()),
+        );
+        policy.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
+
+        let r = make_resource(Some(Value::Map(policy)));
+        let resolved = resolve_policy_attr(&r).expect("map → JSON");
+
+        assert!(resolved.contains("\"Version\""));
+        assert!(resolved.contains("\"Statement\""));
+        assert!(resolved.contains("\"Effect\""));
+        assert!(resolved.contains("\"Action\""));
+        assert!(!resolved.contains("\"version\""));
+    }
+
+    #[test]
+    fn resolve_policy_attr_errors_when_missing() {
+        let r = make_resource(None);
+        let err = resolve_policy_attr(&r).expect_err("missing policy");
+        assert!(format!("{}", err).contains("policy is required"));
+    }
+
+    #[test]
+    fn resolve_policy_attr_errors_on_non_string_non_map() {
+        let r = make_resource(Some(Value::Bool(true)));
+        let err = resolve_policy_attr(&r).expect_err("invalid type");
+        assert!(format!("{}", err).contains("policy is required"));
+    }
+}

--- a/carina-provider-aws/src/services/s3/mod.rs
+++ b/carina-provider-aws/src/services/s3/mod.rs
@@ -1,1 +1,2 @@
 pub mod bucket;
+pub mod bucket_policy;


### PR DESCRIPTION
## Summary

- Adds `aws.s3.BucketPolicy` as a standalone Carina-managed resource — the first slice of the Terraform-style decomposition decided in #164
- Maps to `PutBucketPolicy` / `GetBucketPolicy` / `DeleteBucketPolicy` (delete is idempotent — swallows `NoSuchBucketPolicy` and `NoSuchBucket`)
- The `policy` attribute uses the existing `iam_policy_document()` Struct, so users write block-syntax DSL (matching `iam.role.assume_role_policy_document`); the provider converts to/from JSON at the API boundary

## Critical incidental fix

Implementing this PR surfaced a critical bug in the existing `iam.role` policy converter: a blanket `snake_to_pascal` was applied to every map key, mangling IAM condition variable keys like `aws:SecureTransport` → `Aws:SecureTransport` (AWS treats this as an unknown — and therefore unenforced — key). This silently broke any policy with `Condition` blocks. `iam.role` shipped with the bug because typical `assume_role_policy_document` usage rarely needs `Condition`.

The PR replaces `value_to_iam_policy_json` / `iam_policy_json_to_value` with **position-aware** converters that case-convert only IAM standard fields and condition operators, passing condition variable keys, ARN values, and Action / Resource literals through verbatim. Round-trip lossless on the deny-insecure-transport fixture.

Lookup tables (`POLICY_TOP_FIELDS`, `STATEMENT_FIELDS`, `PRINCIPAL_FIELDS`) cover the IAM JSON policy reference; condition operators delegate to the existing `carina_aws_types::condition_operator_to_aws/snake` (which already handles `ForAllValues:` qualifiers and `IfExists` suffixes).

## DSL example

```
let bucket = aws.s3.Bucket {
  bucket = 'carina-acc-test-aws-s3-bucket-policy-basic-v1'
}

aws.s3.BucketPolicy {
  bucket = bucket.bucket

  policy = {
    version = '2012-10-17'
    statement {
      sid    = 'DenyInsecureTransport'
      effect = 'Deny'
      principal = { aws = '*' }
      action   = 's3:*'
      resource = [
        'arn:aws:s3:::carina-acc-test-aws-s3-bucket-policy-basic-v1',
        'arn:aws:s3:::carina-acc-test-aws-s3-bucket-policy-basic-v1/*',
      ]
      condition = {
        bool = {
          'aws:SecureTransport' = 'false'
        }
      }
    }
  }
}
```

## Test plan

- [x] `cargo nextest run` — 330 tests passing (incl. 14 IAM policy converter tests covering condition-variable-key preservation, list-valued action / resource, principal string form, statement-as-object form, `Id` field, `ForAllValues:` qualifier, full lossless round-trip)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — builds
- [x] `bash scripts/generate-schemas-smithy.sh && bash scripts/generate-provider.sh` — no diff
- [ ] Acceptance test (`acceptance-tests/s3_bucket_policy/basic.crn`) — apply against real AWS with `aws-vault exec`; not yet run

Closes #209
