### PR TITLE
Implement aws.s3.BucketPublicAccessBlock as a standalone resource (#164 slice)

### DIFF
--- a/acceptance-tests/s3_bucket_public_access_block/basic.crn
+++ b/acceptance-tests/s3_bucket_public_access_block/basic.crn
@@ -1,0 +1,21 @@
+# S3 BucketPublicAccessBlock - Basic test
+#
+# Tests: standalone aws.s3.BucketPublicAccessBlock controlling the
+# Public Access Block settings of a bucket.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-bucket-pab-basic-v1'
+}
+
+aws.s3.BucketPublicAccessBlock {
+  bucket = bucket.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -580,11 +580,11 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             && !read_only_overrides.contains(name.as_str());
         let is_read_only = read_only_overrides.contains(name.as_str());
         // `extra_writable` fields with `read_source = None` are synthetic:
-        // the codegen has no Smithy member to ground them in, so it has to
-        // assume create-only. Fields with `read_source = Some(...)` come
-        // from a real read-structure member and follow the normal rules —
-        // whether they're updatable is decided by `create_only_overrides`
-        // and `update_ops`, the same as any other writable field.
+        // the codegen has no Smithy member to ground them in. They default
+        // to create-only — UNLESS they appear in `update_ops` (typically as
+        // `FieldLayout::InsideStruct` members, e.g. PutPublicAccessBlock's
+        // `PublicAccessBlockConfiguration` sub-fields), in which case they
+        // are updatable just like any other writable field.
         let is_synthetic_extra_writable = res
             .extra_writable
             .iter()
@@ -592,7 +592,8 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         let is_create_only = if is_read_only {
             false
         } else if is_synthetic_extra_writable {
-            true
+            !updatable_fields.contains(name.as_str())
+                || create_only_overrides.contains(name.as_str())
         } else if schema_structure.is_some() {
             // For schema_structure resources, only explicit overrides are create-only.
             // The default is writable since the update operation is hand-coded.
@@ -637,7 +638,10 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         });
     }
 
