### PR TITLE
Revert "aws: normalize absent optional list/map attributes in read state"

### DIFF
--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 
 use carina_core::provider::{self, ProviderNormalizer};
 use carina_core::resource::{Resource, Value};
-use carina_core::schema::{AttributeType, SchemaRegistry};
+use carina_core::schema::SchemaRegistry;
 
 /// Schema extension for the AWS provider.
 ///
@@ -126,64 +126,6 @@ pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMa
 
     for (key, value) in resolved {
         attributes.insert(key, value);
-    }
-}
-
-/// Normalize absent optional list/map attributes in read state to canonical empty
-/// collections.
-///
-/// AWS SDK responses model "no value" as `Option::None` (or an empty collection
-/// that read code skips inserting). The differ, however, treats an absent
-/// attribute and an explicit `Value::List(vec![])` as different shapes, which
-/// produces a permanent `(none) → []` plan diff for any optional `list(...)`
-/// attribute the user declared as `[]`.
-///
-/// This normalizer establishes a canonical form at the provider boundary: for
-/// every optional `list(...)` attribute in the resource schema that is missing
-/// from the read state, insert `Value::List(vec![])`. Same for optional
-/// `map(...)` → `Value::Map(IndexMap::new())`.
-///
-/// Skipped:
-/// - `required` attributes — the differ already requires them; absence indicates
-///   a real read-side bug, not the "AWS returned None" surface this fixes.
-/// - `write_only` attributes — by definition, AWS doesn't return them, so an
-///   absent value is correct, not a bug to canonicalize away.
-/// - `read_only` attributes — they are populated server-side; if AWS didn't
-///   return one (e.g. an output ARN), the resource really has no value and
-///   inserting `[]` would be wrong.
-///
-/// Tracked at carina-rs/carina-provider-aws#236, parent carina-rs/carina#2544.
-pub(crate) fn normalize_absent_collections(
-    resource_type: &str,
-    attributes: &mut HashMap<String, Value>,
-) {
-    let configs = crate::schemas::generated::configs();
-    let config = match configs
-        .iter()
-        .find(|c| c.schema.resource_type == resource_type)
-    {
-        Some(c) => c,
-        None => return,
-    };
-
-    for (name, attr) in &config.schema.attributes {
-        // Only canonicalize attributes that the user can actually express in
-        // the DSL and that AWS may legitimately omit from a read response.
-        if attr.required || attr.write_only || attr.read_only {
-            continue;
-        }
-        if attributes.contains_key(name) {
-            continue;
-        }
-        match &attr.attr_type {
-            AttributeType::List { .. } => {
-                attributes.insert(name.clone(), Value::List(Vec::new()));
-            }
-            AttributeType::Map { .. } => {
-                attributes.insert(name.clone(), Value::Map(IndexMap::new()));
-            }
-            _ => {}
-        }
     }
 }
 
@@ -486,105 +428,5 @@ mod tests {
                 "aws.ec2.VpnGateway.Type.ipsec.1".to_string()
             ))
         );
