### PR TITLE
Add aws.s3.BucketReplicationConfiguration as standalone (#164 slice)

### DIFF
--- a/acceptance-tests/s3_bucket_replication_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/basic.crn
@@ -1,0 +1,57 @@
+# S3 BucketReplicationConfiguration - Basic test
+#
+# Tests: standalone aws.s3.BucketReplicationConfiguration replicating
+# a versioned source bucket into a destination bucket. Both buckets
+# must have versioning enabled.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let source = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-repl-src-v1'
+}
+
+aws.s3.BucketVersioning {
+  bucket = source.bucket
+  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+}
+
+let dest = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-repl-dst-v1'
+}
+
+aws.s3.BucketVersioning {
+  bucket = dest.bucket
+  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+}
+
+let role = aws.iam.Role {
+  role_name = 'carina-acc-test-aws-s3-repl-role-v1'
+
+  assume_role_policy_document = {
+    version = '2012-10-17'
+    statement {
+      effect = 'Allow'
+      principal = {
+        service = 's3.amazonaws.com'
+      }
+      action = 'sts:AssumeRole'
+    }
+  }
+}
+
+aws.s3.BucketReplicationConfiguration {
+  bucket = source.bucket
+  role   = role.arn
+
+  rules = [
+    {
+      id     = 'replicate-all'
+      status = aws.s3.BucketReplicationConfiguration.ReplicationRuleStatus.Enabled
+      destination = {
+        bucket = 'arn:aws:s3:::carina-acc-test-aws-s3-repl-dst-v1'
+      }
+    },
+  ]
+}

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1418,6 +1418,70 @@ pub fn bucket_encryption_rules() -> AttributeType {
     AttributeType::list(s3_sse_rule())
 }
 
+/// `Destination` for a replication rule. Minimal fields: target bucket
+/// ARN and optional storage class / account.
+fn s3_replication_destination() -> AttributeType {
+    AttributeType::Struct {
+        name: "ReplicationDestination".to_string(),
+        fields: vec![
+            StructField::new("bucket", AttributeType::String)
+                .with_provider_name("Bucket")
+                .required(),
+            StructField::new("account", AttributeType::String).with_provider_name("Account"),
+            StructField::new(
+                "storage_class",
+                AttributeType::StringEnum {
+                    name: "ReplicationStorageClass".to_string(),
+                    values: vec![
+                        "STANDARD".to_string(),
+                        "REDUCED_REDUNDANCY".to_string(),
+                        "STANDARD_IA".to_string(),
+                        "ONEZONE_IA".to_string(),
+                        "INTELLIGENT_TIERING".to_string(),
+                        "GLACIER".to_string(),
+                        "DEEP_ARCHIVE".to_string(),
+                        "GLACIER_IR".to_string(),
+                    ],
+                    namespace: Some("aws.s3.BucketReplicationConfiguration".to_string()),
+                    to_dsl: None,
+                },
+            )
+            .with_provider_name("StorageClass"),
+        ],
+    }
+}
+
+fn s3_replication_status() -> AttributeType {
+    AttributeType::StringEnum {
+        name: "ReplicationRuleStatus".to_string(),
+        values: vec!["Enabled".to_string(), "Disabled".to_string()],
+        namespace: Some("aws.s3.BucketReplicationConfiguration".to_string()),
+        to_dsl: None,
+    }
+}
+
+fn s3_replication_rule() -> AttributeType {
+    AttributeType::Struct {
+        name: "ReplicationRule".to_string(),
+        fields: vec![
+            StructField::new("id", AttributeType::String).with_provider_name("ID"),
+            StructField::new("priority", AttributeType::Int).with_provider_name("Priority"),
+            StructField::new("prefix", AttributeType::String).with_provider_name("Prefix"),
+            StructField::new("status", s3_replication_status())
+                .with_provider_name("Status")
+                .required(),
+            StructField::new("destination", s3_replication_destination())
+                .with_provider_name("Destination")
+                .with_block_name("destination")
+                .required(),
+        ],
+    }
+}
+
+pub fn bucket_replication_rules() -> AttributeType {
+    AttributeType::list(s3_replication_rule())
+}
+
 /// IAM condition operator mappings: (snake_case, PascalCase).
 ///
 /// See <https://docs.aws.amazon.Com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html>

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3951,6 +3951,7 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         // No native CloudFormation type; synthesize for cf_type_name totality.
         "s3.BucketAcl" => "AWS::S3::BucketAcl",
         "s3.BucketOwnershipControls" => "AWS::S3::BucketOwnershipControls",