-    // Process synthetic extra writable fields (no read_source)
+    // Process synthetic extra writable fields (no read_source).
+    // A synthetic field defaults to create-only, but is treated as updatable
+    // when it appears in `update_ops` (typically as a `FieldLayout::InsideStruct`
+    // member of a wrapper struct in the API request shape).
     for extra in &res.extra_writable {
         if extra.read_source.is_some() {
             continue; // Already handled via writable_fields
@@ -650,12 +654,14 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         } else {
             "AttributeType::String".to_string()
         };
+        let is_create_only =
+            !updatable_fields.contains(extra.name) || create_only_overrides.contains(extra.name);
         attrs.push(AttrInfo {
             snake_name,
             provider_name: extra.name.to_string(),
             type_code,
             is_required: false,
-            is_create_only: true,
+            is_create_only,
             is_read_only: false,
             is_identity: identity_overrides.contains(extra.name),
             description: extra.description.map(|s| s.to_string()),
@@ -1945,6 +1951,17 @@ fn generate_provider_code(
             let suffix = op_suffix(update_op.operation, res.identifier);
             let method_name = format!("write_{}_{}", resource_name, suffix);
             if manual_methods.contains(&method_name) {
+                continue;
+            }
+            // Skip generating the write function if any of the struct fields
+            // has a `type_overrides` entry: the override changes the DSL Value
+            // type (e.g. Bool, Json) but the generated builder body assumes
+            // `Value::String`. The provider-side write must be hand-written
+            // in services/<service>/<resource>.rs.
+            if update_fields
+                .iter()
+                .any(|f| res.type_overrides.iter().any(|(k, _)| *k == *f))
+            {
                 continue;
             }
             let sdk_method = update_op.operation.to_snake_case();
@@ -3919,6 +3936,10 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "ec2.VpnGateway" => "AWS::EC2::VPNGateway",
         "s3.Bucket" => "AWS::S3::Bucket",
         "s3.BucketPolicy" => "AWS::S3::BucketPolicy",
+        // No native CloudFormation type — PublicAccessBlock is a property
+        // of AWS::S3::Bucket. We synthesize a name to keep cf_type_name a
+        // total function for codegen consumers.
+        "s3.BucketPublicAccessBlock" => "AWS::S3::BucketPublicAccessBlock",
         "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
         "organizations.Organization" => "AWS::Organizations::Organization",
         "organizations.Account" => "AWS::Organizations::Account",

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1276,6 +1276,88 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
+        // s3.BucketPublicAccessBlock — controls the Public Access Block
+        // settings of an existing S3 bucket. Maps to PutPublicAccessBlock /
+        // GetPublicAccessBlock / DeletePublicAccessBlock.
+        ResourceDef {
+            name: "s3.BucketPublicAccessBlock",
+            service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
+            // simple_delete: false because delete is hand-written
+            // (delete_s3_bucket_public_access_block_idempotent) — it treats
+            // NoSuchPublicAccessBlockConfiguration / NoSuchBucket as success
+            // so destroy retries succeed when the configuration or its
+            // parent bucket is already gone.
+            simple_delete: false,
+            noop_update: false,
+            create_op: "PutPublicAccessBlock",
+            read_structure: None,
+            // Read / Create / Update / Delete are hand-written in
+            // services/s3/bucket_public_access_block.rs because the AWS
+            // SDK's PublicAccessBlockConfiguration takes typed `bool`
+            // setters that the generic codegen-emitted write function
+            // (which assumes Value::String) cannot satisfy.
+            read_ops: vec![],
+            delete_op: "DeletePublicAccessBlock",
+            update_ops: vec![UpdateOp {
+                operation: "PutPublicAccessBlock",
+                fields: FieldLayout::InsideStruct {
+                    name: "PublicAccessBlockConfiguration",
+                    fields: vec![
+                        "BlockPublicAcls",
+                        "IgnorePublicAcls",
+                        "BlockPublicPolicy",
+                        "RestrictPublicBuckets",
+                    ],
+                },
+            }],
+            identifier: "Bucket",
+            has_tags: false,
+            type_overrides: vec![
+                ("BlockPublicAcls", "AttributeType::Bool"),
+                ("IgnorePublicAcls", "AttributeType::Bool"),
+                ("BlockPublicPolicy", "AttributeType::Bool"),
+                ("RestrictPublicBuckets", "AttributeType::Bool"),
+            ],
+            exclude_fields: vec![
+                "ContentMD5",
+                "ChecksumAlgorithm",
+                "ExpectedBucketOwner",
+                "PublicAccessBlockConfiguration",
+            ],
+            create_only_overrides: vec!["Bucket"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Bucket"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![
+                ExtraField {
+                    name: "BlockPublicAcls",
+                    read_source: None,
+                    description: Some("Block public ACLs on the bucket and its objects."),
+                },
+                ExtraField {
+                    name: "IgnorePublicAcls",
+                    read_source: None,
+                    description: Some("Ignore any public ACLs on the bucket and its objects."),
+                },
+                ExtraField {
+                    name: "BlockPublicPolicy",
+                    read_source: None,
+                    description: Some("Block public bucket policies for the bucket."),
+                },
+                ExtraField {
+                    name: "RestrictPublicBuckets",
+                    read_source: None,
+                    description: Some(
+                        "Restrict access to the bucket to AWS service principals and authorized users when a public policy is set.",
+                    ),
+                },
+            ],
+            identity_overrides: vec![],
+            derived_attributes: vec![],
+        },
     ]
 }
 

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -22,6 +22,10 @@ impl Provider for AwsProvider {
             let mut state = match id.resource_type.as_str() {
                 "s3.Bucket" => self.read_s3_bucket(&id, identifier.as_deref()).await,
                 "s3.BucketPolicy" => self.read_s3_bucket_policy(&id, identifier.as_deref()).await,
+                "s3.BucketPublicAccessBlock" => {
+                    self.read_s3_bucket_public_access_block(&id, identifier.as_deref())
+                        .await
+                }
                 "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
                 "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
                 "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
@@ -119,6 +123,9 @@ impl Provider for AwsProvider {
             match resource.id.resource_type.as_str() {
                 "s3.Bucket" => self.create_s3_bucket(resource).await,
                 "s3.BucketPolicy" => self.create_s3_bucket_policy(resource).await,
+                "s3.BucketPublicAccessBlock" => {
+                    self.create_s3_bucket_public_access_block(resource).await
+                }
                 "ec2.Eip" => self.create_ec2_eip(resource).await,
                 "ec2.Vpc" => self.create_ec2_vpc(resource).await,
                 "ec2.Subnet" => self.create_ec2_subnet(resource).await,
@@ -183,6 +190,10 @@ impl Provider for AwsProvider {
                 "s3.Bucket" => self.update_s3_bucket(id, &identifier, &from, to).await,
                 "s3.BucketPolicy" => {
                     self.update_s3_bucket_policy(id, &identifier, &from, to)
+                        .await
+                }
+                "s3.BucketPublicAccessBlock" => {
+                    self.update_s3_bucket_public_access_block(id, &identifier, &from, to)
                         .await
                 }
                 "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
@@ -281,6 +292,10 @@ impl Provider for AwsProvider {
                 "s3.Bucket" => self.delete_s3_bucket(id, &identifier, &lifecycle).await,
                 "s3.BucketPolicy" => {
                     self.delete_s3_bucket_policy_idempotent(id, &identifier)
+                        .await
+                }
+                "s3.BucketPublicAccessBlock" => {
+                    self.delete_s3_bucket_public_access_block_idempotent(id, &identifier)
                         .await
                 }
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -47,6 +47,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         s3::bucket::s3_bucket_config(),
         s3::bucket_data_source::s3_bucket_data_source_config(),
         s3::bucket_policy::s3_bucket_policy_config(),
+        s3::bucket_public_access_block::s3_bucket_public_access_block_config(),
         sts::caller_identity::sts_caller_identity_config(),
     ]
 }
@@ -89,6 +90,7 @@ pub fn get_enum_valid_values(
         s3::bucket::enum_valid_values(),
         s3::bucket_data_source::enum_valid_values(),
         s3::bucket_policy::enum_valid_values(),
+        s3::bucket_public_access_block::enum_valid_values(),
         sts::caller_identity::enum_valid_values(),
     ];
     for (rt, attrs) in modules {
@@ -188,6 +190,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.BucketPolicy" {
         return s3::bucket_policy::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3.BucketPublicAccessBlock" {
+        return s3::bucket_public_access_block::enum_alias_reverse(attr_name, value);
     }
     None
 }
@@ -377,6 +382,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket_policy::enum_alias_entries() {
         map.entry("s3.BucketPolicy".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket_public_access_block::enum_alias_entries() {
+        map.entry("s3.BucketPublicAccessBlock".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_public_access_block.rs
@@ -1,0 +1,65 @@
+//! BucketPublicAccessBlock schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.s3
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for s3.BucketPublicAccessBlock (Smithy: com.amazonaws.s3)
+pub fn s3_bucket_public_access_block_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::S3::BucketPublicAccessBlock",
+        resource_type_name: "s3.BucketPublicAccessBlock",
+        has_tags: false,
+        schema: ResourceSchema::new("s3.BucketPublicAccessBlock")
+        .attribute(
+            AttributeSchema::new("bucket", AttributeType::String)
+                .required()
+                .create_only()
+                .with_description("The name of the Amazon S3 bucket whose PublicAccessBlock configuration you want to set.")
+                .with_provider_name("Bucket"),
+        )
+        .attribute(
+            AttributeSchema::new("block_public_acls", AttributeType::Bool)
+                .with_description("Block public ACLs on the bucket and its objects.")
+                .with_provider_name("BlockPublicAcls"),
+        )
+        .attribute(
+            AttributeSchema::new("ignore_public_acls", AttributeType::Bool)
+                .with_description("Ignore any public ACLs on the bucket and its objects.")
+                .with_provider_name("IgnorePublicAcls"),
+        )
+        .attribute(
+            AttributeSchema::new("block_public_policy", AttributeType::Bool)
+                .with_description("Block public bucket policies for the bucket.")
+                .with_provider_name("BlockPublicPolicy"),
+        )
+        .attribute(
+            AttributeSchema::new("restrict_public_buckets", AttributeType::Bool)
+                .with_description("Restrict access to the bucket to AWS service principals and authorized users when a public policy is set.")
+                .with_provider_name("RestrictPublicBuckets"),
+        )
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("s3.BucketPublicAccessBlock", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/mod.rs
@@ -9,3 +9,4 @@ pub use super::*;
 pub mod bucket;
 pub mod bucket_data_source;
 pub mod bucket_policy;
+pub mod bucket_public_access_block;

--- a/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
@@ -1,0 +1,154 @@
+use std::collections::HashMap;
+
+use aws_sdk_s3::types::PublicAccessBlockConfiguration;
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::services::s3::bucket::is_s3_not_configured_error;
+
+impl AwsProvider {
+    /// Read an S3 BucketPublicAccessBlock.
+    ///
+    /// `identifier` is the bucket name. Returns `State::not_found` when no
+    /// PublicAccessBlock configuration exists on the bucket
+    /// (`NoSuchPublicAccessBlockConfiguration`).
+    pub(crate) async fn read_s3_bucket_public_access_block(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(bucket) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .s3_client
+            .get_public_access_block()
+            .bucket(bucket)
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                let mut attributes = HashMap::new();
+                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+
+                if let Some(config) = output.public_access_block_configuration() {
+                    if let Some(v) = config.block_public_acls() {
+                        attributes.insert("block_public_acls".to_string(), Value::Bool(v));
+                    }
+                    if let Some(v) = config.ignore_public_acls() {
+                        attributes.insert("ignore_public_acls".to_string(), Value::Bool(v));
+                    }
+                    if let Some(v) = config.block_public_policy() {
+                        attributes.insert("block_public_policy".to_string(), Value::Bool(v));
+                    }
+                    if let Some(v) = config.restrict_public_buckets() {
+                        attributes.insert("restrict_public_buckets".to_string(), Value::Bool(v));
+                    }
+                }
+
+                Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
+            }
+            Err(e) => {
+                if is_s3_not_configured_error(&e, "NoSuchPublicAccessBlockConfiguration") {
+                    return Ok(State::not_found(id.clone()));
+                }
+                Err(
+                    ProviderError::new(sdk_error_message("Failed to get public access block", &e))
+                        .for_resource(id.clone()),
+                )
+            }
+        }
+    }
+
+    pub(crate) async fn create_s3_bucket_public_access_block(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let bucket = require_string_attr(&resource, "bucket")?;
+        self.put_s3_bucket_public_access_block(&resource.id, &bucket, &resource)
+            .await
+    }
+
+    pub(crate) async fn update_s3_bucket_public_access_block(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        _from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.put_s3_bucket_public_access_block(&id, identifier, &to)
+            .await
+    }
+
+    async fn put_s3_bucket_public_access_block(
+        &self,
+        id: &ResourceId,
+        bucket: &str,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let mut builder = PublicAccessBlockConfiguration::builder();
+        if let Some(Value::Bool(v)) = resource.get_attr("block_public_acls") {
+            builder = builder.block_public_acls(*v);
+        }
+        if let Some(Value::Bool(v)) = resource.get_attr("ignore_public_acls") {
+            builder = builder.ignore_public_acls(*v);
+        }
+        if let Some(Value::Bool(v)) = resource.get_attr("block_public_policy") {
+            builder = builder.block_public_policy(*v);
+        }
+        if let Some(Value::Bool(v)) = resource.get_attr("restrict_public_buckets") {
+            builder = builder.restrict_public_buckets(*v);
+        }
+        let config = builder.build();
+
+        self.s3_client
+            .put_public_access_block()
+            .bucket(bucket)
+            .public_access_block_configuration(config)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to put public access block", &e))
+                    .for_resource(id.clone())
+            })?;
+
+        self.read_s3_bucket_public_access_block(id, Some(bucket))
+            .await
+    }
+
+    /// Delete an S3 BucketPublicAccessBlock idempotently.
+    ///
+    /// Treats `NoSuchPublicAccessBlockConfiguration` (no PAB existed) and
+    /// `NoSuchBucket` (the parent bucket was already removed) as success.
+    pub(crate) async fn delete_s3_bucket_public_access_block_idempotent(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let result = self
+            .s3_client
+            .delete_public_access_block()
+            .bucket(identifier)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e)
+                if is_s3_not_configured_error(&e, "NoSuchPublicAccessBlockConfiguration")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket") =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(ProviderError::new(sdk_error_message(
+                "Failed to delete public access block",
+                &e,
+            ))
+            .for_resource(id.clone())),
+        }
+    }
+}

--- a/carina-provider-aws/src/services/s3/mod.rs
+++ b/carina-provider-aws/src/services/s3/mod.rs
@@ -1,2 +1,3 @@
 pub mod bucket;
 pub mod bucket_policy;
+pub mod bucket_public_access_block;


### PR DESCRIPTION
## Summary

- Adds `aws.s3.BucketPublicAccessBlock` as a standalone Carina-managed resource — second slice under #164 (after #215 / #209)
- Maps to `PutPublicAccessBlock` / `GetPublicAccessBlock` / `DeletePublicAccessBlock`
- 4 Bool attributes (`block_public_acls`, `ignore_public_acls`, `block_public_policy`, `restrict_public_buckets`) — all updatable
- Idempotent delete (swallows `NoSuchPublicAccessBlockConfiguration` and `NoSuchBucket`)

## Codegen changes

Two general-purpose tweaks needed to make `extra_writable` synthetic fields work for the InsideStruct update pattern:

1. **Synthetic extra_writable fields are no longer forced to create-only** when they appear in `update_ops`. The previous behavior blocked standalone resources whose write fields don't map 1:1 to a Smithy create-input member.
2. **InsideStruct write helper generation is skipped when any field has a `type_overrides` entry**. The generated body assumes `Value::String`, but a Bool/Json overridden field must be hand-written to use the SDK's typed setters.

These are general improvements that will apply to follow-up resources (#211 / #212 / #213) too.

## DSL example

```
let bucket = aws.s3.Bucket {
  bucket = 'carina-acc-test-aws-s3-bucket-pab-basic-v1'
}

aws.s3.BucketPublicAccessBlock {
  bucket = bucket.bucket

  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true
}
```

## Test plan

- [x] `cargo nextest run` — 330 tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Codegen no-diff
- [ ] Acceptance test (`s3_bucket_public_access_block/basic.crn`) against real AWS — not yet run

Closes #210
