### PR TITLE
Add aws.s3.BucketNotificationConfiguration as a standalone resource

### DIFF
--- a/acceptance-tests/s3_bucket_notification_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_notification_configuration/basic.crn
@@ -1,0 +1,26 @@
+# S3 BucketNotificationConfiguration - Basic test
+#
+# NOTE: this fixture references an SQS queue ARN that must already exist
+# (and grant s3.amazonaws.com permission to send messages) when running
+# the acceptance test. Carina does not yet manage SQS, so the queue is a
+# precondition rather than a fixture-managed resource.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-bucket-notification-basic-v1'
+}
+
+aws.s3.BucketNotificationConfiguration {
+  bucket = bucket.bucket
+
+  queue_configurations = [
+    {
+      id = 'object-created'
+      queue_arn = 'arn:aws:sqs:ap-northeast-1:000000000000:carina-acc-test-aws-s3-bucket-notification-queue'
+      events = ['s3:ObjectCreated:*']
+    },
+  ]
+}

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1646,6 +1646,100 @@ pub fn bucket_cors_rules() -> AttributeType {
     AttributeType::list(s3_cors_rule())
 }
 
+fn s3_notification_filter_rule() -> AttributeType {
+    AttributeType::Struct {
+        name: "FilterRule".to_string(),
+        fields: vec![
+            StructField::new("name", AttributeType::String)
+                .with_provider_name("Name")
+                .required(),
+            StructField::new("value", AttributeType::String)
+                .with_provider_name("Value")
+                .required(),
+        ],
+    }
+}
+
+fn s3_notification_filter() -> AttributeType {
+    AttributeType::Struct {
+        name: "NotificationFilter".to_string(),
+        fields: vec![
+            StructField::new(
+                "filter_rules",
+                AttributeType::list(s3_notification_filter_rule()),
+            )
+            .with_provider_name("FilterRules"),
+        ],
+    }
+}
+
+fn s3_topic_configuration() -> AttributeType {
+    AttributeType::Struct {
+        name: "TopicConfiguration".to_string(),
+        fields: vec![
+            StructField::new("id", AttributeType::String).with_provider_name("Id"),
+            StructField::new("topic_arn", AttributeType::String)
+                .with_provider_name("TopicArn")
+                .required(),
+            StructField::new("events", AttributeType::list(AttributeType::String))
+                .with_provider_name("Events")
+                .required(),
+            StructField::new("filter", s3_notification_filter()).with_provider_name("Filter"),
+        ],
+    }
+}
+
+fn s3_queue_configuration() -> AttributeType {
+    AttributeType::Struct {
+        name: "QueueConfiguration".to_string(),
+        fields: vec![
+            StructField::new("id", AttributeType::String).with_provider_name("Id"),
+            StructField::new("queue_arn", AttributeType::String)
+                .with_provider_name("QueueArn")
+                .required(),
+            StructField::new("events", AttributeType::list(AttributeType::String))
+                .with_provider_name("Events")
+                .required(),
+            StructField::new("filter", s3_notification_filter()).with_provider_name("Filter"),
+        ],
+    }
+}
+
+fn s3_lambda_function_configuration() -> AttributeType {
+    AttributeType::Struct {
+        name: "LambdaFunctionConfiguration".to_string(),
+        fields: vec![
+            StructField::new("id", AttributeType::String).with_provider_name("Id"),
+            StructField::new("lambda_function_arn", AttributeType::String)
+                .with_provider_name("LambdaFunctionArn")
+                .required(),
+            StructField::new("events", AttributeType::list(AttributeType::String))
+                .with_provider_name("Events")
+                .required(),
+            StructField::new("filter", s3_notification_filter()).with_provider_name("Filter"),
+        ],
+    }
+}
+
+pub fn bucket_topic_configurations() -> AttributeType {
+    AttributeType::list(s3_topic_configuration())
+}
+
+pub fn bucket_queue_configurations() -> AttributeType {
+    AttributeType::list(s3_queue_configuration())
+}
+
+pub fn bucket_lambda_function_configurations() -> AttributeType {
+    AttributeType::list(s3_lambda_function_configuration())
+}
+
+pub fn bucket_event_bridge_configuration() -> AttributeType {
+    AttributeType::Struct {
+        name: "EventBridgeConfiguration".to_string(),
+        fields: vec![],
+    }
+}
+
 pub fn s3_index_document() -> AttributeType {
     AttributeType::Struct {
         name: "IndexDocument".to_string(),

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3955,6 +3955,7 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "s3.BucketLifecycleConfiguration" => "AWS::S3::BucketLifecycleConfiguration",
         "s3.BucketWebsiteConfiguration" => "AWS::S3::BucketWebsiteConfiguration",
         "s3.BucketCorsConfiguration" => "AWS::S3::BucketCorsConfiguration",
+        "s3.BucketNotificationConfiguration" => "AWS::S3::BucketNotificationConfiguration",
         "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
         "organizations.Organization" => "AWS::Organizations::Organization",
         "organizations.Account" => "AWS::Organizations::Account",

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1672,6 +1672,92 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
+        // s3.BucketNotificationConfiguration — wires bucket events to
+        // SNS / SQS / Lambda / EventBridge destinations. Maps to
+        // PutBucketNotificationConfiguration / GetBucketNotificationConfiguration.
+        // No DeleteBucket* API exists; destroy is implemented as a Put with
+        // empty configuration (Terraform parity).
+        ResourceDef {
+            name: "s3.BucketNotificationConfiguration",
+            service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
+            simple_delete: false,
+            noop_update: false,
+            create_op: "PutBucketNotificationConfiguration",
+            read_structure: None,
+            read_ops: vec![],
+            // No native delete API — destroy uses the same Put op with
+            // empty lists; we still set delete_op for code-gen totality but
+            // the dispatch table calls the hand-written idempotent helper.
+            delete_op: "PutBucketNotificationConfiguration",
+            update_ops: vec![UpdateOp {
+                operation: "PutBucketNotificationConfiguration",
+                fields: FieldLayout::InsideStruct {
+                    name: "NotificationConfiguration",
+                    fields: vec![
+                        "TopicConfigurations",
+                        "QueueConfigurations",
+                        "LambdaFunctionConfigurations",
+                        "EventBridgeConfiguration",
+                    ],
+                },
+            }],
+            identifier: "Bucket",
+            has_tags: false,
+            type_overrides: vec![
+                (
+                    "TopicConfigurations",
+                    "super::bucket_topic_configurations()",
+                ),
+                (
+                    "QueueConfigurations",
+                    "super::bucket_queue_configurations()",
+                ),
+                (
+                    "LambdaFunctionConfigurations",
+                    "super::bucket_lambda_function_configurations()",
+                ),
+                (
+                    "EventBridgeConfiguration",
+                    "super::bucket_event_bridge_configuration()",
+                ),
+            ],
+            exclude_fields: vec![
+                "ExpectedBucketOwner",
+                "SkipDestinationValidation",
+                "NotificationConfiguration",
+            ],
+            create_only_overrides: vec!["Bucket"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Bucket"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![
+                ExtraField {
+                    name: "TopicConfigurations",
+                    read_source: None,
+                    description: Some("SNS topic notification configurations."),
+                },
+                ExtraField {
+                    name: "QueueConfigurations",
+                    read_source: None,
+                    description: Some("SQS queue notification configurations."),
+                },
+                ExtraField {
+                    name: "LambdaFunctionConfigurations",
+                    read_source: None,
+                    description: Some("Lambda function notification configurations."),
+                },
+                ExtraField {
+                    name: "EventBridgeConfiguration",
+                    read_source: None,
+                    description: Some("Enables EventBridge notifications when present."),
+                },
+            ],
+            identity_overrides: vec![],
+            derived_attributes: vec![],
+        },
         // s3.BucketPublicAccessBlock — controls the Public Access Block
         // settings of an existing S3 bucket. Maps to PutPublicAccessBlock /
         // GetPublicAccessBlock / DeletePublicAccessBlock.

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -58,6 +58,10 @@ impl Provider for AwsProvider {
                     self.read_s3_bucket_cors_configuration(&id, identifier.as_deref())
                         .await
                 }
+                "s3.BucketNotificationConfiguration" => {
+                    self.read_s3_bucket_notification_configuration(&id, identifier.as_deref())
+                        .await
+                }
                 "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
                 "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
                 "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
@@ -181,6 +185,10 @@ impl Provider for AwsProvider {
                 "s3.BucketCorsConfiguration" => {
                     self.create_s3_bucket_cors_configuration(resource).await
                 }
+                "s3.BucketNotificationConfiguration" => {
+                    self.create_s3_bucket_notification_configuration(resource)
+                        .await
+                }
                 "ec2.Eip" => self.create_ec2_eip(resource).await,
                 "ec2.Vpc" => self.create_ec2_vpc(resource).await,
                 "ec2.Subnet" => self.create_ec2_subnet(resource).await,
@@ -283,6 +291,10 @@ impl Provider for AwsProvider {
                 }
                 "s3.BucketCorsConfiguration" => {
                     self.update_s3_bucket_cors_configuration(id, &identifier, &from, to)
+                        .await
+                }
+                "s3.BucketNotificationConfiguration" => {
+                    self.update_s3_bucket_notification_configuration(id, &identifier, &from, to)
                         .await
                 }
                 "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
@@ -417,6 +429,10 @@ impl Provider for AwsProvider {
                 }
                 "s3.BucketCorsConfiguration" => {
                     self.delete_s3_bucket_cors_configuration_idempotent(id, &identifier)
+                        .await
+                }
+                "s3.BucketNotificationConfiguration" => {
+                    self.delete_s3_bucket_notification_configuration_idempotent(id, &identifier)
                         .await
                 }
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -49,6 +49,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         s3::bucket_cors_configuration::s3_bucket_cors_configuration_config(),
         s3::bucket_data_source::s3_bucket_data_source_config(),
         s3::bucket_lifecycle_configuration::s3_bucket_lifecycle_configuration_config(),
+        s3::bucket_notification_configuration::s3_bucket_notification_configuration_config(),
         s3::bucket_ownership_controls::s3_bucket_ownership_controls_config(),
         s3::bucket_policy::s3_bucket_policy_config(),
         s3::bucket_public_access_block::s3_bucket_public_access_block_config(),
@@ -100,6 +101,7 @@ pub fn get_enum_valid_values(
         s3::bucket_cors_configuration::enum_valid_values(),
         s3::bucket_data_source::enum_valid_values(),
         s3::bucket_lifecycle_configuration::enum_valid_values(),
+        s3::bucket_notification_configuration::enum_valid_values(),
         s3::bucket_ownership_controls::enum_valid_values(),
         s3::bucket_policy::enum_valid_values(),
         s3::bucket_public_access_block::enum_valid_values(),
@@ -212,6 +214,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.BucketLifecycleConfiguration" {
         return s3::bucket_lifecycle_configuration::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3.BucketNotificationConfiguration" {
+        return s3::bucket_notification_configuration::enum_alias_reverse(attr_name, value);
     }
     if resource_type == "s3.BucketOwnershipControls" {
         return s3::bucket_ownership_controls::enum_alias_reverse(attr_name, value);
@@ -438,6 +443,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket_lifecycle_configuration::enum_alias_entries() {
         map.entry("s3.BucketLifecycleConfiguration".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket_notification_configuration::enum_alias_entries() {
+        map.entry("s3.BucketNotificationConfiguration".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_notification_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_notification_configuration.rs
@@ -1,0 +1,71 @@
+//! BucketNotificationConfiguration schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.s3
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for s3.BucketNotificationConfiguration (Smithy: com.amazonaws.s3)
+pub fn s3_bucket_notification_configuration_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::S3::BucketNotificationConfiguration",
+        resource_type_name: "s3.BucketNotificationConfiguration",
+        has_tags: false,
+        schema: ResourceSchema::new("s3.BucketNotificationConfiguration")
+            .attribute(
+                AttributeSchema::new("bucket", AttributeType::String)
+                    .required()
+                    .create_only()
+                    .with_description("The name of the bucket.")
+                    .with_provider_name("Bucket"),
+            )
+            .attribute(
+                AttributeSchema::new("topic_configurations", super::bucket_topic_configurations())
+                    .with_description("SNS topic notification configurations.")
+                    .with_provider_name("TopicConfigurations"),
+            )
+            .attribute(
+                AttributeSchema::new("queue_configurations", super::bucket_queue_configurations())
+                    .with_description("SQS queue notification configurations.")
+                    .with_provider_name("QueueConfigurations"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "lambda_function_configurations",
+                    super::bucket_lambda_function_configurations(),
+                )
+                .with_description("Lambda function notification configurations.")
+                .with_provider_name("LambdaFunctionConfigurations"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "event_bridge_configuration",
+                    super::bucket_event_bridge_configuration(),
+                )
+                .with_description("Enables EventBridge notifications when present.")
+                .with_provider_name("EventBridgeConfiguration"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("s3.BucketNotificationConfiguration", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/mod.rs
@@ -11,6 +11,7 @@ pub mod bucket_acl;
 pub mod bucket_cors_configuration;
 pub mod bucket_data_source;
 pub mod bucket_lifecycle_configuration;
+pub mod bucket_notification_configuration;
 pub mod bucket_ownership_controls;
 pub mod bucket_policy;
 pub mod bucket_public_access_block;

--- a/carina-provider-aws/src/services/s3/bucket_notification.rs
+++ b/carina-provider-aws/src/services/s3/bucket_notification.rs
@@ -1,0 +1,435 @@
+use std::collections::HashMap;
+
+use aws_sdk_s3::types::{
+    Event, EventBridgeConfiguration, FilterRule, FilterRuleName, LambdaFunctionConfiguration,
+    NotificationConfiguration, NotificationConfigurationFilter, QueueConfiguration, S3KeyFilter,
+    TopicConfiguration,
+};
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+use indexmap::IndexMap;
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::services::s3::bucket::is_s3_not_configured_error;
+
+impl AwsProvider {
+    pub(crate) async fn read_s3_bucket_notification_configuration(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(bucket) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .s3_client
+            .get_bucket_notification_configuration()
+            .bucket(bucket)
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                let mut attributes = HashMap::new();
+                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+
+                let topics: Vec<Value> = output
+                    .topic_configurations()
+                    .iter()
+                    .map(topic_to_value)
+                    .collect();
+                if !topics.is_empty() {
+                    attributes.insert("topic_configurations".to_string(), Value::List(topics));
+                }
+                let queues: Vec<Value> = output
+                    .queue_configurations()
+                    .iter()
+                    .map(queue_to_value)
+                    .collect();
+                if !queues.is_empty() {
+                    attributes.insert("queue_configurations".to_string(), Value::List(queues));
+                }
+                let lambdas: Vec<Value> = output
+                    .lambda_function_configurations()
+                    .iter()
+                    .map(lambda_to_value)
+                    .collect();
+                if !lambdas.is_empty() {
+                    attributes.insert(
+                        "lambda_function_configurations".to_string(),
+                        Value::List(lambdas),
+                    );
+                }
+                if output.event_bridge_configuration().is_some() {
+                    attributes.insert(
+                        "event_bridge_configuration".to_string(),
+                        Value::Map(IndexMap::new()),
+                    );
+                }
+
+                Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
+            }
+            Err(e) => {
+                if is_s3_not_configured_error(&e, "NoSuchBucket") {
+                    return Ok(State::not_found(id.clone()));
+                }
+                Err(ProviderError::new(sdk_error_message(
+                    "Failed to get bucket notification configuration",
+                    &e,
+                ))
+                .for_resource(id.clone()))
+            }
+        }
+    }
+
+    pub(crate) async fn create_s3_bucket_notification_configuration(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let bucket = require_string_attr(&resource, "bucket")?;
+        self.put_s3_bucket_notification(&resource.id, &bucket, &resource)
+            .await
+    }
+
+    pub(crate) async fn update_s3_bucket_notification_configuration(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        _from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.put_s3_bucket_notification(&id, identifier, &to).await
+    }
+
+    async fn put_s3_bucket_notification(
+        &self,
+        id: &ResourceId,
+        bucket: &str,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let topics = match resource.get_attr("topic_configurations") {
+            Some(Value::List(items)) => items
+                .iter()
+                .map(|v| build_topic(id, v))
+                .collect::<ProviderResult<Vec<_>>>()?,
+            _ => Vec::new(),
+        };
+        let queues = match resource.get_attr("queue_configurations") {
+            Some(Value::List(items)) => items
+                .iter()
+                .map(|v| build_queue(id, v))
+                .collect::<ProviderResult<Vec<_>>>()?,
+            _ => Vec::new(),
+        };
+        let lambdas = match resource.get_attr("lambda_function_configurations") {
+            Some(Value::List(items)) => items
+                .iter()
+                .map(|v| build_lambda(id, v))
+                .collect::<ProviderResult<Vec<_>>>()?,
+            _ => Vec::new(),
+        };
+        let event_bridge = resource
+            .get_attr("event_bridge_configuration")
+            .map(|_| EventBridgeConfiguration::builder().build());
+
+        let mut config = NotificationConfiguration::builder()
+            .set_topic_configurations(if topics.is_empty() {
+                None
+            } else {
+                Some(topics)
+            })
+            .set_queue_configurations(if queues.is_empty() {
+                None
+            } else {
+                Some(queues)
+            })
+            .set_lambda_function_configurations(if lambdas.is_empty() {
+                None
+            } else {
+                Some(lambdas)
+            });
+        if let Some(eb) = event_bridge {
+            config = config.event_bridge_configuration(eb);
+        }
+        let config = config.build();
+
+        self.s3_client
+            .put_bucket_notification_configuration()
+            .bucket(bucket)
+            .notification_configuration(config)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message(
+                    "Failed to put bucket notification configuration",
+                    &e,
+                ))
+                .for_resource(id.clone())
+            })?;
+
+        self.read_s3_bucket_notification_configuration(id, Some(bucket))
+            .await
+    }
+
+    pub(crate) async fn delete_s3_bucket_notification_configuration_idempotent(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let empty = NotificationConfiguration::builder().build();
+        let result = self
+            .s3_client
+            .put_bucket_notification_configuration()
+            .bucket(identifier)
+            .notification_configuration(empty)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
+            Err(e) => Err(ProviderError::new(sdk_error_message(
+                "Failed to clear bucket notification configuration",
+                &e,
+            ))
+            .for_resource(id.clone())),
+        }
+    }
+}
+
+fn build_topic(id: &ResourceId, value: &Value) -> ProviderResult<TopicConfiguration> {
+    let Value::Map(map) = value else {
+        return Err(
+            ProviderError::new("topic_configurations entry must be a map").for_resource(id.clone()),
+        );
+    };
+    let topic_arn = require_string_field(id, map, "topic_arn", "topic_configurations")?;
+    let events = build_events(id, map, "topic_configurations")?;
+
+    let mut builder = TopicConfiguration::builder()
+        .topic_arn(topic_arn)
+        .set_events(Some(events));
+    if let Some(Value::String(s)) = map.get("id") {
+        builder = builder.id(s);
+    }
+    if let Some(filter) = build_filter(id, map, "topic_configurations")? {
+        builder = builder.filter(filter);
+    }
+    builder.build().map_err(|e| {
+        ProviderError::new(sdk_error_message("Failed to build TopicConfiguration", &e))
+            .for_resource(id.clone())
+    })
+}
+
+fn build_queue(id: &ResourceId, value: &Value) -> ProviderResult<QueueConfiguration> {
+    let Value::Map(map) = value else {
+        return Err(
+            ProviderError::new("queue_configurations entry must be a map").for_resource(id.clone()),
+        );
+    };
+    let queue_arn = require_string_field(id, map, "queue_arn", "queue_configurations")?;
+    let events = build_events(id, map, "queue_configurations")?;
+
+    let mut builder = QueueConfiguration::builder()
+        .queue_arn(queue_arn)
+        .set_events(Some(events));
+    if let Some(Value::String(s)) = map.get("id") {
+        builder = builder.id(s);
+    }
+    if let Some(filter) = build_filter(id, map, "queue_configurations")? {
+        builder = builder.filter(filter);
+    }
+    builder.build().map_err(|e| {
+        ProviderError::new(sdk_error_message("Failed to build QueueConfiguration", &e))
+            .for_resource(id.clone())
+    })
+}
+
+fn build_lambda(id: &ResourceId, value: &Value) -> ProviderResult<LambdaFunctionConfiguration> {
+    let Value::Map(map) = value else {
+        return Err(
+            ProviderError::new("lambda_function_configurations entry must be a map")
+                .for_resource(id.clone()),
+        );
+    };
+    let lambda_arn = require_string_field(
+        id,
+        map,
+        "lambda_function_arn",
+        "lambda_function_configurations",
+    )?;
+    let events = build_events(id, map, "lambda_function_configurations")?;
+
+    let mut builder = LambdaFunctionConfiguration::builder()
+        .lambda_function_arn(lambda_arn)
+        .set_events(Some(events));
+    if let Some(Value::String(s)) = map.get("id") {
+        builder = builder.id(s);
+    }
+    if let Some(filter) = build_filter(id, map, "lambda_function_configurations")? {
+        builder = builder.filter(filter);
+    }
+    builder.build().map_err(|e| {
+        ProviderError::new(sdk_error_message(
+            "Failed to build LambdaFunctionConfiguration",
+            &e,
+        ))
+        .for_resource(id.clone())
+    })
+}
+
+fn require_string_field(
+    id: &ResourceId,
+    map: &IndexMap<String, Value>,
+    field: &str,
+    parent: &str,
+) -> ProviderResult<String> {
+    match map.get(field) {
+        Some(Value::String(s)) => Ok(s.clone()),
+        _ => {
+            Err(ProviderError::new(format!("{parent}.{field} is required"))
+                .for_resource(id.clone()))
+        }
+    }
+}
+
+fn build_events(
+    id: &ResourceId,
+    map: &IndexMap<String, Value>,
+    parent: &str,
+) -> ProviderResult<Vec<Event>> {
+    match map.get("events") {
+        Some(Value::List(items)) => items
+            .iter()
+            .map(|v| match v {
+                Value::String(s) => Ok(Event::from(s.as_str())),
+                _ => Err(
+                    ProviderError::new(format!("{parent}.events must be a list of strings"))
+                        .for_resource(id.clone()),
+                ),
+            })
+            .collect(),
+        _ => {
+            Err(ProviderError::new(format!("{parent}.events is required")).for_resource(id.clone()))
+        }
+    }
+}
+
+fn build_filter(
+    id: &ResourceId,
+    map: &IndexMap<String, Value>,
+    parent: &str,
+) -> ProviderResult<Option<NotificationConfigurationFilter>> {
+    let Some(Value::Map(filter_map)) = map.get("filter") else {
+        return Ok(None);
+    };
+    let Some(Value::List(rules)) = filter_map.get("filter_rules") else {
+        return Ok(Some(NotificationConfigurationFilter::builder().build()));
+    };
+
+    let sdk_rules: Vec<FilterRule> = rules
+        .iter()
+        .map(|v| {
+            let Value::Map(rule_map) = v else {
+                return Err(ProviderError::new(format!(
+                    "{parent}.filter.filter_rules entry must be a map"
+                ))
+                .for_resource(id.clone()));
+            };
+            let name = require_string_field(id, rule_map, "name", "filter.filter_rules")?;
+            let value = require_string_field(id, rule_map, "value", "filter.filter_rules")?;
+            Ok(FilterRule::builder()
+                .name(FilterRuleName::from(name.as_str()))
+                .value(value)
+                .build())
+        })
+        .collect::<ProviderResult<Vec<_>>>()?;
+
+    let key = S3KeyFilter::builder()
+        .set_filter_rules(Some(sdk_rules))
+        .build();
+    Ok(Some(
+        NotificationConfigurationFilter::builder().key(key).build(),
+    ))
+}
+
+fn topic_to_value(t: &TopicConfiguration) -> Value {
+    let mut m = IndexMap::new();
+    if let Some(s) = t.id() {
+        m.insert("id".to_string(), Value::String(s.to_string()));
+    }
+    m.insert(
+        "topic_arn".to_string(),
+        Value::String(t.topic_arn().to_string()),
+    );
+    m.insert("events".to_string(), events_to_value(t.events()));
+    if let Some(f) = t.filter() {
+        m.insert("filter".to_string(), filter_to_value(f));
+    }
+    Value::Map(m)
+}
+
+fn queue_to_value(q: &QueueConfiguration) -> Value {
+    let mut m = IndexMap::new();
+    if let Some(s) = q.id() {
+        m.insert("id".to_string(), Value::String(s.to_string()));
+    }
+    m.insert(
+        "queue_arn".to_string(),
+        Value::String(q.queue_arn().to_string()),
+    );
+    m.insert("events".to_string(), events_to_value(q.events()));
+    if let Some(f) = q.filter() {
+        m.insert("filter".to_string(), filter_to_value(f));
+    }
+    Value::Map(m)
+}
+
+fn lambda_to_value(l: &LambdaFunctionConfiguration) -> Value {
+    let mut m = IndexMap::new();
+    if let Some(s) = l.id() {
+        m.insert("id".to_string(), Value::String(s.to_string()));
+    }
+    m.insert(
+        "lambda_function_arn".to_string(),
+        Value::String(l.lambda_function_arn().to_string()),
+    );
+    m.insert("events".to_string(), events_to_value(l.events()));
+    if let Some(f) = l.filter() {
+        m.insert("filter".to_string(), filter_to_value(f));
+    }
+    Value::Map(m)
+}
+
+fn events_to_value(events: &[Event]) -> Value {
+    Value::List(
+        events
+            .iter()
+            .map(|e| Value::String(e.as_str().to_string()))
+            .collect(),
+    )
+}
+
+fn filter_to_value(f: &NotificationConfigurationFilter) -> Value {
+    let mut outer = IndexMap::new();
+    if let Some(key) = f.key() {
+        let rules: Vec<Value> = key
+            .filter_rules()
+            .iter()
+            .map(|r| {
+                let mut m = IndexMap::new();
+                if let Some(n) = r.name() {
+                    m.insert("name".to_string(), Value::String(n.as_str().to_string()));
+                }
+                if let Some(v) = r.value() {
+                    m.insert("value".to_string(), Value::String(v.to_string()));
+                }
+                Value::Map(m)
+            })
+            .collect();
+        outer.insert("filter_rules".to_string(), Value::List(rules));
+    }
+    Value::Map(outer)
+}

--- a/carina-provider-aws/src/services/s3/mod.rs
+++ b/carina-provider-aws/src/services/s3/mod.rs
@@ -3,6 +3,7 @@ pub mod bucket_acl;
 pub mod bucket_cors;
 pub mod bucket_encryption;
 pub mod bucket_lifecycle;
+pub mod bucket_notification;
 pub mod bucket_ownership_controls;
 pub mod bucket_policy;
 pub mod bucket_public_access_block;


### PR DESCRIPTION
## Summary

Eleventh slice under #164 (Terraform-style decomposition of `aws.s3.Bucket`).

Adds `aws.s3.BucketNotificationConfiguration` as a standalone Managed resource that wires bucket events to SNS / SQS / Lambda / EventBridge destinations.

- `bucket: String` (required, create-only)
- `topic_configurations: List<Struct>` — SNS topic configs (`id`, `topic_arn`, `events`, `filter`)
- `queue_configurations: List<Struct>` — SQS queue configs (`id`, `queue_arn`, `events`, `filter`)
- `lambda_function_configurations: List<Struct>` — Lambda configs (`id`, `lambda_function_arn`, `events`, `filter`)
- `event_bridge_configuration: Struct` — empty struct enables EventBridge
- `filter: { filter_rules: List<{ name, value }> }` — maps to AWS `Filter.Key.FilterRules`

CRUD:
- Create / Update: `PutBucketNotificationConfiguration`
- Read: `GetBucketNotificationConfiguration`
- Delete: `PutBucketNotificationConfiguration` with empty configuration (no Delete API; matches Terraform). `NoSuchBucket` is treated as success.

Acceptance fixture exercises a `queue_configurations` entry; the SQS queue is a precondition (Carina does not yet manage SQS).

Closes #225

## Test plan

- [x] `cargo nextest run` — 326 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --release -p carina-provider-aws`
- [x] `bash scripts/generate-schemas-smithy.sh`
- [x] `bash scripts/generate-provider.sh`
- [x] `bash scripts/generate-docs.sh`
- [ ] Acceptance test on AWS (will run after merge per series practice)