+        "s3.BucketReplicationConfiguration" => "AWS::S3::BucketReplicationConfiguration",
         "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
         "organizations.Organization" => "AWS::Organizations::Organization",
         "organizations.Account" => "AWS::Organizations::Account",

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1472,6 +1472,57 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
+        // s3.BucketReplicationConfiguration — controls cross-region (or
+        // same-region) replication. Maps to PutBucketReplication /
+        // GetBucketReplication / DeleteBucketReplication.
+        ResourceDef {
+            name: "s3.BucketReplicationConfiguration",
+            service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
+            simple_delete: false,
+            noop_update: false,
+            create_op: "PutBucketReplication",
+            read_structure: None,
+            read_ops: vec![],
+            delete_op: "DeleteBucketReplication",
+            update_ops: vec![UpdateOp {
+                operation: "PutBucketReplication",
+                fields: FieldLayout::InsideStruct {
+                    name: "ReplicationConfiguration",
+                    fields: vec!["Role", "Rules"],
+                },
+            }],
+            identifier: "Bucket",
+            has_tags: false,
+            type_overrides: vec![("Rules", "super::bucket_replication_rules()")],
+            exclude_fields: vec![
+                "ContentMD5",
+                "ChecksumAlgorithm",
+                "Token",
+                "ExpectedBucketOwner",
+                "ReplicationConfiguration",
+            ],
+            create_only_overrides: vec!["Bucket"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Bucket", "Role", "Rules"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![
+                ExtraField {
+                    name: "Role",
+                    read_source: None,
+                    description: Some("ARN of the IAM role S3 uses to perform the replication."),
+                },
+                ExtraField {
+                    name: "Rules",
+                    read_source: None,
+                    description: Some("Replication rules — at least one is required."),
+                },
+            ],
+            identity_overrides: vec![],
+            derived_attributes: vec![],
+        },
         // s3.BucketPublicAccessBlock — controls the Public Access Block
         // settings of an existing S3 bucket. Maps to PutPublicAccessBlock /
         // GetPublicAccessBlock / DeletePublicAccessBlock.

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -42,6 +42,10 @@ impl Provider for AwsProvider {
                     self.read_s3_bucket_ownership_controls(&id, identifier.as_deref())
                         .await
                 }
+                "s3.BucketReplicationConfiguration" => {
+                    self.read_s3_bucket_replication_configuration(&id, identifier.as_deref())
+                        .await
+                }
                 "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
                 "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
                 "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
