### PR TITLE
Add allowed_account_ids / forbidden_account_ids provider options

### DIFF
--- a/carina-provider-aws/src/factory.rs
+++ b/carina-provider-aws/src/factory.rs
@@ -38,6 +38,20 @@ impl ProviderFactory for AwsProviderFactory {
                 to_dsl: Some(|s| s.replace('-', "_")),
             },
         );
+        types.insert(
+            "allowed_account_ids".to_string(),
+            carina_core::schema::AttributeType::List {
+                inner: Box::new(carina_core::schema::AttributeType::String),
+                ordered: false,
+            },
+        );
+        types.insert(
+            "forbidden_account_ids".to_string(),
+            carina_core::schema::AttributeType::List {
+                inner: Box::new(carina_core::schema::AttributeType::String),
+                ordered: false,
+            },
+        );
         types
     }
 
@@ -59,9 +73,13 @@ impl ProviderFactory for AwsProviderFactory {
         &self,
         attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn carina_core::provider::Provider>> {
+        use crate::services::sts::account_guard::extract_string_list;
         let region = self.extract_region(attributes);
+        let allowed = extract_string_list(attributes.get("allowed_account_ids"));
+        let forbidden = extract_string_list(attributes.get("forbidden_account_ids"));
         Box::pin(async move {
-            Box::new(AwsProvider::new(&region).await) as Box<dyn carina_core::provider::Provider>
+            Box::new(AwsProvider::new_with_account_guard(&region, allowed, forbidden).await)
+                as Box<dyn carina_core::provider::Provider>
         })
     }
 

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -11,7 +11,7 @@ mod normalizer;
 mod provider;
 pub mod provider_generated;
 pub mod schemas;
-mod services;
+pub mod services;
 #[cfg(test)]
 mod tests;
 
@@ -39,11 +39,31 @@ pub struct AwsProvider {
     identitystore_client: IdentityStoreClient,
     route53_client: Route53Client,
     region: String,
+    /// Provider-level allow-list of AWS account IDs. Empty means "no
+    /// allow-list configured" (the check is skipped). Enforced once
+    /// during initialization via [`AwsProvider::verify_account_id`].
+    pub(crate) allowed_account_ids: Vec<String>,
+    /// Provider-level deny-list of AWS account IDs. Empty means "no
+    /// deny-list configured". Enforced once during initialization via
+    /// [`AwsProvider::verify_account_id`].
+    pub(crate) forbidden_account_ids: Vec<String>,
 }
 
 impl AwsProvider {
     /// Create a new AWS Provider
     pub async fn new(region: &str) -> Self {
+        Self::new_with_account_guard(region, Vec::new(), Vec::new()).await
+    }
+
+    /// Create a new AWS Provider with provider-level account guard
+    /// configuration. `allowed_account_ids` and `forbidden_account_ids`
+    /// are stored verbatim; the guard itself is only run when
+    /// [`AwsProvider::verify_account_id`] is called.
+    pub async fn new_with_account_guard(
+        region: &str,
+        allowed_account_ids: Vec<String>,
+        forbidden_account_ids: Vec<String>,
+    ) -> Self {
         let config = Self::build_config(region).await;
 
         Self {
@@ -56,6 +76,8 @@ impl AwsProvider {
             identitystore_client: IdentityStoreClient::new(&config),
             route53_client: Route53Client::new(&config),
             region: region.to_string(),
+            allowed_account_ids,
+            forbidden_account_ids,
         }
     }
 
@@ -100,6 +122,8 @@ impl AwsProvider {
             identitystore_client,
             route53_client,
             region,
+            allowed_account_ids: Vec::new(),
+            forbidden_account_ids: Vec::new(),
         }
     }
 }

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -95,6 +95,20 @@ impl CarinaProvider for AwsProcessProvider {
                 namespace: Some("aws".to_string()),
             },
         );
