### PR TITLE
Add aws.s3.BucketCorsConfiguration as a standalone resource

### DIFF
--- a/acceptance-tests/s3_bucket_cors_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_cors_configuration/basic.crn
@@ -1,0 +1,24 @@
+# S3 BucketCorsConfiguration - Basic test
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-bucket-cors-basic-v1'
+}
+
+aws.s3.BucketCorsConfiguration {
+  bucket = bucket.bucket
+
+  cors_rules = [
+    {
+      id = 'allow-get-from-example'
+      allowed_methods = ['GET']
+      allowed_origins = ['https://example.com']
+      allowed_headers = ['*']
+      expose_headers = ['ETag']
+      max_age_seconds = 3000
+    },
+  ]
+}

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1612,6 +1612,40 @@ pub fn bucket_lifecycle_rules() -> AttributeType {
     AttributeType::list(s3_lifecycle_rule())
 }
 
+fn s3_cors_rule() -> AttributeType {
+    AttributeType::Struct {
+        name: "CorsRule".to_string(),
+        fields: vec![
+            StructField::new("id", AttributeType::String).with_provider_name("ID"),
+            StructField::new(
+                "allowed_methods",
+                AttributeType::list(AttributeType::String),
+            )
+            .with_provider_name("AllowedMethods")
+            .required(),
+            StructField::new(
+                "allowed_origins",
+                AttributeType::list(AttributeType::String),
+            )
+            .with_provider_name("AllowedOrigins")
+            .required(),
+            StructField::new(
+                "allowed_headers",
+                AttributeType::list(AttributeType::String),
+            )
+            .with_provider_name("AllowedHeaders"),
+            StructField::new("expose_headers", AttributeType::list(AttributeType::String))
+                .with_provider_name("ExposeHeaders"),
+            StructField::new("max_age_seconds", AttributeType::Int)
+                .with_provider_name("MaxAgeSeconds"),
+        ],
+    }
+}
+
+pub fn bucket_cors_rules() -> AttributeType {
+    AttributeType::list(s3_cors_rule())
+}
+
 pub fn s3_index_document() -> AttributeType {
     AttributeType::Struct {
         name: "IndexDocument".to_string(),

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3954,6 +3954,7 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "s3.BucketReplicationConfiguration" => "AWS::S3::BucketReplicationConfiguration",
         "s3.BucketLifecycleConfiguration" => "AWS::S3::BucketLifecycleConfiguration",
         "s3.BucketWebsiteConfiguration" => "AWS::S3::BucketWebsiteConfiguration",
+        "s3.BucketCorsConfiguration" => "AWS::S3::BucketCorsConfiguration",
         "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
         "organizations.Organization" => "AWS::Organizations::Organization",
         "organizations.Account" => "AWS::Organizations::Account",

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1630,6 +1630,48 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
+        // s3.BucketCorsConfiguration — controls CORS rules on an existing
+        // S3 bucket. Maps to PutBucketCors / GetBucketCors / DeleteBucketCors.
+        ResourceDef {
+            name: "s3.BucketCorsConfiguration",
+            service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
+            simple_delete: false,
+            noop_update: false,
+            create_op: "PutBucketCors",
+            read_structure: None,
+            read_ops: vec![],
+            delete_op: "DeleteBucketCors",
+            update_ops: vec![UpdateOp {
+                operation: "PutBucketCors",
+                fields: FieldLayout::InsideStruct {
+                    name: "CORSConfiguration",
+                    fields: vec!["CORSRules"],
+                },
+            }],
+            identifier: "Bucket",
+            has_tags: false,
+            type_overrides: vec![("CORSRules", "super::bucket_cors_rules()")],
+            exclude_fields: vec![
+                "ContentMD5",
+                "ChecksumAlgorithm",
+                "ExpectedBucketOwner",
+                "CORSConfiguration",
+            ],
+            create_only_overrides: vec!["Bucket"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Bucket", "CORSRules"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![ExtraField {
+                name: "CORSRules",
+                read_source: None,
+                description: Some("CORS rules to apply to the bucket."),
+            }],
+            identity_overrides: vec![],
+            derived_attributes: vec![],
+        },
         // s3.BucketPublicAccessBlock — controls the Public Access Block
         // settings of an existing S3 bucket. Maps to PutPublicAccessBlock /
         // GetPublicAccessBlock / DeletePublicAccessBlock.

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -54,6 +54,10 @@ impl Provider for AwsProvider {
                     self.read_s3_bucket_website_configuration(&id, identifier.as_deref())
                         .await
                 }
+                "s3.BucketCorsConfiguration" => {
+                    self.read_s3_bucket_cors_configuration(&id, identifier.as_deref())
+                        .await
+                }
                 "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
                 "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
                 "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
@@ -174,6 +178,9 @@ impl Provider for AwsProvider {
                 "s3.BucketWebsiteConfiguration" => {
                     self.create_s3_bucket_website_configuration(resource).await
                 }
+                "s3.BucketCorsConfiguration" => {
+                    self.create_s3_bucket_cors_configuration(resource).await
+                }
                 "ec2.Eip" => self.create_ec2_eip(resource).await,
                 "ec2.Vpc" => self.create_ec2_vpc(resource).await,
                 "ec2.Subnet" => self.create_ec2_subnet(resource).await,
@@ -272,6 +279,10 @@ impl Provider for AwsProvider {
                 }
                 "s3.BucketWebsiteConfiguration" => {
                     self.update_s3_bucket_website_configuration(id, &identifier, &from, to)
+                        .await
+                }
+                "s3.BucketCorsConfiguration" => {
+                    self.update_s3_bucket_cors_configuration(id, &identifier, &from, to)
                         .await
                 }
                 "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
@@ -402,6 +413,10 @@ impl Provider for AwsProvider {
                 }
                 "s3.BucketWebsiteConfiguration" => {
                     self.delete_s3_bucket_website_configuration_idempotent(id, &identifier)
+                        .await
+                }
+                "s3.BucketCorsConfiguration" => {
+                    self.delete_s3_bucket_cors_configuration_idempotent(id, &identifier)
                         .await
                 }
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -46,6 +46,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         route53::record_set::route53_record_set_config(),
         s3::bucket::s3_bucket_config(),
         s3::bucket_acl::s3_bucket_acl_config(),
+        s3::bucket_cors_configuration::s3_bucket_cors_configuration_config(),
         s3::bucket_data_source::s3_bucket_data_source_config(),
         s3::bucket_lifecycle_configuration::s3_bucket_lifecycle_configuration_config(),
         s3::bucket_ownership_controls::s3_bucket_ownership_controls_config(),
@@ -96,6 +97,7 @@ pub fn get_enum_valid_values(
         route53::record_set::enum_valid_values(),
         s3::bucket::enum_valid_values(),
         s3::bucket_acl::enum_valid_values(),
+        s3::bucket_cors_configuration::enum_valid_values(),
         s3::bucket_data_source::enum_valid_values(),
         s3::bucket_lifecycle_configuration::enum_valid_values(),
         s3::bucket_ownership_controls::enum_valid_values(),
@@ -204,6 +206,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.BucketAcl" {
         return s3::bucket_acl::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3.BucketCorsConfiguration" {
+        return s3::bucket_cors_configuration::enum_alias_reverse(attr_name, value);
     }
     if resource_type == "s3.BucketLifecycleConfiguration" {
         return s3::bucket_lifecycle_configuration::enum_alias_reverse(attr_name, value);
@@ -419,6 +424,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket_acl::enum_alias_entries() {
         map.entry("s3.BucketAcl".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket_cors_configuration::enum_alias_entries() {
+        map.entry("s3.BucketCorsConfiguration".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_cors_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_cors_configuration.rs
@@ -1,0 +1,51 @@
+//! BucketCorsConfiguration schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.s3
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for s3.BucketCorsConfiguration (Smithy: com.amazonaws.s3)
+pub fn s3_bucket_cors_configuration_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::S3::BucketCorsConfiguration",
+        resource_type_name: "s3.BucketCorsConfiguration",
+        has_tags: false,
+        schema: ResourceSchema::new("s3.BucketCorsConfiguration")
+            .attribute(
+                AttributeSchema::new("bucket", AttributeType::String)
+                    .required()
+                    .create_only()
+                    .with_description("Specifies the bucket impacted by the corsconfiguration.")
+                    .with_provider_name("Bucket"),
+            )
+            .attribute(
+                AttributeSchema::new("cors_rules", super::bucket_cors_rules())
+                    .required()
+                    .with_description("CORS rules to apply to the bucket.")
+                    .with_provider_name("CORSRules"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("s3.BucketCorsConfiguration", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/mod.rs
@@ -8,6 +8,7 @@ pub use super::*;
 
 pub mod bucket;
 pub mod bucket_acl;
+pub mod bucket_cors_configuration;
 pub mod bucket_data_source;
 pub mod bucket_lifecycle_configuration;
 pub mod bucket_ownership_controls;

--- a/carina-provider-aws/src/services/s3/bucket_cors.rs
+++ b/carina-provider-aws/src/services/s3/bucket_cors.rs
@@ -1,0 +1,237 @@
+use std::collections::HashMap;
+
+use aws_sdk_s3::types::{CorsConfiguration, CorsRule};
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+use indexmap::IndexMap;
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::services::s3::bucket::is_s3_not_configured_error;
+
+impl AwsProvider {
+    pub(crate) async fn read_s3_bucket_cors_configuration(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(bucket) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self.s3_client.get_bucket_cors().bucket(bucket).send().await;
+
+        match result {
+            Ok(output) => {
+                let mut attributes = HashMap::new();
+                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                let rules: Vec<Value> = output.cors_rules().iter().map(rule_to_value).collect();
+                attributes.insert("cors_rules".to_string(), Value::List(rules));
+                Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
+            }
+            Err(e) => {
+                if is_s3_not_configured_error(&e, "NoSuchCORSConfiguration")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket")
+                {
+                    return Ok(State::not_found(id.clone()));
+                }
+                Err(ProviderError::new(sdk_error_message(
+                    "Failed to get bucket cors configuration",
+                    &e,
+                ))
+                .for_resource(id.clone()))
+            }
+        }
+    }
+
+    pub(crate) async fn create_s3_bucket_cors_configuration(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let bucket = require_string_attr(&resource, "bucket")?;
+        self.put_s3_bucket_cors(&resource.id, &bucket, &resource)
+            .await
+    }
+
+    pub(crate) async fn update_s3_bucket_cors_configuration(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        _from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.put_s3_bucket_cors(&id, identifier, &to).await
+    }
+
+    async fn put_s3_bucket_cors(
+        &self,
+        id: &ResourceId,
+        bucket: &str,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let rules = match resource.get_attr("cors_rules") {
+            Some(Value::List(items)) => items,
+            _ => {
+                return Err(
+                    ProviderError::new("cors_rules is required and must be a list")
+                        .for_resource(id.clone()),
+                );
+            }
+        };
+
+        let sdk_rules: Vec<CorsRule> = rules
+            .iter()
+            .map(|v| build_rule(id, v))
+            .collect::<ProviderResult<Vec<_>>>()?;
+
+        let config = CorsConfiguration::builder()
+            .set_cors_rules(Some(sdk_rules))
+            .build()
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to build CorsConfiguration", &e))
+                    .for_resource(id.clone())
+            })?;
+
+        self.s3_client
+            .put_bucket_cors()
+            .bucket(bucket)
+            .cors_configuration(config)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to put bucket cors", &e))
+                    .for_resource(id.clone())
+            })?;
+
+        self.read_s3_bucket_cors_configuration(id, Some(bucket))
+            .await
+    }
+
+    pub(crate) async fn delete_s3_bucket_cors_configuration_idempotent(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let result = self
+            .s3_client
+            .delete_bucket_cors()
+            .bucket(identifier)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e)
+                if is_s3_not_configured_error(&e, "NoSuchCORSConfiguration")
+                    || is_s3_not_configured_error(&e, "NoSuchBucket") =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(ProviderError::new(sdk_error_message(
+                "Failed to delete bucket cors configuration",
+                &e,
+            ))
+            .for_resource(id.clone())),
+        }
+    }
+}
+
+fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<CorsRule> {
+    let Value::Map(map) = rule_value else {
+        return Err(ProviderError::new("each cors rule must be a map").for_resource(id.clone()));
+    };
+
+    let allowed_methods = require_string_list(id, map, "allowed_methods")?;
+    let allowed_origins = require_string_list(id, map, "allowed_origins")?;
+
+    let mut builder = CorsRule::builder()
+        .set_allowed_methods(Some(allowed_methods))
+        .set_allowed_origins(Some(allowed_origins));
+
+    if let Some(Value::String(s)) = map.get("id") {
+        builder = builder.id(s);
+    }
+    if let Some(Value::List(items)) = map.get("allowed_headers") {
+        builder =
+            builder.set_allowed_headers(Some(strings_from_list(id, items, "allowed_headers")?));
+    }
+    if let Some(Value::List(items)) = map.get("expose_headers") {
+        builder = builder.set_expose_headers(Some(strings_from_list(id, items, "expose_headers")?));
+    }
+    if let Some(Value::Int(n)) = map.get("max_age_seconds") {
+        builder = builder.max_age_seconds(*n as i32);
+    }
+
+    builder.build().map_err(|e| {
+        ProviderError::new(sdk_error_message("Failed to build CorsRule", &e))
+            .for_resource(id.clone())
+    })
+}
+
+fn require_string_list(
+    id: &ResourceId,
+    map: &IndexMap<String, Value>,
+    field: &str,
+) -> ProviderResult<Vec<String>> {
+    match map.get(field) {
+        Some(Value::List(items)) => strings_from_list(id, items, field),
+        _ => {
+            Err(ProviderError::new(format!("cors_rule.{field} is required"))
+                .for_resource(id.clone()))
+        }
+    }
+}
+
+fn strings_from_list(id: &ResourceId, items: &[Value], field: &str) -> ProviderResult<Vec<String>> {
+    items
+        .iter()
+        .map(|v| match v {
+            Value::String(s) => Ok(s.clone()),
+            _ => Err(
+                ProviderError::new(format!("cors_rule.{field} must be a list of strings"))
+                    .for_resource(id.clone()),
+            ),
+        })
+        .collect()
+}
+
+fn rule_to_value(rule: &CorsRule) -> Value {
+    let mut m = IndexMap::new();
+    if let Some(s) = rule.id()
+        && !s.is_empty()
+    {
+        m.insert("id".to_string(), Value::String(s.to_string()));
+    }
+    let methods: Vec<Value> = rule
+        .allowed_methods()
+        .iter()
+        .map(|s| Value::String(s.clone()))
+        .collect();
+    m.insert("allowed_methods".to_string(), Value::List(methods));
+    let origins: Vec<Value> = rule
+        .allowed_origins()
+        .iter()
+        .map(|s| Value::String(s.clone()))
+        .collect();
+    m.insert("allowed_origins".to_string(), Value::List(origins));
+    let headers: Vec<Value> = rule
+        .allowed_headers()
+        .iter()
+        .map(|s| Value::String(s.clone()))
+        .collect();
+    if !headers.is_empty() {
+        m.insert("allowed_headers".to_string(), Value::List(headers));
+    }
+    let expose: Vec<Value> = rule
+        .expose_headers()
+        .iter()
+        .map(|s| Value::String(s.clone()))
+        .collect();
+    if !expose.is_empty() {
+        m.insert("expose_headers".to_string(), Value::List(expose));
+    }
+    if let Some(n) = rule.max_age_seconds() {
+        m.insert("max_age_seconds".to_string(), Value::Int(n as i64));
+    }
+    Value::Map(m)
+}

--- a/carina-provider-aws/src/services/s3/mod.rs
+++ b/carina-provider-aws/src/services/s3/mod.rs
@@ -1,5 +1,6 @@
 pub mod bucket;
 pub mod bucket_acl;
+pub mod bucket_cors;
 pub mod bucket_encryption;
 pub mod bucket_lifecycle;
 pub mod bucket_ownership_controls;


### PR DESCRIPTION
## Summary

Tenth slice under #164 (Terraform-style decomposition of `aws.s3.Bucket`).

Adds `aws.s3.BucketCorsConfiguration` as a standalone Managed resource that controls CORS rules on an existing S3 bucket. Maps to `PutBucketCors` / `GetBucketCors` / `DeleteBucketCors`.

- `bucket: String` (required, create-only)
- `cors_rules: List<Struct>` (required) — each with `id`, `allowed_methods`, `allowed_origins`, `allowed_headers`, `expose_headers`, `max_age_seconds`
- Delete is idempotent — swallows `NoSuchCORSConfiguration` and `NoSuchBucket`
- Acceptance fixture in `acceptance-tests/s3_bucket_cors_configuration/basic.crn`

Closes #224

## Test plan

- [x] `cargo nextest run` — 326 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --release -p carina-provider-aws`
- [x] `bash scripts/generate-schemas-smithy.sh`
- [x] `bash scripts/generate-provider.sh`
- [x] `bash scripts/generate-docs.sh`
- [ ] Acceptance test on AWS (will run after merge per series practice)