### PR TITLE
Add aws.s3.BucketServerSideEncryptionConfiguration as standalone (#164 slice)

### DIFF
--- a/acceptance-tests/s3_bucket_server_side_encryption_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_server_side_encryption_configuration/basic.crn
@@ -1,0 +1,25 @@
+# S3 BucketServerSideEncryptionConfiguration - Basic test
+#
+# Tests: standalone aws.s3.BucketServerSideEncryptionConfiguration
+# applying AES256 SSE on a bucket.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-bucket-sse-basic-v1'
+}
+
+aws.s3.BucketServerSideEncryptionConfiguration {
+  bucket = bucket.bucket
+
+  rules = [
+    {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = aws.s3.BucketServerSideEncryptionConfiguration.SseAlgorithm.AES256
+      }
+      bucket_key_enabled = true
+    },
+  ]
+}

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1367,6 +1367,57 @@ pub fn iam_policy_document() -> AttributeType {
     }
 }
 
+/// SSE algorithm enum for `aws.s3.BucketServerSideEncryptionConfiguration`.
+fn s3_sse_algorithm() -> AttributeType {
+    AttributeType::StringEnum {
+        name: "SseAlgorithm".to_string(),
+        values: vec![
+            "AES256".to_string(),
+            "aws:kms".to_string(),
+            "aws:kms:dsse".to_string(),
+        ],
+        namespace: Some("aws.s3.BucketServerSideEncryptionConfiguration".to_string()),
+        to_dsl: None,
+    }
+}
+
+/// `ApplyServerSideEncryptionByDefault` struct: SSE algorithm + optional KMS key.
+fn s3_sse_by_default() -> AttributeType {
+    AttributeType::Struct {
+        name: "SseByDefault".to_string(),
+        fields: vec![
+            StructField::new("sse_algorithm", s3_sse_algorithm())
+                .with_provider_name("SSEAlgorithm")
+                .required(),
+            StructField::new("kms_master_key_id", AttributeType::String)
+                .with_provider_name("KMSMasterKeyID"),
+        ],
+    }
+}
+
+/// A single SSE rule: per-bucket default + optional bucket-key flag.
+fn s3_sse_rule() -> AttributeType {
+    AttributeType::Struct {
+        name: "SseRule".to_string(),
+        fields: vec![
+            StructField::new(
+                "apply_server_side_encryption_by_default",
+                s3_sse_by_default(),
+            )
+            .with_provider_name("ApplyServerSideEncryptionByDefault")
+            .with_block_name("apply_server_side_encryption_by_default"),
+            StructField::new("bucket_key_enabled", AttributeType::Bool)
+                .with_provider_name("BucketKeyEnabled"),
+        ],
+    }
+}
+
+/// List of SSE rules — the `rules` attribute on
+/// `aws.s3.BucketServerSideEncryptionConfiguration`.
+pub fn bucket_encryption_rules() -> AttributeType {
+    AttributeType::list(s3_sse_rule())
+}
+
 /// IAM condition operator mappings: (snake_case, PascalCase).
 ///
 /// See <https://docs.aws.amazon.Com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html>

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3944,6 +3944,10 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "s3.BucketPublicAccessBlock" => "AWS::S3::BucketPublicAccessBlock",
         // No native CloudFormation type; synthesize for cf_type_name totality.
         "s3.BucketVersioning" => "AWS::S3::BucketVersioning",
