### PR TITLE
Add aws.s3.BucketLogging as a standalone resource

### DIFF
--- a/acceptance-tests/s3_bucket_logging/basic.crn
+++ b/acceptance-tests/s3_bucket_logging/basic.crn
@@ -1,0 +1,26 @@
+# S3 BucketLogging - Basic test
+#
+# Two buckets: a source bucket whose access we want logged, and a
+# separate destination bucket that receives the log objects. The
+# destination bucket must allow s3.amazonaws.com to write under the
+# given prefix; the destination bucket's ACL/policy is a precondition
+# (Carina does not yet manage the log-delivery grant).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let source = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-bucket-logging-source-v1'
+}
+
+let logs = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-bucket-logging-target-v1'
+}
+
+aws.s3.BucketLogging {
+  bucket = source.bucket
+
+  target_bucket = logs.bucket
+  target_prefix = 'access-logs/'
+}

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1740,6 +1740,44 @@ pub fn bucket_event_bridge_configuration() -> AttributeType {
     }
 }
 
+fn s3_partition_date_source() -> AttributeType {
+    AttributeType::StringEnum {
+        name: "PartitionDateSource".to_string(),
+        values: vec!["EventTime".to_string(), "DeliveryTime".to_string()],
+        namespace: Some("aws.s3.BucketLogging".to_string()),
+        to_dsl: None,
+    }
+}
+
+fn s3_partitioned_prefix() -> AttributeType {
+    AttributeType::Struct {
+        name: "PartitionedPrefix".to_string(),
+        fields: vec![
+            StructField::new("partition_date_source", s3_partition_date_source())
+                .with_provider_name("PartitionDateSource"),
+        ],
+    }
+}
+
+fn s3_simple_prefix() -> AttributeType {
+    AttributeType::Struct {
+        name: "SimplePrefix".to_string(),
+        fields: vec![],
+    }
+}
+
+pub fn bucket_target_object_key_format() -> AttributeType {
+    AttributeType::Struct {
+        name: "TargetObjectKeyFormat".to_string(),
+        fields: vec![
+            StructField::new("simple_prefix", s3_simple_prefix())
+                .with_provider_name("SimplePrefix"),
+            StructField::new("partitioned_prefix", s3_partitioned_prefix())
+                .with_provider_name("PartitionedPrefix"),
+        ],
+    }
+}
+
 pub fn s3_index_document() -> AttributeType {
     AttributeType::Struct {
         name: "IndexDocument".to_string(),

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3956,6 +3956,7 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "s3.BucketWebsiteConfiguration" => "AWS::S3::BucketWebsiteConfiguration",
         "s3.BucketCorsConfiguration" => "AWS::S3::BucketCorsConfiguration",
         "s3.BucketNotificationConfiguration" => "AWS::S3::BucketNotificationConfiguration",
+        "s3.BucketLogging" => "AWS::S3::BucketLogging",
         "sts.CallerIdentity" => "AWS::STS::CallerIdentity",
         "organizations.Organization" => "AWS::Organizations::Organization",
         "organizations.Account" => "AWS::Organizations::Account",

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1758,6 +1758,66 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
+        // s3.BucketLogging — controls server-access logging on a bucket.
+        // Maps to PutBucketLogging / GetBucketLogging. No DeleteBucketLogging
+        // API exists; destroy is implemented as a Put with an empty
+        // BucketLoggingStatus (Terraform parity).
+        ResourceDef {
+            name: "s3.BucketLogging",
+            service_namespace: "com.amazonaws.s3",
+            schema_structure: None,
+            simple_delete: false,
+            noop_update: false,
+            create_op: "PutBucketLogging",
+            read_structure: None,
+            read_ops: vec![],
+            // No native delete API — destroy uses the same Put op.
+            delete_op: "PutBucketLogging",
+            update_ops: vec![UpdateOp {
+                operation: "PutBucketLogging",
+                fields: FieldLayout::InsideStruct {
+                    name: "LoggingEnabled",
+                    fields: vec!["TargetBucket", "TargetPrefix", "TargetObjectKeyFormat"],
+                },
+            }],
+            identifier: "Bucket",
+            has_tags: false,
+            type_overrides: vec![(
+                "TargetObjectKeyFormat",
+                "super::bucket_target_object_key_format()",
+            )],
+            exclude_fields: vec![
+                "ContentMD5",
+                "ChecksumAlgorithm",
+                "ExpectedBucketOwner",
+                "BucketLoggingStatus",
+            ],
+            create_only_overrides: vec!["Bucket"],
+            enum_aliases: vec![],
+            to_dsl_overrides: vec![],
+            required_overrides: vec!["Bucket", "TargetBucket"],
+            extra_read_only: vec![],
+            read_only_overrides: vec![],
+            extra_writable: vec![
+                ExtraField {
+                    name: "TargetBucket",
+                    read_source: None,
+                    description: Some("Destination bucket for server access logs."),
+                },
+                ExtraField {
+                    name: "TargetPrefix",
+                    read_source: None,
+                    description: Some("Key prefix to apply to log objects."),
+                },
+                ExtraField {
+                    name: "TargetObjectKeyFormat",
+                    read_source: None,
+                    description: Some("Partitioning / simple-prefix selector for log object keys."),
+                },
+            ],
+            identity_overrides: vec![],
+            derived_attributes: vec![],
+        },
         // s3.BucketPublicAccessBlock — controls the Public Access Block
         // settings of an existing S3 bucket. Maps to PutPublicAccessBlock /
         // GetPublicAccessBlock / DeletePublicAccessBlock.

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -62,6 +62,10 @@ impl Provider for AwsProvider {
                     self.read_s3_bucket_notification_configuration(&id, identifier.as_deref())
                         .await
                 }
+                "s3.BucketLogging" => {
+                    self.read_s3_bucket_logging(&id, identifier.as_deref())
+                        .await
+                }
                 "ec2.Eip" => self.read_ec2_eip(&id, identifier.as_deref()).await,
                 "ec2.Vpc" => self.read_ec2_vpc(&id, identifier.as_deref()).await,
                 "ec2.Subnet" => self.read_ec2_subnet(&id, identifier.as_deref()).await,
@@ -189,6 +193,7 @@ impl Provider for AwsProvider {
                     self.create_s3_bucket_notification_configuration(resource)
                         .await
                 }
+                "s3.BucketLogging" => self.create_s3_bucket_logging(resource).await,
                 "ec2.Eip" => self.create_ec2_eip(resource).await,
                 "ec2.Vpc" => self.create_ec2_vpc(resource).await,
                 "ec2.Subnet" => self.create_ec2_subnet(resource).await,
@@ -295,6 +300,10 @@ impl Provider for AwsProvider {
                 }
                 "s3.BucketNotificationConfiguration" => {
                     self.update_s3_bucket_notification_configuration(id, &identifier, &from, to)
+                        .await
+                }
+                "s3.BucketLogging" => {
+                    self.update_s3_bucket_logging(id, &identifier, &from, to)
                         .await
                 }
                 "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
@@ -433,6 +442,10 @@ impl Provider for AwsProvider {
                 }
                 "s3.BucketNotificationConfiguration" => {
                     self.delete_s3_bucket_notification_configuration_idempotent(id, &identifier)
+                        .await
+                }
+                "s3.BucketLogging" => {
+                    self.delete_s3_bucket_logging_idempotent(id, &identifier)
                         .await
                 }
                 "ec2.Eip" => self.delete_ec2_eip(id, &identifier).await,

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -49,6 +49,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         s3::bucket_cors_configuration::s3_bucket_cors_configuration_config(),
         s3::bucket_data_source::s3_bucket_data_source_config(),
         s3::bucket_lifecycle_configuration::s3_bucket_lifecycle_configuration_config(),
+        s3::bucket_logging::s3_bucket_logging_config(),
         s3::bucket_notification_configuration::s3_bucket_notification_configuration_config(),
         s3::bucket_ownership_controls::s3_bucket_ownership_controls_config(),
         s3::bucket_policy::s3_bucket_policy_config(),
@@ -101,6 +102,7 @@ pub fn get_enum_valid_values(
         s3::bucket_cors_configuration::enum_valid_values(),
         s3::bucket_data_source::enum_valid_values(),
         s3::bucket_lifecycle_configuration::enum_valid_values(),
+        s3::bucket_logging::enum_valid_values(),
         s3::bucket_notification_configuration::enum_valid_values(),
         s3::bucket_ownership_controls::enum_valid_values(),
         s3::bucket_policy::enum_valid_values(),
@@ -214,6 +216,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.BucketLifecycleConfiguration" {
         return s3::bucket_lifecycle_configuration::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3.BucketLogging" {
+        return s3::bucket_logging::enum_alias_reverse(attr_name, value);
     }
     if resource_type == "s3.BucketNotificationConfiguration" {
         return s3::bucket_notification_configuration::enum_alias_reverse(attr_name, value);
@@ -443,6 +448,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket_lifecycle_configuration::enum_alias_entries() {
         map.entry("s3.BucketLifecycleConfiguration".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket_logging::enum_alias_entries() {
+        map.entry("s3.BucketLogging".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_logging.rs
@@ -1,0 +1,66 @@
+//! BucketLogging schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.s3
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for s3.BucketLogging (Smithy: com.amazonaws.s3)
+pub fn s3_bucket_logging_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::S3::BucketLogging",
+        resource_type_name: "s3.BucketLogging",
+        has_tags: false,
+        schema: ResourceSchema::new("s3.BucketLogging")
+            .attribute(
+                AttributeSchema::new("bucket", AttributeType::String)
+                    .required()
+                    .create_only()
+                    .with_description(
+                        "The name of the bucket for which to set the logging parameters.",
+                    )
+                    .with_provider_name("Bucket"),
+            )
+            .attribute(
+                AttributeSchema::new("target_bucket", AttributeType::String)
+                    .required()
+                    .with_description("Destination bucket for server access logs.")
+                    .with_provider_name("TargetBucket"),
+            )
+            .attribute(
+                AttributeSchema::new("target_prefix", AttributeType::String)
+                    .with_description("Key prefix to apply to log objects.")
+                    .with_provider_name("TargetPrefix"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "target_object_key_format",
+                    super::bucket_target_object_key_format(),
+                )
+                .with_description("Partitioning / simple-prefix selector for log object keys.")
+                .with_provider_name("TargetObjectKeyFormat"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("s3.BucketLogging", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/schemas/generated/s3/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/mod.rs
@@ -11,6 +11,7 @@ pub mod bucket_acl;
 pub mod bucket_cors_configuration;
 pub mod bucket_data_source;
 pub mod bucket_lifecycle_configuration;
+pub mod bucket_logging;
 pub mod bucket_notification_configuration;
 pub mod bucket_ownership_controls;
 pub mod bucket_policy;

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -1,0 +1,196 @@
+use std::collections::HashMap;
+
+use aws_sdk_s3::types::{
+    BucketLoggingStatus, LoggingEnabled, PartitionDateSource, PartitionedPrefix, SimplePrefix,
+    TargetObjectKeyFormat,
+};
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::utils::extract_enum_value;
+use indexmap::IndexMap;
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::services::s3::bucket::is_s3_not_configured_error;
+
+impl AwsProvider {
+    pub(crate) async fn read_s3_bucket_logging(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(bucket) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .s3_client
+            .get_bucket_logging()
+            .bucket(bucket)
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                let mut attributes = HashMap::new();
+                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                if let Some(le) = output.logging_enabled() {
+                    attributes.insert(
+                        "target_bucket".to_string(),
+                        Value::String(le.target_bucket().to_string()),
+                    );
+                    attributes.insert(
+                        "target_prefix".to_string(),
+                        Value::String(le.target_prefix().to_string()),
+                    );
+                    if let Some(fmt) = le.target_object_key_format() {
+                        attributes.insert(
+                            "target_object_key_format".to_string(),
+                            target_object_key_format_to_value(fmt),
+                        );
+                    }
+                }
+                Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
+            }
+            Err(e) => {
+                if is_s3_not_configured_error(&e, "NoSuchBucket") {
+                    return Ok(State::not_found(id.clone()));
+                }
+                Err(
+                    ProviderError::new(sdk_error_message("Failed to get bucket logging", &e))
+                        .for_resource(id.clone()),
+                )
+            }
+        }
+    }
+
+    pub(crate) async fn create_s3_bucket_logging(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let bucket = require_string_attr(&resource, "bucket")?;
+        self.put_s3_bucket_logging(&resource.id, &bucket, &resource)
+            .await
+    }
+
+    pub(crate) async fn update_s3_bucket_logging(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        _from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.put_s3_bucket_logging(&id, identifier, &to).await
+    }
+
+    async fn put_s3_bucket_logging(
+        &self,
+        id: &ResourceId,
+        bucket: &str,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let target_bucket = require_string_attr(resource, "target_bucket")?;
+        let target_prefix = match resource.get_attr("target_prefix") {
+            Some(Value::String(s)) => s.clone(),
+            None => String::new(),
+            _ => {
+                return Err(
+                    ProviderError::new("target_prefix must be a string").for_resource(id.clone())
+                );
+            }
+        };
+
+        let mut le_builder = LoggingEnabled::builder()
+            .target_bucket(target_bucket)
+            .target_prefix(target_prefix);
+
+        if let Some(v) = resource.get_attr("target_object_key_format") {
+            le_builder = le_builder.target_object_key_format(build_key_format(id, v)?);
+        }
+
+        let le = le_builder.build().map_err(|e| {
+            ProviderError::new(sdk_error_message("Failed to build LoggingEnabled", &e))
+                .for_resource(id.clone())
+        })?;
+
+        let status = BucketLoggingStatus::builder().logging_enabled(le).build();
+
+        self.s3_client
+            .put_bucket_logging()
+            .bucket(bucket)
+            .bucket_logging_status(status)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new(sdk_error_message("Failed to put bucket logging", &e))
+                    .for_resource(id.clone())
+            })?;
+
+        self.read_s3_bucket_logging(id, Some(bucket)).await
+    }
+
+    pub(crate) async fn delete_s3_bucket_logging_idempotent(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        let empty = BucketLoggingStatus::builder().build();
+        let result = self
+            .s3_client
+            .put_bucket_logging()
+            .bucket(identifier)
+            .bucket_logging_status(empty)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
+            Err(e) => Err(ProviderError::new(sdk_error_message(
+                "Failed to clear bucket logging",
+                &e,
+            ))
+            .for_resource(id.clone())),
+        }
+    }
+}
+
+fn build_key_format(id: &ResourceId, value: &Value) -> ProviderResult<TargetObjectKeyFormat> {
+    let Value::Map(map) = value else {
+        return Err(
+            ProviderError::new("target_object_key_format must be a map").for_resource(id.clone())
+        );
+    };
+
+    let mut builder = TargetObjectKeyFormat::builder();
+    if map.contains_key("simple_prefix") {
+        builder = builder.simple_prefix(SimplePrefix::builder().build());
+    }
+    if let Some(Value::Map(pp)) = map.get("partitioned_prefix") {
+        let mut pb = PartitionedPrefix::builder();
+        if let Some(Value::String(s)) = pp.get("partition_date_source") {
+            let normalized = extract_enum_value(s);
+            pb = pb.partition_date_source(PartitionDateSource::from(normalized));
+        }
+        builder = builder.partitioned_prefix(pb.build());
+    }
+    Ok(builder.build())
+}
+
+fn target_object_key_format_to_value(fmt: &TargetObjectKeyFormat) -> Value {
+    let mut m = IndexMap::new();
+    if fmt.simple_prefix().is_some() {
+        m.insert("simple_prefix".to_string(), Value::Map(IndexMap::new()));
+    }
+    if let Some(pp) = fmt.partitioned_prefix() {
+        let mut inner = IndexMap::new();
+        if let Some(src) = pp.partition_date_source() {
+            inner.insert(
+                "partition_date_source".to_string(),
+                Value::String(src.as_str().to_string()),
+            );
+        }
+        m.insert("partitioned_prefix".to_string(), Value::Map(inner));
+    }
+    Value::Map(m)
+}

--- a/carina-provider-aws/src/services/s3/mod.rs
+++ b/carina-provider-aws/src/services/s3/mod.rs
@@ -3,6 +3,7 @@ pub mod bucket_acl;
 pub mod bucket_cors;
 pub mod bucket_encryption;
 pub mod bucket_lifecycle;
+pub mod bucket_logging;
 pub mod bucket_notification;
 pub mod bucket_ownership_controls;
 pub mod bucket_policy;


### PR DESCRIPTION
## Summary

Twelfth (and final) slice under #164 (Terraform-style decomposition of `aws.s3.Bucket`).

Adds `aws.s3.BucketLogging` as a standalone Managed resource that controls server-access logging on a bucket.

- `bucket: String` (required, create-only) — source bucket whose access is logged
- `target_bucket: String` (required) — destination bucket for log objects
- `target_prefix: String` (optional, defaults to empty)
- `target_object_key_format: Struct` (optional) — `simple_prefix` or `partitioned_prefix.partition_date_source` (`EventTime` / `DeliveryTime`)

CRUD:
- Create / Update: `PutBucketLogging`
- Read: `GetBucketLogging`
- Delete: `PutBucketLogging` with empty `BucketLoggingStatus` (no Delete API; matches Terraform). `NoSuchBucket` is treated as success.

Acceptance fixture provisions both a source and a destination bucket; the destination's log-delivery grant is a precondition (Carina does not yet manage that grant).

This finishes the #164 series — `aws.s3.Bucket` is now an identity-only resource with all bundled configurations split into standalone Managed resources.

Closes #226

## Test plan

- [x] `cargo nextest run` — 326 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build --release -p carina-provider-aws`
- [x] `bash scripts/generate-schemas-smithy.sh`
- [x] `bash scripts/generate-provider.sh`
- [x] `bash scripts/generate-docs.sh`
- [ ] Acceptance test on AWS (will run after merge per series practice)