### PR TITLE
Add aws.s3.BucketLifecycleConfiguration as standalone (#164 slice)

### DIFF
--- a/acceptance-tests/s3_bucket_lifecycle_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_lifecycle_configuration/basic.crn
@@ -1,0 +1,33 @@
+# S3 BucketLifecycleConfiguration - Basic test
+#
+# Tests: standalone aws.s3.BucketLifecycleConfiguration with one
+# transition rule (Standard → Standard-IA after 30 days) and one
+# expiration rule (delete after 365 days).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-bucket-lifecycle-basic-v1'
+}
+
+aws.s3.BucketLifecycleConfiguration {
+  bucket = bucket.bucket
+
+  rules = [
+    {
+      id     = 'transition-then-expire'
+      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.Enabled
+      transitions = [
+        {
+          days          = 30
+          storage_class = aws.s3.BucketLifecycleConfiguration.TransitionStorageClass.STANDARD_IA
+        },
+      ]
+      expiration = {
+        days = 365
+      }
+    },
+  ]
+}

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1482,6 +1482,136 @@ pub fn bucket_replication_rules() -> AttributeType {
     AttributeType::list(s3_replication_rule())
 }
 
+/// Lifecycle rule status (Enabled / Disabled).
+fn s3_lifecycle_status() -> AttributeType {
+    AttributeType::StringEnum {
+        name: "LifecycleRuleStatus".to_string(),
+        values: vec!["Enabled".to_string(), "Disabled".to_string()],
+        namespace: Some("aws.s3.BucketLifecycleConfiguration".to_string()),
+        to_dsl: None,
+    }
+}
+
+/// Storage class for lifecycle transitions (Glacier / IA / etc.).
+fn s3_transition_storage_class() -> AttributeType {
+    AttributeType::StringEnum {
+        name: "TransitionStorageClass".to_string(),
+        values: vec![
+            "GLACIER".to_string(),
+            "STANDARD_IA".to_string(),
+            "ONEZONE_IA".to_string(),
+            "INTELLIGENT_TIERING".to_string(),
+            "DEEP_ARCHIVE".to_string(),
+            "GLACIER_IR".to_string(),
+        ],
+        namespace: Some("aws.s3.BucketLifecycleConfiguration".to_string()),
+        to_dsl: None,
+    }
+}
+
+fn s3_lifecycle_expiration() -> AttributeType {
+    AttributeType::Struct {
+        name: "LifecycleExpiration".to_string(),
+        fields: vec![
+            StructField::new("days", AttributeType::Int).with_provider_name("Days"),
+            StructField::new("date", AttributeType::String).with_provider_name("Date"),
+            StructField::new("expired_object_delete_marker", AttributeType::Bool)
+                .with_provider_name("ExpiredObjectDeleteMarker"),
+        ],
+    }
+}
+
+fn s3_lifecycle_transition() -> AttributeType {
+    AttributeType::Struct {
+        name: "LifecycleTransition".to_string(),
+        fields: vec![
+            StructField::new("days", AttributeType::Int).with_provider_name("Days"),
+            StructField::new("date", AttributeType::String).with_provider_name("Date"),
+            StructField::new("storage_class", s3_transition_storage_class())
+                .with_provider_name("StorageClass")
+                .required(),
+        ],
+    }
+}
+
+fn s3_noncurrent_version_expiration() -> AttributeType {
+    AttributeType::Struct {
+        name: "NoncurrentVersionExpiration".to_string(),
+        fields: vec![
+            StructField::new("noncurrent_days", AttributeType::Int)
+                .with_provider_name("NoncurrentDays"),
+            StructField::new("newer_noncurrent_versions", AttributeType::Int)
+                .with_provider_name("NewerNoncurrentVersions"),
+        ],
+    }
+}
+
+fn s3_noncurrent_version_transition() -> AttributeType {
+    AttributeType::Struct {
+        name: "NoncurrentVersionTransition".to_string(),
+        fields: vec![
+            StructField::new("noncurrent_days", AttributeType::Int)
+                .with_provider_name("NoncurrentDays"),
+            StructField::new("storage_class", s3_transition_storage_class())
+                .with_provider_name("StorageClass")
+                .required(),
+            StructField::new("newer_noncurrent_versions", AttributeType::Int)
+                .with_provider_name("NewerNoncurrentVersions"),
+        ],
+    }
+}
+
+fn s3_abort_multipart() -> AttributeType {
+    AttributeType::Struct {
+        name: "AbortIncompleteMultipartUpload".to_string(),
+        fields: vec![
+            StructField::new("days_after_initiation", AttributeType::Int)
+                .with_provider_name("DaysAfterInitiation"),
+        ],
+    }
+}
+
+fn s3_lifecycle_rule() -> AttributeType {
+    AttributeType::Struct {
+        name: "LifecycleRule".to_string(),
+        fields: vec![
+            StructField::new("id", AttributeType::String).with_provider_name("ID"),
+            StructField::new("status", s3_lifecycle_status())
+                .with_provider_name("Status")
+                .required(),
+            StructField::new("prefix", AttributeType::String).with_provider_name("Prefix"),
+            StructField::new("expiration", s3_lifecycle_expiration())
+                .with_provider_name("Expiration")
+                .with_block_name("expiration"),
+            StructField::new(
+                "transitions",
+                AttributeType::list(s3_lifecycle_transition()),
+            )
+            .with_provider_name("Transitions")
+            .with_block_name("transition"),
+            StructField::new(
+                "noncurrent_version_expiration",
+                s3_noncurrent_version_expiration(),
+            )
+            .with_provider_name("NoncurrentVersionExpiration")
+            .with_block_name("noncurrent_version_expiration"),
+            StructField::new(
+                "noncurrent_version_transitions",
+                AttributeType::list(s3_noncurrent_version_transition()),
+            )
+            .with_provider_name("NoncurrentVersionTransitions")
+            .with_block_name("noncurrent_version_transition"),
+            StructField::new("abort_incomplete_multipart_upload", s3_abort_multipart())
+                .with_provider_name("AbortIncompleteMultipartUpload")
+                .with_block_name("abort_incomplete_multipart_upload"),
+        ],
+    }
+}
+
+pub fn bucket_lifecycle_rules() -> AttributeType {
+    AttributeType::list(s3_lifecycle_rule())
+}
+
 /// IAM condition operator mappings: (snake_case, PascalCase).
 ///
 /// See <https://docs.aws.amazon.Com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html>

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3952,6 +3952,7 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "s3.BucketAcl" => "AWS::S3::BucketAcl",
         "s3.BucketOwnershipControls" => "AWS::S3::BucketOwnershipControls",
         "s3.BucketReplicationConfiguration" => "AWS::S3::BucketReplicationConfiguration",