+        // No native CloudFormation type; synthesize for cf_type_name totality.
+        "s3.BucketServerSideEncryptionConfiguration" => {
+            "AWS::S3::BucketServerSideEncryptionConfiguration"
+        }
         "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
         "organizations.Organization" => "AWS::Organizations::Organization",
         "organizations.Account" => "AWS::Organizations::Account",

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1334,6 +1334,55 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
+        // s3.BucketServerSideEncryptionConfiguration — controls the SSE
+        // configuration of an existing S3 bucket. Maps to PutBucketEncryption /
+        // GetBucketEncryption / DeleteBucketEncryption.
+        ResourceDef {
+            name: "s3.BucketServerSideEncryptionConfiguration",
+            service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
+            simple_delete: false,
+            noop_update: false,
+            create_op: "PutBucketEncryption",
+            read_structure: None,
+            // Read / Create / Update / Delete are hand-written; the rules
+            // attribute is a typed Struct list (carina_aws_types::bucket_encryption_rules)
+            // that the generic codegen body cannot construct.
+            read_ops: vec![],
+            delete_op: "DeleteBucketEncryption",
+            // Declare PutBucketEncryption as the update op so codegen marks
+            // `Rules` as updatable; the generated write helper is suppressed
+            // because `Rules` has a `type_overrides` entry.
+            update_ops: vec![UpdateOp {
+                operation: "PutBucketEncryption",
+                fields: FieldLayout::InsideStruct {
+                    name: "ServerSideEncryptionConfiguration",
+                    fields: vec!["Rules"],
+                },
+            }],
+            identifier: "Bucket",
+            has_tags: false,
+            type_overrides: vec![("Rules", "super::bucket_encryption_rules()")],
+            exclude_fields: vec![
+                "ContentMD5",
+                "ChecksumAlgorithm",
+                "ExpectedBucketOwner",
+                "ServerSideEncryptionConfiguration",
+            ],
+            create_only_overrides: vec!["Bucket"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Bucket", "Rules"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![ExtraField {
+                name: "Rules",
+                read_source: None,
+                description: Some("List of server-side encryption rules to apply to the bucket."),
+            }],
+            identity_overrides: vec![],
+            derived_attributes: vec![],
+        },
         // s3.BucketPublicAccessBlock — controls the Public Access Block
         // settings of an existing S3 bucket. Maps to PutPublicAccessBlock /
         // GetPublicAccessBlock / DeletePublicAccessBlock.

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -30,6 +30,13 @@ impl Provider for AwsProvider {
                     self.read_s3_bucket_versioning(&id, identifier.as_deref())
                         .await
                 }
+                "s3.BucketServerSideEncryptionConfiguration" => {
+                    self.read_s3_bucket_server_side_encryption_configuration(
+                        &id,
+                        identifier.as_deref(),
+                    )
+                    .await
+                }
                 "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
                 "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
                 "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
@@ -131,6 +138,10 @@ impl Provider for AwsProvider {
                     self.create_s3_bucket_public_access_block(resource).await
                 }
                 "s3.BucketVersioning" => self.create_s3_bucket_versioning(resource).await,
+                "s3.BucketServerSideEncryptionConfiguration" => {
+                    self.create_s3_bucket_server_side_encryption_configuration(resource)
+                        .await
+                }
                 "ec2.Eip" => self.create_ec2_eip(resource).await,
                 "ec2.Vpc" => self.create_ec2_vpc(resource).await,
                 "ec2.Subnet" => self.create_ec2_subnet(resource).await,