+        types.insert(
+            "allowed_account_ids".to_string(),
+            proto::AttributeType::List {
+                inner: Box::new(proto::AttributeType::String),
+                ordered: false,
+            },
+        );
+        types.insert(
+            "forbidden_account_ids".to_string(),
+            proto::AttributeType::List {
+                inner: Box::new(proto::AttributeType::String),
+                ordered: false,
+            },
+        );
         types
     }
 
@@ -106,13 +120,22 @@ impl CarinaProvider for AwsProcessProvider {
     }
 
     fn initialize(&mut self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
+        use carina_provider_aws::services::sts::account_guard::extract_string_list;
         let core_attrs = convert::proto_to_core_value_map(attrs);
         let region = if let Some(CoreValue::String(region)) = core_attrs.get("region") {
             carina_core::utils::convert_region_value(region)
         } else {
             "ap-northeast-1".to_string()
         };
-        let provider = self.runtime.block_on(AwsProvider::new(&region));
+        let allowed = extract_string_list(core_attrs.get("allowed_account_ids"));
+        let forbidden = extract_string_list(core_attrs.get("forbidden_account_ids"));
+        let provider = self.runtime.block_on(AwsProvider::new_with_account_guard(
+            &region, allowed, forbidden,
+        ));
+        // Run the account guard before we accept this provider — fails
+        // fast (before any read/plan/apply) when the credentials in use
+        // point at the wrong AWS account.
+        self.runtime.block_on(provider.verify_account_id())?;
         self.provider = Some(provider);
         Ok(())
     }