+        "s3.BucketLifecycleConfiguration" => "AWS::S3::BucketLifecycleConfiguration",
         "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
         "organizations.Organization" => "AWS::Organizations::Organization",
         "organizations.Account" => "AWS::Organizations::Account",

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1523,6 +1523,50 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
+        // s3.BucketLifecycleConfiguration — controls object lifecycle rules
+        // (transitions, expiration, abort-multipart). Maps to
+        // PutBucketLifecycleConfiguration / GetBucketLifecycleConfiguration /
+        // DeleteBucketLifecycle.
+        ResourceDef {
+            name: "s3.BucketLifecycleConfiguration",
+            service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
+            simple_delete: false,
+            noop_update: false,
+            create_op: "PutBucketLifecycleConfiguration",
+            read_structure: None,
+            read_ops: vec![],
+            delete_op: "DeleteBucketLifecycle",
+            update_ops: vec![UpdateOp {
+                operation: "PutBucketLifecycleConfiguration",
+                fields: FieldLayout::InsideStruct {
+                    name: "LifecycleConfiguration",
+                    fields: vec!["Rules"],
+                },
+            }],
+            identifier: "Bucket",
+            has_tags: false,
+            type_overrides: vec![("Rules", "super::bucket_lifecycle_rules()")],
+            exclude_fields: vec![
+                "ChecksumAlgorithm",
+                "ExpectedBucketOwner",
+                "LifecycleConfiguration",
+                "TransitionDefaultMinimumObjectSize",
+            ],
+            create_only_overrides: vec!["Bucket"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Bucket", "Rules"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![ExtraField {
+                name: "Rules",
+                read_source: None,
+                description: Some("Lifecycle rules to apply to the bucket."),
+            }],
+            identity_overrides: vec![],
+            derived_attributes: vec![],
+        },
         // s3.BucketPublicAccessBlock — controls the Public Access Block
         // settings of an existing S3 bucket. Maps to PutPublicAccessBlock /
         // GetPublicAccessBlock / DeletePublicAccessBlock.

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -46,6 +46,10 @@ impl Provider for AwsProvider {
                     self.read_s3_bucket_replication_configuration(&id, identifier.as_deref())
                         .await
                 }