@@ -151,6 +155,10 @@ impl Provider for AwsProvider {
                 "s3.BucketOwnershipControls" => {
                     self.create_s3_bucket_ownership_controls(resource).await
                 }
+                "s3.BucketReplicationConfiguration" => {
+                    self.create_s3_bucket_replication_configuration(resource)
+                        .await
+                }
                 "ec2.Eip" => self.create_ec2_eip(resource).await,
                 "ec2.Vpc" => self.create_ec2_vpc(resource).await,
                 "ec2.Subnet" => self.create_ec2_subnet(resource).await,
@@ -237,6 +245,10 @@ impl Provider for AwsProvider {
                 "s3.BucketAcl" => self.update_s3_bucket_acl(id, &identifier, &from, to).await,
                 "s3.BucketOwnershipControls" => {
                     self.update_s3_bucket_ownership_controls(id, &identifier, &from, to)
+                        .await
+                }
+                "s3.BucketReplicationConfiguration" => {
+                    self.update_s3_bucket_replication_configuration(id, &identifier, &from, to)
                         .await
                 }
                 "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
@@ -355,6 +367,10 @@ impl Provider for AwsProvider {
                 "s3.BucketAcl" => self.delete_s3_bucket_acl_reset(id, &identifier).await,
                 "s3.BucketOwnershipControls" => {
                     self.delete_s3_bucket_ownership_controls_idempotent(id, &identifier)
+                        .await
+                }
+                "s3.BucketReplicationConfiguration" => {
+                    self.delete_s3_bucket_replication_configuration_idempotent(id, &identifier)
                         .await
                 }
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -50,6 +50,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         s3::bucket_ownership_controls::s3_bucket_ownership_controls_config(),
         s3::bucket_policy::s3_bucket_policy_config(),
         s3::bucket_public_access_block::s3_bucket_public_access_block_config(),
+        s3::bucket_replication_configuration::s3_bucket_replication_configuration_config(),
         s3::bucket_server_side_encryption_configuration::s3_bucket_server_side_encryption_configuration_config(),
         s3::bucket_versioning::s3_bucket_versioning_config(),
         sts::caller_identity::sts_caller_identity_config(),
@@ -97,6 +98,7 @@ pub fn get_enum_valid_values(
         s3::bucket_ownership_controls::enum_valid_values(),
         s3::bucket_policy::enum_valid_values(),
         s3::bucket_public_access_block::enum_valid_values(),
+        s3::bucket_replication_configuration::enum_valid_values(),
         s3::bucket_server_side_encryption_configuration::enum_valid_values(),
         s3::bucket_versioning::enum_valid_values(),
         sts::caller_identity::enum_valid_values(),
@@ -207,6 +209,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.BucketPublicAccessBlock" {
         return s3::bucket_public_access_block::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3.BucketReplicationConfiguration" {
+        return s3::bucket_replication_configuration::enum_alias_reverse(attr_name, value);
     }
     if resource_type == "s3.BucketServerSideEncryptionConfiguration" {
         return s3::bucket_server_side_encryption_configuration::enum_alias_reverse(
@@ -425,6 +430,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket_public_access_block::enum_alias_entries() {
         map.entry("s3.BucketPublicAccessBlock".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket_replication_configuration::enum_alias_entries() {
+        map.entry("s3.BucketReplicationConfiguration".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_replication_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_replication_configuration.rs
@@ -1,0 +1,57 @@
+//! BucketReplicationConfiguration schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.s3
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for s3.BucketReplicationConfiguration (Smithy: com.amazonaws.s3)
+pub fn s3_bucket_replication_configuration_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::S3::BucketReplicationConfiguration",
+        resource_type_name: "s3.BucketReplicationConfiguration",
+        has_tags: false,
+        schema: ResourceSchema::new("s3.BucketReplicationConfiguration")
+            .attribute(
+                AttributeSchema::new("bucket", AttributeType::String)
+                    .required()
+                    .create_only()
+                    .with_description("The name of the bucket")
+                    .with_provider_name("Bucket"),
+            )
+            .attribute(
+                AttributeSchema::new("role", AttributeType::String)
+                    .required()
+                    .with_description("ARN of the IAM role S3 uses to perform the replication.")
+                    .with_provider_name("Role"),
+            )
+            .attribute(
+                AttributeSchema::new("rules", super::bucket_replication_rules())
+                    .required()
+                    .with_description("Replication rules — at least one is required.")
+                    .with_provider_name("Rules"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("s3.BucketReplicationConfiguration", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/mod.rs
@@ -12,5 +12,6 @@ pub mod bucket_data_source;
 pub mod bucket_ownership_controls;
 pub mod bucket_policy;
 pub mod bucket_public_access_block;
+pub mod bucket_replication_configuration;
 pub mod bucket_server_side_encryption_configuration;
 pub mod bucket_versioning;

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -1,0 +1,259 @@
+use std::collections::HashMap;
+
+use aws_sdk_s3::types::{
+    Destination, ReplicationConfiguration, ReplicationRule, ReplicationRuleStatus, StorageClass,
+};
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::utils::extract_enum_value;
+use indexmap::IndexMap;
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::services::s3::bucket::is_s3_not_configured_error;
+
+impl AwsProvider {
+    pub(crate) async fn read_s3_bucket_replication_configuration(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(bucket) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .s3_client
+            .get_bucket_replication()
+            .bucket(bucket)
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                let mut attributes = HashMap::new();
+                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                if let Some(config) = output.replication_configuration() {
+                    attributes.insert("role".to_string(), Value::String(config.role().to_string()));
+                    let rules: Vec<Value> = config.rules().iter().map(rule_to_value).collect();
+                    if !rules.is_empty() {
+                        attributes.insert("rules".to_string(), Value::List(rules));
+                    }
+                }
+                Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
+            }
+            Err(e) => {
+                if is_s3_not_configured_error(&e, "ReplicationConfigurationNotFoundError")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket")
+                {
+                    return Ok(State::not_found(id.clone()));
+                }
+                Err(
+                    ProviderError::new(sdk_error_message("Failed to get bucket replication", &e))
+                        .for_resource(id.clone()),
+                )
+            }
+        }
+    }
+
+    pub(crate) async fn create_s3_bucket_replication_configuration(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let bucket = require_string_attr(&resource, "bucket")?;
+        self.put_s3_bucket_replication(&resource.id, &bucket, &resource)
+            .await
+    }
+
+    pub(crate) async fn update_s3_bucket_replication_configuration(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        _from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.put_s3_bucket_replication(&id, identifier, &to).await
+    }
+
+    async fn put_s3_bucket_replication(
+        &self,
+        id: &ResourceId,
+        bucket: &str,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let role = require_string_attr(resource, "role")?;
+        let rules = match resource.get_attr("rules") {
+            Some(Value::List(items)) => items,
+            _ => {
+                return Err(ProviderError::new("rules is required and must be a list")
+                    .for_resource(id.clone()));
+            }
+        };
+
+        let sdk_rules: Vec<ReplicationRule> = rules
+            .iter()
+            .map(|v| build_rule(id, v))
+            .collect::<ProviderResult<Vec<_>>>()?;
+
+        let config = ReplicationConfiguration::builder()
+            .role(&role)
+            .set_rules(Some(sdk_rules))
+            .build()
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message(
+                    "Failed to build replication configuration",
+                    &e,
+                ))
+                .for_resource(id.clone())
+            })?;
+
+        self.s3_client
+            .put_bucket_replication()
+            .bucket(bucket)
+            .replication_configuration(config)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to put bucket replication", &e))
+                    .for_resource(id.clone())
+            })?;
+
+        self.read_s3_bucket_replication_configuration(id, Some(bucket))
+            .await
+    }
+
+    pub(crate) async fn delete_s3_bucket_replication_configuration_idempotent(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let result = self
+            .s3_client
+            .delete_bucket_replication()
+            .bucket(identifier)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e)
+                if is_s3_not_configured_error(&e, "ReplicationConfigurationNotFoundError")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket") =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(ProviderError::new(sdk_error_message(
+                "Failed to delete bucket replication",
+                &e,
+            ))
+            .for_resource(id.clone())),
+        }
+    }
+}
+
+fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ReplicationRule> {
+    let Value::Map(map) = rule_value else {
+        return Err(ProviderError::new("each rule must be a map").for_resource(id.clone()));
+    };
+
+    let status_str = match map.get("status") {
+        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        _ => {
+            return Err(ProviderError::new("rule.status is required").for_resource(id.clone()));
+        }
+    };
+    let destination = match map.get("destination") {
+        Some(v) => build_destination(id, v)?,
+        None => {
+            return Err(ProviderError::new("rule.destination is required").for_resource(id.clone()));
+        }
+    };
+
+    let mut builder = ReplicationRule::builder()
+        .status(ReplicationRuleStatus::from(status_str.as_str()))
+        .destination(destination);
+
+    if let Some(Value::String(s)) = map.get("id") {
+        builder = builder.id(s);
+    }
+    if let Some(Value::Int(n)) = map.get("priority") {
+        builder = builder.priority(*n as i32);
+    }
+    if let Some(Value::String(s)) = map.get("prefix") {
+        #[allow(deprecated)]
+        {
+            builder = builder.prefix(s);
+        }
+    }
+
+    builder.build().map_err(|e| {
+        ProviderError::new(sdk_error_message("Failed to build ReplicationRule", &e))
+            .for_resource(id.clone())
+    })
+}
+
+fn build_destination(id: &ResourceId, value: &Value) -> ProviderResult<Destination> {
+    let Value::Map(map) = value else {
+        return Err(ProviderError::new("destination must be a map").for_resource(id.clone()));
+    };
+    let bucket = match map.get("bucket") {
+        Some(Value::String(s)) => s.clone(),
+        _ => {
+            return Err(
+                ProviderError::new("destination.bucket is required").for_resource(id.clone())
+            );
+        }
+    };
+    let mut builder = Destination::builder().bucket(bucket);
+    if let Some(Value::String(s)) = map.get("account") {
+        builder = builder.account(s);
+    }
+    if let Some(Value::String(s)) = map.get("storage_class") {
+        let normalized = extract_enum_value(s);
+        builder = builder.storage_class(StorageClass::from(normalized));
+    }
+    builder.build().map_err(|e| {
+        ProviderError::new(sdk_error_message("Failed to build Destination", &e))
+            .for_resource(id.clone())
+    })
+}
+
+fn rule_to_value(rule: &ReplicationRule) -> Value {
+    let mut map = IndexMap::new();
+    if let Some(s) = rule.id()
+        && !s.is_empty()
+    {
+        map.insert("id".to_string(), Value::String(s.to_string()));
+    }
+    if let Some(p) = rule.priority() {
+        map.insert("priority".to_string(), Value::Int(p as i64));
+    }
+    #[allow(deprecated)]
+    if let Some(s) = rule.prefix()
+        && !s.is_empty()
+    {
+        map.insert("prefix".to_string(), Value::String(s.to_string()));
+    }
+    map.insert(
+        "status".to_string(),
+        Value::String(rule.status().as_str().to_string()),
+    );
+    if let Some(dest) = rule.destination() {
+        let mut d = IndexMap::new();
+        d.insert(
+            "bucket".to_string(),
+            Value::String(dest.bucket().to_string()),
+        );
+        if let Some(a) = dest.account() {
+            d.insert("account".to_string(), Value::String(a.to_string()));
+        }
+        if let Some(sc) = dest.storage_class() {
+            d.insert(
+                "storage_class".to_string(),
+                Value::String(sc.as_str().to_string()),
+            );
+        }
+        map.insert("destination".to_string(), Value::Map(d));
+    }
+    Value::Map(map)
+}

--- a/carina-provider-aws/src/services/s3/mod.rs
+++ b/carina-provider-aws/src/services/s3/mod.rs
@@ -4,4 +4,5 @@ pub mod bucket_encryption;
 pub mod bucket_ownership_controls;
 pub mod bucket_policy;
 pub mod bucket_public_access_block;
+pub mod bucket_replication;
 pub mod bucket_versioning;


### PR DESCRIPTION
Closes #221

Sixth slice of #164. Cross-region replication with IAM role + destination bucket. Uses carina-aws-types::bucket_replication_rules() for the typed Struct list.

CI: 326 tests, clippy clean, fmt clean, codegen no-diff.