@@ -382,6 +405,30 @@ mod tests {
                 .validate_custom_type("unknown_type", "any-value")
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn provider_config_attribute_types_declares_account_guard_lists() {
+        // The host validates `list(string)` shape against these
+        // declarations before calling `initialize`. If the declarations
+        // disappear, the host silently drops the attributes and the
+        // guard becomes a no-op — this test prevents that regression.
+        let provider = AwsProcessProvider::new();
+        let types = provider.provider_config_attribute_types();
+        for attr in ["allowed_account_ids", "forbidden_account_ids"] {
+            let ty = types.get(attr).unwrap_or_else(|| {
+                panic!("{attr} must be declared as a provider config attribute")
+            });
+            match ty {
+                proto::AttributeType::List { inner, .. } => match inner.as_ref() {
+                    proto::AttributeType::String => {}
+                    other => {
+                        panic!("{attr} must be List<String>, inner was {other:?}")
+                    }
+                },
+                other => panic!("{attr} must be a List, was {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/carina-provider-aws/src/services/sts/account_guard.rs
+++ b/carina-provider-aws/src/services/sts/account_guard.rs
@@ -1,0 +1,206 @@
+//! Provider-level account guard: enforce `allowed_account_ids` and
+//! `forbidden_account_ids` against the caller's STS identity.
+//!
+//! Mirrors Terraform AWS provider's `allowed_account_ids` /
+//! `forbidden_account_ids`. The check runs once during provider
+//! initialization (before any read/plan/apply mutation) and fails fast
+//! when the credentials in use point at the wrong AWS account.
+
+use carina_core::resource::Value;
+
+use crate::AwsProvider;
+use crate::helpers::sdk_error_message;
+
+/// Pure policy check. Returns `Ok(())` when the caller's account is
+/// permitted by the configured allow/forbid lists, otherwise an error
+/// string that names both the rule and the actual account ID.
+///
+/// Both lists empty is treated as "no check configured" and always
+/// passes — preserves the pre-issue-233 behavior for users who did
+/// not opt in to the guard.
+pub fn check_account_id(
+    account_id: &str,
+    allowed: &[String],
+    forbidden: &[String],
+) -> Result<(), String> {
+    if !forbidden.is_empty() && forbidden.iter().any(|a| a == account_id) {
+        return Err(format!(
+            "AWS account ID {account_id} is in forbidden_account_ids {forbidden:?}; \
+             refusing to operate against this account"
+        ));
+    }
+    if !allowed.is_empty() && !allowed.iter().any(|a| a == account_id) {
+        return Err(format!(
+            "AWS account ID {account_id} is not in allowed_account_ids {allowed:?}; \
+             refusing to operate against this account"
+        ));
+    }
+    Ok(())
+}
+
+/// Extract a `Value::List` of strings from a provider config attribute.
+///
+/// Non-string entries are dropped silently — type-level validation is
+/// the host's responsibility via
+/// `ProviderFactory::provider_config_attribute_types`; by the time we
+/// see the value here the host has already enforced
+/// `list(string)`. Missing keys yield an empty `Vec`, which the policy
+/// treats as "list not configured".
+pub fn extract_string_list(value: Option<&Value>) -> Vec<String> {
+    match value {
+        Some(Value::List(items)) => items
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+impl AwsProvider {
+    /// Run the configured account guard. No-op when both
+    /// `allowed_account_ids` and `forbidden_account_ids` are empty.
+    ///
+    /// Otherwise calls STS `GetCallerIdentity` and validates the
+    /// returned account against the configured lists, returning an
+    /// error string suitable for surfacing through
+    /// `CarinaProvider::initialize`.
+    pub async fn verify_account_id(&self) -> Result<(), String> {
+        if self.allowed_account_ids.is_empty() && self.forbidden_account_ids.is_empty() {
+            return Ok(());
+        }
+
+        let response = self
+            .sts_client
+            .get_caller_identity()
+            .send()
+            .await
+            .map_err(|e| {
+                sdk_error_message("Failed to get STS caller identity for account guard", &e)
+            })?;
+
+        let account_id = response.account().ok_or_else(|| {
+            "STS GetCallerIdentity returned no account ID; cannot enforce account guard".to_string()
+        })?;
+
+        check_account_id(
+            account_id,
+            &self.allowed_account_ids,
+            &self.forbidden_account_ids,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_lists_empty_passes() {
+        assert!(check_account_id("123456789012", &[], &[]).is_ok());
+    }
+
+    #[test]
+    fn allowed_match_passes() {
+        let allowed = vec!["123456789012".to_string()];
+        assert!(check_account_id("123456789012", &allowed, &[]).is_ok());
+    }
+
+    #[test]
+    fn allowed_miss_fails_and_names_both_lists_and_account() {
+        let allowed = vec!["111111111111".to_string(), "222222222222".to_string()];
+        let err = check_account_id("999999999999", &allowed, &[])
+            .expect_err("should fail when caller is not in allowed list");
+        assert!(
+            err.contains("999999999999"),
+            "error must name actual account: {err}"
+        );
+        assert!(
+            err.contains("111111111111"),
+            "error must name expected list: {err}"
+        );
+        assert!(
+            err.contains("222222222222"),
+            "error must name full expected list: {err}"
+        );
+        assert!(
+            err.contains("allowed_account_ids"),
+            "error must name the rule: {err}"
+        );
+    }
+
+    #[test]
+    fn forbidden_match_fails_and_names_both_lists_and_account() {
+        let forbidden = vec!["412038850359".to_string()];
+        let err = check_account_id("412038850359", &[], &forbidden)
+            .expect_err("should fail when caller is in forbidden list");
+        assert!(
+            err.contains("412038850359"),
+            "error must name actual account: {err}"
+        );
+        assert!(
+            err.contains("forbidden_account_ids"),
+            "error must name the rule: {err}"
+        );
+    }
+
+    #[test]
+    fn forbidden_takes_precedence_over_allowed() {
+        // If for some reason the same account appears in both lists,
+        // forbid wins — the safer outcome.
+        let allowed = vec!["123456789012".to_string()];
+        let forbidden = vec!["123456789012".to_string()];
+        let err = check_account_id("123456789012", &allowed, &forbidden)
+            .expect_err("forbidden must win when caller is in both lists");
+        assert!(
+            err.contains("forbidden_account_ids"),
+            "must surface the forbidden rule first: {err}"
+        );
+    }
+
+    #[test]
+    fn allowed_and_forbidden_both_set_caller_in_allowed_only_passes() {
+        let allowed = vec!["123456789012".to_string()];
+        let forbidden = vec!["999999999999".to_string()];
+        assert!(check_account_id("123456789012", &allowed, &forbidden).is_ok());
+    }
+
+    #[test]
+    fn extract_string_list_handles_missing() {
+        assert!(extract_string_list(None).is_empty());
+    }
+
+    #[test]
+    fn extract_string_list_handles_non_list() {
+        assert!(extract_string_list(Some(&Value::String("oops".into()))).is_empty());
+    }
+
+    #[test]
+    fn extract_string_list_extracts_strings_in_order() {
+        let v = Value::List(vec![
+            Value::String("aaa".into()),
+            Value::String("bbb".into()),
+        ]);
+        assert_eq!(
+            extract_string_list(Some(&v)),
+            vec!["aaa".to_string(), "bbb".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_string_list_drops_non_string_entries() {
+        // Type validation happens host-side via
+        // `provider_config_attribute_types`; this is just the safety net.
+        let v = Value::List(vec![
+            Value::String("aaa".into()),
+            Value::Int(42),
+            Value::String("bbb".into()),
+        ]);
+        assert_eq!(
+            extract_string_list(Some(&v)),
+            vec!["aaa".to_string(), "bbb".to_string()]
+        );
+    }
+}

--- a/carina-provider-aws/src/services/sts/mod.rs
+++ b/carina-provider-aws/src/services/sts/mod.rs
@@ -1,1 +1,2 @@
+pub mod account_guard;
 pub mod caller_identity;


### PR DESCRIPTION
## Summary

- Adds `allowed_account_ids: list(String)` and `forbidden_account_ids: list(String)` to the `aws` provider, mirroring the Terraform AWS provider's options of the same name.
- On `initialize()` the provider calls `sts:GetCallerIdentity` once and fails fast (before any read/plan/apply) when the caller's account is not in the allow list, or is in the forbid list. Both lists empty preserves the previous behavior.
- Error message names both the violated rule (`allowed_account_ids` or `forbidden_account_ids`) and the actual caller account ID.

## Implementation

- New `carina-provider-aws/src/services/sts/account_guard.rs`:
  - `check_account_id(account_id, allowed, forbidden)` — pure policy, covered by 9 unit tests.
  - `extract_string_list(Option<&Value>) -> Vec<String>` — pulls list-of-string config attributes through the proto/core boundary.
  - `AwsProvider::verify_account_id()` — early-returns when both lists are empty; otherwise calls STS and runs the policy.
- `factory.rs` and `main.rs` now declare `allowed_account_ids` / `forbidden_account_ids` as `List<String>` provider config attribute types so the host enforces the shape before `initialize` is invoked.
- `CarinaProvider::initialize` runs `verify_account_id` after constructing the provider; the error string surfaces through the existing host error path.
- `AwsProvider` gains `allowed_account_ids` / `forbidden_account_ids` fields and a new `new_with_account_guard` constructor; `new` and `with_clients` keep the previous shape (empty guard).

Forbidden takes precedence over allowed when an account is (incorrectly) listed in both — the safer outcome.

## Test plan

- [x] `cargo test` (carina-provider-aws + workspace) — all green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --target wasm32-wasip2 --release` — clean
- [x] Codegen scripts produce no diff
- [x] 10 new unit tests (9 pure policy + 1 attribute-type declaration)
- [ ] Acceptance: a `.crn` with `allowed_account_ids = ['000000000000']` should fail immediately when applied with any real credentials. The host wiring can be verified in carina-rs/infra once both this PR and the awscc-side counterpart land.

Closes #233