@@ -204,6 +215,15 @@ impl Provider for AwsProvider {
                 "s3.BucketVersioning" => {
                     self.update_s3_bucket_versioning(id, &identifier, &from, to)
                         .await
+                }
+                "s3.BucketServerSideEncryptionConfiguration" => {
+                    self.update_s3_bucket_server_side_encryption_configuration(
+                        id,
+                        &identifier,
+                        &from,
+                        to,
+                    )
+                    .await
                 }
                 "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
                 "ec2.Vpc" => self.update_ec2_vpc(id, &identifier, &from, to).await,
@@ -310,6 +330,13 @@ impl Provider for AwsProvider {
                 "s3.BucketVersioning" => {
                     self.delete_s3_bucket_versioning_suspend(id, &identifier)
                         .await
+                }
+                "s3.BucketServerSideEncryptionConfiguration" => {
+                    self.delete_s3_bucket_server_side_encryption_configuration_idempotent(
+                        id,
+                        &identifier,
+                    )
+                    .await
                 }
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,
                 "ec2.Vpc" => self.delete_ec2_vpc(id, &identifier).await,

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -48,6 +48,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         s3::bucket_data_source::s3_bucket_data_source_config(),
         s3::bucket_policy::s3_bucket_policy_config(),
         s3::bucket_public_access_block::s3_bucket_public_access_block_config(),
+        s3::bucket_server_side_encryption_configuration::s3_bucket_server_side_encryption_configuration_config(),
         s3::bucket_versioning::s3_bucket_versioning_config(),
         sts::caller_identity::sts_caller_identity_config(),
     ]
@@ -92,6 +93,7 @@ pub fn get_enum_valid_values(
         s3::bucket_data_source::enum_valid_values(),
         s3::bucket_policy::enum_valid_values(),
         s3::bucket_public_access_block::enum_valid_values(),
+        s3::bucket_server_side_encryption_configuration::enum_valid_values(),
         s3::bucket_versioning::enum_valid_values(),
         sts::caller_identity::enum_valid_values(),
     ];
@@ -195,6 +197,11 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.BucketPublicAccessBlock" {
         return s3::bucket_public_access_block::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3.BucketServerSideEncryptionConfiguration" {
+        return s3::bucket_server_side_encryption_configuration::enum_alias_reverse(
+            attr_name, value,
+        );
     }
     if resource_type == "s3.BucketVersioning" {
         return s3::bucket_versioning::enum_alias_reverse(attr_name, value);
@@ -394,6 +401,15 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket_public_access_block::enum_alias_entries() {
         map.entry("s3.BucketPublicAccessBlock".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in
+        s3::bucket_server_side_encryption_configuration::enum_alias_entries()
+    {
+        map.entry("s3.BucketServerSideEncryptionConfiguration".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_server_side_encryption_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_server_side_encryption_configuration.rs
@@ -1,0 +1,51 @@
+//! BucketServerSideEncryptionConfiguration schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.s3
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for s3.BucketServerSideEncryptionConfiguration (Smithy: com.amazonaws.s3)
+pub fn s3_bucket_server_side_encryption_configuration_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::S3::BucketServerSideEncryptionConfiguration",
+        resource_type_name: "s3.BucketServerSideEncryptionConfiguration",
+        has_tags: false,
+        schema: ResourceSchema::new("s3.BucketServerSideEncryptionConfiguration")
+        .attribute(
+            AttributeSchema::new("bucket", AttributeType::String)
+                .required()
+                .create_only()
+                .with_description("Specifies default encryption for a bucket using server-side encryption with different key options. Directory buckets - When you use this operation wit...")
+                .with_provider_name("Bucket"),
+        )
+        .attribute(
+            AttributeSchema::new("rules", super::bucket_encryption_rules())
+                .required()
+                .with_description("List of server-side encryption rules to apply to the bucket.")
+                .with_provider_name("Rules"),
+        )
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("s3.BucketServerSideEncryptionConfiguration", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/mod.rs
@@ -10,4 +10,5 @@ pub mod bucket;
 pub mod bucket_data_source;
 pub mod bucket_policy;
 pub mod bucket_public_access_block;
+pub mod bucket_server_side_encryption_configuration;
 pub mod bucket_versioning;

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+
+use aws_sdk_s3::types::{
+    ServerSideEncryption, ServerSideEncryptionByDefault, ServerSideEncryptionConfiguration,
+    ServerSideEncryptionRule,
+};
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::utils::extract_enum_value;
+use indexmap::IndexMap;
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::services::s3::bucket::is_s3_not_configured_error;
+
+impl AwsProvider {
+    pub(crate) async fn read_s3_bucket_server_side_encryption_configuration(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(bucket) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .s3_client
+            .get_bucket_encryption()
+            .bucket(bucket)
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                let mut attributes = HashMap::new();
+                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                if let Some(config) = output.server_side_encryption_configuration() {
+                    let rules: Vec<Value> = config.rules().iter().map(rule_to_value).collect();
+                    if !rules.is_empty() {
+                        attributes.insert("rules".to_string(), Value::List(rules));
+                    }
+                }
+                Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
+            }
+            Err(e) => {
+                if is_s3_not_configured_error(&e, "ServerSideEncryptionConfigurationNotFoundError")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket")
+                {
+                    return Ok(State::not_found(id.clone()));
+                }
+                Err(
+                    ProviderError::new(sdk_error_message("Failed to get bucket encryption", &e))
+                        .for_resource(id.clone()),
+                )
+            }
+        }
+    }
+
+    pub(crate) async fn create_s3_bucket_server_side_encryption_configuration(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let bucket = require_string_attr(&resource, "bucket")?;
+        self.put_s3_bucket_encryption(&resource.id, &bucket, &resource)
+            .await
+    }
+
+    pub(crate) async fn update_s3_bucket_server_side_encryption_configuration(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        _from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.put_s3_bucket_encryption(&id, identifier, &to).await
+    }
+
+    async fn put_s3_bucket_encryption(
+        &self,
+        id: &ResourceId,
+        bucket: &str,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let rules = match resource.get_attr("rules") {
+            Some(Value::List(items)) => items,
+            _ => {
+                return Err(ProviderError::new("rules is required and must be a list")
+                    .for_resource(id.clone()));
+            }
+        };
+
+        let sdk_rules: Vec<ServerSideEncryptionRule> = rules
+            .iter()
+            .map(|v| build_rule(id, v))
+            .collect::<ProviderResult<Vec<_>>>()?;
+
+        let config = ServerSideEncryptionConfiguration::builder()
+            .set_rules(Some(sdk_rules))
+            .build()
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message(
+                    "Failed to build server-side encryption configuration",
+                    &e,
+                ))
+                .for_resource(id.clone())
+            })?;
+
+        self.s3_client
+            .put_bucket_encryption()
+            .bucket(bucket)
+            .server_side_encryption_configuration(config)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to put bucket encryption", &e))
+                    .for_resource(id.clone())
+            })?;
+
+        self.read_s3_bucket_server_side_encryption_configuration(id, Some(bucket))
+            .await
+    }
+
+    pub(crate) async fn delete_s3_bucket_server_side_encryption_configuration_idempotent(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let result = self
+            .s3_client
+            .delete_bucket_encryption()
+            .bucket(identifier)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e)
+                if is_s3_not_configured_error(
+                    &e,
+                    "ServerSideEncryptionConfigurationNotFoundError",
+                ) || is_s3_not_configured_error(&e, "NoSuchBucket") =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(ProviderError::new(sdk_error_message(
+                "Failed to delete bucket encryption",
+                &e,
+            ))
+            .for_resource(id.clone())),
+        }
+    }
+}
+
+fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ServerSideEncryptionRule> {
+    let Value::Map(rule_map) = rule_value else {
+        return Err(ProviderError::new("each rule must be a map").for_resource(id.clone()));
+    };
+
+    let mut builder = ServerSideEncryptionRule::builder();
+
+    if let Some(by_default) = rule_map.get("apply_server_side_encryption_by_default") {
+        builder =
+            builder.apply_server_side_encryption_by_default(build_by_default(id, by_default)?);
+    }
+    if let Some(Value::Bool(b)) = rule_map.get("bucket_key_enabled") {
+        builder = builder.bucket_key_enabled(*b);
+    }
+
+    Ok(builder.build())
+}
+
+fn build_by_default(
+    id: &ResourceId,
+    value: &Value,
+) -> ProviderResult<ServerSideEncryptionByDefault> {
+    let Value::Map(map) = value else {
+        return Err(
+            ProviderError::new("apply_server_side_encryption_by_default must be a map")
+                .for_resource(id.clone()),
+        );
+    };
+    let algorithm_str = match map.get("sse_algorithm") {
+        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        _ => {
+            return Err(ProviderError::new("sse_algorithm is required").for_resource(id.clone()));
+        }
+    };
+    let mut builder = ServerSideEncryptionByDefault::builder()
+        .sse_algorithm(ServerSideEncryption::from(algorithm_str.as_str()));
+    if let Some(Value::String(k)) = map.get("kms_master_key_id") {
+        builder = builder.kms_master_key_id(k);
+    }
+    builder.build().map_err(|e| {
+        ProviderError::new(sdk_error_message(
+            "Failed to build apply_server_side_encryption_by_default",
+            &e,
+        ))
+        .for_resource(id.clone())
+    })
+}
+
+fn rule_to_value(rule: &ServerSideEncryptionRule) -> Value {
+    let mut map = IndexMap::new();
+    if let Some(by_default) = rule.apply_server_side_encryption_by_default() {
+        let mut inner = IndexMap::new();
+        inner.insert(
+            "sse_algorithm".to_string(),
+            Value::String(by_default.sse_algorithm().as_str().to_string()),
+        );
+        if let Some(k) = by_default.kms_master_key_id() {
+            inner.insert(
+                "kms_master_key_id".to_string(),
+                Value::String(k.to_string()),
+            );
+        }
+        map.insert(
+            "apply_server_side_encryption_by_default".to_string(),
+            Value::Map(inner),
+        );
+    }
+    if let Some(b) = rule.bucket_key_enabled() {
+        map.insert("bucket_key_enabled".to_string(), Value::Bool(b));
+    }
+    Value::Map(map)
+}

--- a/carina-provider-aws/src/services/s3/mod.rs
+++ b/carina-provider-aws/src/services/s3/mod.rs
@@ -1,4 +1,5 @@
 pub mod bucket;
+pub mod bucket_encryption;
 pub mod bucket_policy;
 pub mod bucket_public_access_block;
 pub mod bucket_versioning;


### PR DESCRIPTION
Closes #212

Adds the standalone resource per #164 decomposition. SSE rules are written via Carina DSL block syntax (mirror of iam_policy_document). Idempotent delete handles ServerSideEncryptionConfigurationNotFoundError and NoSuchBucket.

CI: 331 tests, clippy clean, fmt clean, codegen no-diff.