+                "s3.BucketLifecycleConfiguration" => {
+                    self.read_s3_bucket_lifecycle_configuration(&id, identifier.as_deref())
+                        .await
+                }
                 "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
                 "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
                 "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
@@ -159,6 +163,10 @@ impl Provider for AwsProvider {
                     self.create_s3_bucket_replication_configuration(resource)
                         .await
                 }
+                "s3.BucketLifecycleConfiguration" => {
+                    self.create_s3_bucket_lifecycle_configuration(resource)
+                        .await
+                }
                 "ec2.Eip" => self.create_ec2_eip(resource).await,
                 "ec2.Vpc" => self.create_ec2_vpc(resource).await,
                 "ec2.Subnet" => self.create_ec2_subnet(resource).await,
@@ -249,6 +257,10 @@ impl Provider for AwsProvider {
                 }
                 "s3.BucketReplicationConfiguration" => {
                     self.update_s3_bucket_replication_configuration(id, &identifier, &from, to)
+                        .await
+                }
+                "s3.BucketLifecycleConfiguration" => {
+                    self.update_s3_bucket_lifecycle_configuration(id, &identifier, &from, to)
                         .await
                 }
                 "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
@@ -371,6 +383,10 @@ impl Provider for AwsProvider {
                 }
                 "s3.BucketReplicationConfiguration" => {
                     self.delete_s3_bucket_replication_configuration_idempotent(id, &identifier)
+                        .await
+                }
+                "s3.BucketLifecycleConfiguration" => {
+                    self.delete_s3_bucket_lifecycle_configuration_idempotent(id, &identifier)
                         .await
                 }
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -47,6 +47,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         s3::bucket::s3_bucket_config(),
         s3::bucket_acl::s3_bucket_acl_config(),
         s3::bucket_data_source::s3_bucket_data_source_config(),
+        s3::bucket_lifecycle_configuration::s3_bucket_lifecycle_configuration_config(),
         s3::bucket_ownership_controls::s3_bucket_ownership_controls_config(),
         s3::bucket_policy::s3_bucket_policy_config(),
         s3::bucket_public_access_block::s3_bucket_public_access_block_config(),