-    }
-
-    // ---- normalize_absent_collections (#236) ----
-
-    #[test]
-    fn test_normalize_absent_collections_inserts_empty_list() {
-        // route53.RecordSet has an optional list(String) attribute
-        // `resource_records`. When the SDK response carries no records the
-        // service code skips the insert; the normalizer must canonicalize the
-        // gap to `Value::List(vec![])`.
-        let mut attributes: HashMap<String, Value> = HashMap::new();
-        attributes.insert("name".to_string(), Value::String("example.com".to_string()));
-        attributes.insert("type".to_string(), Value::String("A".to_string()));
-
-        normalize_absent_collections("route53.RecordSet", &mut attributes);
-
-        assert_eq!(
-            attributes.get("resource_records"),
-            Some(&Value::List(Vec::new())),
-            "absent optional list(...) attribute must canonicalize to Value::List(vec![])"
-        );
-    }
-
-    #[test]
-    fn test_normalize_absent_collections_preserves_present_list() {
-        // If the read code already populated the list, it must be left alone.
-        let mut attributes: HashMap<String, Value> = HashMap::new();
-        attributes.insert(
-            "resource_records".to_string(),
-            Value::List(vec![Value::String("1.2.3.4".to_string())]),
-        );
-
-        normalize_absent_collections("route53.RecordSet", &mut attributes);
-
-        assert_eq!(
-            attributes.get("resource_records"),
-            Some(&Value::List(vec![Value::String("1.2.3.4".to_string())])),
-        );
-    }
-
-    #[test]
-    fn test_normalize_absent_collections_skips_required() {
-        // `name` is required on route53.RecordSet — its absence is a bug, not
-        // something we should paper over by inserting an empty value (and the
-        // schema type is String, not List, so this is doubly defensive).
-        let mut attributes: HashMap<String, Value> = HashMap::new();
-        normalize_absent_collections("route53.RecordSet", &mut attributes);
-        assert!(!attributes.contains_key("name"));
-    }
-
-    #[test]
-    fn test_normalize_absent_collections_skips_unknown_resource_type() {
-        // No-op for unknown resource types — never panics, never inserts.
-        let mut attributes: HashMap<String, Value> = HashMap::new();
-        normalize_absent_collections("not.a.real.resource", &mut attributes);
-        assert!(attributes.is_empty());
-    }
-
-    #[test]
-    fn test_normalize_absent_collections_does_not_touch_scalars() {
-        // String/Int/Bool optional attributes must remain absent, not be
-        // synthesized to "" / 0 / false. The canonical-form fix is for
-        // collection shapes only.
-        let mut attributes: HashMap<String, Value> = HashMap::new();
-        normalize_absent_collections("iam.Role", &mut attributes);
-        // `description` is optional String — must not be inserted.
-        assert!(!attributes.contains_key("description"));
-        // `path` is optional String — must not be inserted.
-        assert!(!attributes.contains_key("path"));
-    }
-
-    #[test]
-    fn test_normalize_absent_collections_skips_read_only() {
-        // route53.RecordSet exposes a read-only `id` attribute (synthesized
-        // during read). The normalizer must not invent collection values for
-        // read-only fields even if their type happened to be a list/map.
-        let configs = crate::schemas::generated::configs();
-        let config = configs
-            .iter()
-            .find(|c| c.schema.resource_type == "route53.RecordSet")
-            .expect("route53.RecordSet schema present");
-        let read_only_lists: Vec<&str> = config
-            .schema
-            .attributes
-            .iter()
-            .filter(|(_, a)| a.read_only && matches!(a.attr_type, AttributeType::List { .. }))
-            .map(|(name, _)| name.as_str())
-            .collect();
-        // Whether or not such a read-only list happens to exist today, this
-        // test is a regression guard: any read-only list/map must stay absent
-        // unless the read code actually returned it.
-        let mut attributes: HashMap<String, Value> = HashMap::new();
-        normalize_absent_collections("route53.RecordSet", &mut attributes);
-        for name in read_only_lists {
-            assert!(
-                !attributes.contains_key(name),
-                "read-only list attribute {} must not be normalized to []",
-                name
-            );
-        }
     }
 }

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{BoxFuture, Provider, ProviderError, ProviderResult};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State};
 
 use crate::AwsProvider;
-use crate::normalizer::{normalize_absent_collections, normalize_state_enums};
+use crate::normalizer::normalize_state_enums;
 
 impl Provider for AwsProvider {
     fn name(&self) -> &str {
@@ -136,12 +136,9 @@ impl Provider for AwsProvider {
                 .for_resource(id.clone())),
             }?;
 
-            // Normalize enum values in read state to namespaced DSL format,
-            // and canonicalize absent optional list/map attributes to empty
-            // collections (#236) so the differ does not see `(none) → []`.
+            // Normalize enum values in read state to namespaced DSL format
             if state.exists {
                 normalize_state_enums(&id.resource_type, &mut state.attributes);
-                normalize_absent_collections(&id.resource_type, &mut state.attributes);
             }
 
             Ok(state)
@@ -155,7 +152,6 @@ impl Provider for AwsProvider {
                 crate::provider_generated::dispatch_read_data_source(self, &resource).await?;
             if state.exists {
                 normalize_state_enums(&resource.id.resource_type, &mut state.attributes);
-                normalize_absent_collections(&resource.id.resource_type, &mut state.attributes);
             }
             Ok(state)
         })


### PR DESCRIPTION
Reverts #237.

## Why

The companion PR `carina-rs/carina-provider-awscc#183` did not actually fix the underlying issue (`carina-rs/carina#2544` / `carina-rs/carina-provider-awscc#182`). The persistent `(none) → []` plan diff continues to reproduce on real infra after that merge — see `carina-rs/carina-provider-awscc#184`. Reverting the awscc-side change leaves this aws-side companion stranded; revert it together so both providers return to a known state and the parent issue can be re-investigated cleanly.

`carina-rs/carina#2544` and `carina-rs/carina-provider-aws#236` should be re-opened.

## Test plan

- [x] `cargo check` clean on the revert.
- [ ] CI green.