@@ -95,6 +96,7 @@ pub fn get_enum_valid_values(
         s3::bucket::enum_valid_values(),
         s3::bucket_acl::enum_valid_values(),
         s3::bucket_data_source::enum_valid_values(),
+        s3::bucket_lifecycle_configuration::enum_valid_values(),
         s3::bucket_ownership_controls::enum_valid_values(),
         s3::bucket_policy::enum_valid_values(),
         s3::bucket_public_access_block::enum_valid_values(),
@@ -200,6 +202,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.BucketAcl" {
         return s3::bucket_acl::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3.BucketLifecycleConfiguration" {
+        return s3::bucket_lifecycle_configuration::enum_alias_reverse(attr_name, value);
     }
     if resource_type == "s3.BucketOwnershipControls" {
         return s3::bucket_ownership_controls::enum_alias_reverse(attr_name, value);
@@ -409,6 +414,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket_acl::enum_alias_entries() {
         map.entry("s3.BucketAcl".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket_lifecycle_configuration::enum_alias_entries() {
+        map.entry("s3.BucketLifecycleConfiguration".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_lifecycle_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_lifecycle_configuration.rs
@@ -1,0 +1,51 @@
+//! BucketLifecycleConfiguration schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.s3
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for s3.BucketLifecycleConfiguration (Smithy: com.amazonaws.s3)
+pub fn s3_bucket_lifecycle_configuration_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::S3::BucketLifecycleConfiguration",
+        resource_type_name: "s3.BucketLifecycleConfiguration",
+        has_tags: false,
+        schema: ResourceSchema::new("s3.BucketLifecycleConfiguration")
+            .attribute(
+                AttributeSchema::new("bucket", AttributeType::String)
+                    .required()
+                    .create_only()
+                    .with_description("The name of the bucket for which to set the configuration.")
+                    .with_provider_name("Bucket"),
+            )
+            .attribute(
+                AttributeSchema::new("rules", super::bucket_lifecycle_rules())
+                    .required()
+                    .with_description("Lifecycle rules to apply to the bucket.")
+                    .with_provider_name("Rules"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("s3.BucketLifecycleConfiguration", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/mod.rs
@@ -9,6 +9,7 @@ pub use super::*;
 pub mod bucket;
 pub mod bucket_acl;
 pub mod bucket_data_source;
+pub mod bucket_lifecycle_configuration;
 pub mod bucket_ownership_controls;
 pub mod bucket_policy;
 pub mod bucket_public_access_block;

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -1,0 +1,413 @@
+use std::collections::HashMap;
+
+use aws_sdk_s3::types::{
+    AbortIncompleteMultipartUpload, BucketLifecycleConfiguration, ExpirationStatus,
+    LifecycleExpiration, LifecycleRule, NoncurrentVersionExpiration, NoncurrentVersionTransition,
+    Transition, TransitionStorageClass,
+};
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::utils::extract_enum_value;
+use indexmap::IndexMap;
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::services::s3::bucket::is_s3_not_configured_error;
+
+impl AwsProvider {
+    pub(crate) async fn read_s3_bucket_lifecycle_configuration(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(bucket) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .s3_client
+            .get_bucket_lifecycle_configuration()
+            .bucket(bucket)
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                let mut attributes = HashMap::new();
+                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                let rules: Vec<Value> = output.rules().iter().map(rule_to_value).collect();
+                if !rules.is_empty() {
+                    attributes.insert("rules".to_string(), Value::List(rules));
+                }
+                Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
+            }
+            Err(e) => {
+                if is_s3_not_configured_error(&e, "NoSuchLifecycleConfiguration")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket")
+                {
+                    return Ok(State::not_found(id.clone()));
+                }
+                Err(ProviderError::new(sdk_error_message(
+                    "Failed to get bucket lifecycle configuration",
+                    &e,
+                ))
+                .for_resource(id.clone()))
+            }
+        }
+    }
+
+    pub(crate) async fn create_s3_bucket_lifecycle_configuration(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let bucket = require_string_attr(&resource, "bucket")?;
+        self.put_s3_bucket_lifecycle(&resource.id, &bucket, &resource)
+            .await
+    }
+
+    pub(crate) async fn update_s3_bucket_lifecycle_configuration(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        _from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.put_s3_bucket_lifecycle(&id, identifier, &to).await
+    }
+
+    async fn put_s3_bucket_lifecycle(
+        &self,
+        id: &ResourceId,
+        bucket: &str,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let rules = match resource.get_attr("rules") {
+            Some(Value::List(items)) => items,
+            _ => {
+                return Err(ProviderError::new("rules is required and must be a list")
+                    .for_resource(id.clone()));
+            }
+        };
+
+        let sdk_rules: Vec<LifecycleRule> = rules
+            .iter()
+            .map(|v| build_rule(id, v))
+            .collect::<ProviderResult<Vec<_>>>()?;
+
+        let config = BucketLifecycleConfiguration::builder()
+            .set_rules(Some(sdk_rules))
+            .build()
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message(
+                    "Failed to build BucketLifecycleConfiguration",
+                    &e,
+                ))
+                .for_resource(id.clone())
+            })?;
+
+        self.s3_client
+            .put_bucket_lifecycle_configuration()
+            .bucket(bucket)
+            .lifecycle_configuration(config)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message(
+                    "Failed to put bucket lifecycle configuration",
+                    &e,
+                ))
+                .for_resource(id.clone())
+            })?;
+
+        self.read_s3_bucket_lifecycle_configuration(id, Some(bucket))
+            .await
+    }
+
+    pub(crate) async fn delete_s3_bucket_lifecycle_configuration_idempotent(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let result = self
+            .s3_client
+            .delete_bucket_lifecycle()
+            .bucket(identifier)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e)
+                if is_s3_not_configured_error(&e, "NoSuchLifecycleConfiguration")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket") =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(ProviderError::new(sdk_error_message(
+                "Failed to delete bucket lifecycle configuration",
+                &e,
+            ))
+            .for_resource(id.clone())),
+        }
+    }
+}
+
+fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRule> {
+    let Value::Map(map) = rule_value else {
+        return Err(ProviderError::new("each rule must be a map").for_resource(id.clone()));
+    };
+
+    let status_str = match map.get("status") {
+        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        _ => {
+            return Err(ProviderError::new("rule.status is required").for_resource(id.clone()));
+        }
+    };
+
+    let mut builder = LifecycleRule::builder().status(ExpirationStatus::from(status_str.as_str()));
+
+    if let Some(Value::String(s)) = map.get("id") {
+        builder = builder.id(s);
+    }
+    #[allow(deprecated)]
+    if let Some(Value::String(s)) = map.get("prefix") {
+        builder = builder.prefix(s);
+    }
+    if let Some(v) = map.get("expiration") {
+        builder = builder.expiration(build_expiration(id, v)?);
+    }
+    if let Some(Value::List(items)) = map.get("transitions") {
+        let transitions: Vec<Transition> = items
+            .iter()
+            .map(|v| build_transition(id, v))
+            .collect::<ProviderResult<Vec<_>>>()?;
+        builder = builder.set_transitions(Some(transitions));
+    }
+    if let Some(v) = map.get("noncurrent_version_expiration") {
+        builder = builder.noncurrent_version_expiration(build_ncv_expiration(id, v)?);
+    }
+    if let Some(Value::List(items)) = map.get("noncurrent_version_transitions") {
+        let transitions: Vec<NoncurrentVersionTransition> = items
+            .iter()
+            .map(|v| build_ncv_transition(id, v))
+            .collect::<ProviderResult<Vec<_>>>()?;
+        builder = builder.set_noncurrent_version_transitions(Some(transitions));
+    }
+    if let Some(v) = map.get("abort_incomplete_multipart_upload") {
+        builder = builder.abort_incomplete_multipart_upload(build_abort_multipart(id, v)?);
+    }
+
+    builder.build().map_err(|e| {
+        ProviderError::new(sdk_error_message("Failed to build LifecycleRule", &e))
+            .for_resource(id.clone())
+    })
+}
+
+fn build_expiration(id: &ResourceId, value: &Value) -> ProviderResult<LifecycleExpiration> {
+    let Value::Map(map) = value else {
+        return Err(ProviderError::new("expiration must be a map").for_resource(id.clone()));
+    };
+    let mut builder = LifecycleExpiration::builder();
+    if let Some(Value::Int(d)) = map.get("days") {
+        builder = builder.days(*d as i32);
+    }
+    if let Some(Value::Bool(b)) = map.get("expired_object_delete_marker") {
+        builder = builder.expired_object_delete_marker(*b);
+    }
+    Ok(builder.build())
+}
+
+fn build_transition(id: &ResourceId, value: &Value) -> ProviderResult<Transition> {
+    let Value::Map(map) = value else {
+        return Err(ProviderError::new("transition must be a map").for_resource(id.clone()));
+    };
+    let storage_class_str = match map.get("storage_class") {
+        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        _ => {
+            return Err(
+                ProviderError::new("transition.storage_class is required").for_resource(id.clone())
+            );
+        }
+    };
+    let mut builder = Transition::builder()
+        .storage_class(TransitionStorageClass::from(storage_class_str.as_str()));
+    if let Some(Value::Int(d)) = map.get("days") {
+        builder = builder.days(*d as i32);
+    }
+    Ok(builder.build())
+}
+
+fn build_ncv_expiration(
+    id: &ResourceId,
+    value: &Value,
+) -> ProviderResult<NoncurrentVersionExpiration> {
+    let Value::Map(map) = value else {
+        return Err(
+            ProviderError::new("noncurrent_version_expiration must be a map")
+                .for_resource(id.clone()),
+        );
+    };
+    let mut builder = NoncurrentVersionExpiration::builder();
+    if let Some(Value::Int(d)) = map.get("noncurrent_days") {
+        builder = builder.noncurrent_days(*d as i32);
+    }
+    if let Some(Value::Int(n)) = map.get("newer_noncurrent_versions") {
+        builder = builder.newer_noncurrent_versions(*n as i32);
+    }
+    Ok(builder.build())
+}
+
+fn build_ncv_transition(
+    id: &ResourceId,
+    value: &Value,
+) -> ProviderResult<NoncurrentVersionTransition> {
+    let Value::Map(map) = value else {
+        return Err(
+            ProviderError::new("noncurrent_version_transition must be a map")
+                .for_resource(id.clone()),
+        );
+    };
+    let storage_class_str = match map.get("storage_class") {
+        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        _ => {
+            return Err(ProviderError::new(
+                "noncurrent_version_transition.storage_class is required",
+            )
+            .for_resource(id.clone()));
+        }
+    };
+    let mut builder = NoncurrentVersionTransition::builder()
+        .storage_class(TransitionStorageClass::from(storage_class_str.as_str()));
+    if let Some(Value::Int(d)) = map.get("noncurrent_days") {
+        builder = builder.noncurrent_days(*d as i32);
+    }
+    if let Some(Value::Int(n)) = map.get("newer_noncurrent_versions") {
+        builder = builder.newer_noncurrent_versions(*n as i32);
+    }
+    Ok(builder.build())
+}
+
+fn build_abort_multipart(
+    id: &ResourceId,
+    value: &Value,
+) -> ProviderResult<AbortIncompleteMultipartUpload> {
+    let Value::Map(map) = value else {
+        return Err(
+            ProviderError::new("abort_incomplete_multipart_upload must be a map")
+                .for_resource(id.clone()),
+        );
+    };
+    let mut builder = AbortIncompleteMultipartUpload::builder();
+    if let Some(Value::Int(d)) = map.get("days_after_initiation") {
+        builder = builder.days_after_initiation(*d as i32);
+    }
+    Ok(builder.build())
+}
+
+fn rule_to_value(rule: &LifecycleRule) -> Value {
+    let mut map = IndexMap::new();
+    if let Some(s) = rule.id()
+        && !s.is_empty()
+    {
+        map.insert("id".to_string(), Value::String(s.to_string()));
+    }
+    map.insert(
+        "status".to_string(),
+        Value::String(rule.status().as_str().to_string()),
+    );
+    #[allow(deprecated)]
+    if let Some(s) = rule.prefix()
+        && !s.is_empty()
+    {
+        map.insert("prefix".to_string(), Value::String(s.to_string()));
+    }
+    if let Some(exp) = rule.expiration() {
+        let mut e = IndexMap::new();
+        if let Some(d) = exp.days() {
+            e.insert("days".to_string(), Value::Int(d as i64));
+        }
+        if let Some(b) = exp.expired_object_delete_marker() {
+            e.insert("expired_object_delete_marker".to_string(), Value::Bool(b));
+        }
+        if !e.is_empty() {
+            map.insert("expiration".to_string(), Value::Map(e));
+        }
+    }
+    let transitions: Vec<Value> = rule.transitions().iter().map(transition_to_value).collect();
+    if !transitions.is_empty() {
+        map.insert("transitions".to_string(), Value::List(transitions));
+    }
+    if let Some(ncv) = rule.noncurrent_version_expiration() {
+        let mut e = IndexMap::new();
+        if let Some(d) = ncv.noncurrent_days() {
+            e.insert("noncurrent_days".to_string(), Value::Int(d as i64));
+        }
+        if let Some(n) = ncv.newer_noncurrent_versions() {
+            e.insert(
+                "newer_noncurrent_versions".to_string(),
+                Value::Int(n as i64),
+            );
+        }
+        if !e.is_empty() {
+            map.insert("noncurrent_version_expiration".to_string(), Value::Map(e));
+        }
+    }
+    let ncv_transitions: Vec<Value> = rule
+        .noncurrent_version_transitions()
+        .iter()
+        .map(ncv_transition_to_value)
+        .collect();
+    if !ncv_transitions.is_empty() {
+        map.insert(
+            "noncurrent_version_transitions".to_string(),
+            Value::List(ncv_transitions),
+        );
+    }
+    if let Some(abort) = rule.abort_incomplete_multipart_upload() {
+        let mut a = IndexMap::new();
+        if let Some(d) = abort.days_after_initiation() {
+            a.insert("days_after_initiation".to_string(), Value::Int(d as i64));
+        }
+        if !a.is_empty() {
+            map.insert(
+                "abort_incomplete_multipart_upload".to_string(),
+                Value::Map(a),
+            );
+        }
+    }
+    Value::Map(map)
+}
+
+fn transition_to_value(t: &Transition) -> Value {
+    let mut m = IndexMap::new();
+    if let Some(d) = t.days() {
+        m.insert("days".to_string(), Value::Int(d as i64));
+    }
+    if let Some(sc) = t.storage_class() {
+        m.insert(
+            "storage_class".to_string(),
+            Value::String(sc.as_str().to_string()),
+        );
+    }
+    Value::Map(m)
+}
+
+fn ncv_transition_to_value(t: &NoncurrentVersionTransition) -> Value {
+    let mut m = IndexMap::new();
+    if let Some(d) = t.noncurrent_days() {
+        m.insert("noncurrent_days".to_string(), Value::Int(d as i64));
+    }
+    if let Some(n) = t.newer_noncurrent_versions() {
+        m.insert(
+            "newer_noncurrent_versions".to_string(),
+            Value::Int(n as i64),
+        );
+    }
+    if let Some(sc) = t.storage_class() {
+        m.insert(
+            "storage_class".to_string(),
+            Value::String(sc.as_str().to_string()),
+        );
+    }
+    Value::Map(m)
+}

--- a/carina-provider-aws/src/services/s3/mod.rs
+++ b/carina-provider-aws/src/services/s3/mod.rs
@@ -1,6 +1,7 @@
 pub mod bucket;
 pub mod bucket_acl;
 pub mod bucket_encryption;
+pub mod bucket_lifecycle;
 pub mod bucket_ownership_controls;
 pub mod bucket_policy;
 pub mod bucket_public_access_block;


### PR DESCRIPTION
Closes #222

Seventh slice of #164. Lifecycle rules (transitions, expiration, noncurrent-version handling, abort-multipart) via Carina DSL block syntax.

CI: 326 tests, clippy clean, fmt clean, codegen no-diff.