### PR TITLE
aws: adopt Level 3 Provider trait and provider-error variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
+source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
 dependencies = [
  "argon2",
  "futures",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
+source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
+source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1768,7 +1768,7 @@ fn generate_provider_code(
              \x20       identifier: &str,\n\
              \x20   ) -> ProviderResult<()> {{\n\
              \x20       self.{}.{}().{}(identifier).send().await.map_err(|e| {{\n\
-             \x20           ProviderError::new(sdk_error_message(\"Failed to delete {}\", &e))\n\
+             \x20           ProviderError::api_error(sdk_error_message(\"Failed to delete {}\", &e))\n\
              \x20               .for_resource(id.clone())\n\
              \x20       }})?;\n\
              \x20       Ok(())\n\
@@ -1864,7 +1864,7 @@ fn generate_provider_code(
                 client_field, sdk_method, id_setter
             ));
             code.push_str(&format!(
-                "\x20           ProviderError::new(sdk_error_message(\"Failed to read {}\", &e))\n",
+                "\x20           ProviderError::api_error(sdk_error_message(\"Failed to read {}\", &e))\n",
                 op_desc
             ));
             code.push_str("\x20               .for_resource(id.clone())\n");
@@ -2078,7 +2078,7 @@ fn generate_provider_code(
                 client_field, sdk_method, id_setter, struct_setter
             ));
             code.push_str(&format!(
-                "\x20               ProviderError::new(sdk_error_message(\"Failed to {}\", &e))\n",
+                "\x20               ProviderError::api_error(sdk_error_message(\"Failed to {}\", &e))\n",
                 op_desc
             ));
             code.push_str("\x20                   .for_resource(id.clone())\n");
@@ -2659,7 +2659,7 @@ fn generate_provider_code(
          \x20           let id = resource.id.clone();\n\
          \x20           let resource_type = resource.id.resource_type.clone();\n\
          \x20           Box::pin(async move {\n\
-         \x20               Err(ProviderError::new(format!(\n\
+         \x20               Err(ProviderError::internal(format!(\n\
          \x20                   \"aws provider does not implement read_data_source for '{}'\",\n\
          \x20                   resource_type\n\
          \x20               )).for_resource(id))\n\

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -28,7 +28,7 @@ impl AwsProvider {
             req = req.security_group_rule_ids(*rule_id);
         }
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message(
+            ProviderError::api_error(sdk_error_message(
                 "Failed to describe security group rules",
                 &e,
             ))
@@ -105,10 +105,10 @@ impl AwsProvider {
         let sg_id = match resource.get_attr("group_id") {
             Some(Value::String(s)) => s.clone(),
             _ => {
-                return Err(
-                    ProviderError::new("Security Group ID (group_id) is required")
-                        .for_resource(resource.id.clone()),
-                );
+                return Err(ProviderError::invalid_input(
+                    "Security Group ID (group_id) is required",
+                )
+                .for_resource(resource.id.clone()));
             }
         };
 
@@ -215,7 +215,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to create ingress rule", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to create ingress rule", &e))
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -233,7 +233,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to create egress rule", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to create egress rule", &e))
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -288,7 +288,7 @@ impl AwsProvider {
             req = req.security_group_rule_ids(*rule_id);
         }
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message(
+            ProviderError::api_error(sdk_error_message(
                 "Failed to describe security group rules",
                 &e,
             ))
@@ -298,12 +298,12 @@ impl AwsProvider {
         let rules = result.security_group_rules();
         if rules.is_empty() {
             return Err(
-                ProviderError::new("Security Group Rule not found").for_resource(id.clone())
+                ProviderError::not_found("Security Group Rule not found").for_resource(id.clone())
             );
         }
 
         let sg_id = rules[0].group_id().ok_or_else(|| {
-            ProviderError::new("Rule has no security group ID").for_resource(id.clone())
+            ProviderError::internal("Rule has no security group ID").for_resource(id.clone())
         })?;
 
         // Delete all rules at once
@@ -316,7 +316,7 @@ impl AwsProvider {
                 request = request.security_group_rule_ids(*rule_id);
             }
             request.send().await.map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete ingress rules", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete ingress rules", &e))
                     .for_resource(id.clone())
             })?;
         } else {
@@ -328,7 +328,7 @@ impl AwsProvider {
                 request = request.security_group_rule_ids(*rule_id);
             }
             request.send().await.map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete egress rules", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete egress rules", &e))
                     .for_resource(id.clone())
             })?;
         }

--- a/carina-provider-aws/src/ec2_tags.rs
+++ b/carina-provider-aws/src/ec2_tags.rs
@@ -70,7 +70,7 @@ impl AwsProvider {
                     req = req.tags(aws_sdk_ec2::types::Tag::builder().key(key.as_str()).build());
                 }
                 req.send().await.map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to delete tags", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to delete tags", &e))
                         .for_resource(resource_id.clone())
                 })?;
             }
@@ -85,7 +85,7 @@ impl AwsProvider {
                     req = req.tags(tag);
                 }
                 req.send().await.map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to tag resource", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to tag resource", &e))
                         .for_resource(resource_id.clone())
                 })?;
             }

--- a/carina-provider-aws/src/factory.rs
+++ b/carina-provider-aws/src/factory.rs
@@ -72,14 +72,19 @@ impl ProviderFactory for AwsProviderFactory {
     fn create_provider(
         &self,
         attributes: &IndexMap<String, Value>,
-    ) -> BoxFuture<'_, Box<dyn carina_core::provider::Provider>> {
+    ) -> BoxFuture<
+        '_,
+        carina_core::provider::ProviderResult<Box<dyn carina_core::provider::Provider>>,
+    > {
         use crate::services::sts::account_guard::extract_string_list;
         let region = self.extract_region(attributes);
         let allowed = extract_string_list(attributes.get("allowed_account_ids"));
         let forbidden = extract_string_list(attributes.get("forbidden_account_ids"));
         Box::pin(async move {
-            Box::new(AwsProvider::new_with_account_guard(&region, allowed, forbidden).await)
-                as Box<dyn carina_core::provider::Provider>
+            Ok(
+                Box::new(AwsProvider::new_with_account_guard(&region, allowed, forbidden).await)
+                    as Box<dyn carina_core::provider::Provider>,
+            )
         })
     }
 

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -10,8 +10,8 @@ use aws_sdk_ec2::types::{ResourceType, Tag, TagSpecification};
 use aws_smithy_types::error::display::DisplayErrorContext;
 use tokio::time::sleep;
 
-use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, Value};
+use carina_core::provider::{PatchOpKind, ProviderError, ProviderResult, UpdatePatch};
+use carina_core::resource::{Resource, ResourceId, State, Value};
 
 /// Extract a required `String` attribute from a resource.
 ///
@@ -19,8 +19,10 @@ use carina_core::resource::{Resource, ResourceId, Value};
 pub fn require_string_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
     match resource.get_attr(attr_name) {
         Some(Value::String(s)) => Ok(s.clone()),
-        _ => Err(ProviderError::new(format!("{} is required", attr_name))
-            .for_resource(resource.id.clone())),
+        _ => Err(
+            ProviderError::invalid_input(format!("{} is required", attr_name))
+                .for_resource(resource.id.clone()),
+        ),
     }
 }
 
@@ -141,6 +143,48 @@ fn is_retryable_error(error_msg: &str) -> bool {
     PATTERNS.iter().any(|p| error_msg.contains(p))
 }
 
+/// Reconstruct a `Resource` from `from` state plus an `UpdatePatch`.
+///
+/// The aws provider's existing per-resource `update_*` methods take
+/// `to: Resource` (a full desired state). The Level 3 `Provider::update`
+/// signature replaces `to` with `(from: State, patch: UpdatePatch)`, so
+/// this adapter rebuilds an equivalent desired `Resource` by applying
+/// each [`PatchOpKind`] on top of `from`'s attributes:
+///
+/// - `Add` / `Replace` set the attribute to the patch value.
+/// - `Remove` deletes the attribute from the resulting resource.
+///
+/// This is a faithful translation: the result mirrors what the user's
+/// desired state would look like if it had been computed full-replace
+/// style. Per-resource update methods continue to write the same fields
+/// they always did.
+///
+/// The returned `Resource` carries `from`'s `ResourceId` and an empty
+/// `LifecycleConfig` (lifecycle is delete-only and is not consulted on
+/// update paths in this provider).
+pub fn apply_patch_to_state(from: &State, patch: &UpdatePatch) -> Resource {
+    let mut resource = Resource::new(from.id.resource_type.clone(), from.id.name.to_string());
+    resource.id = from.id.clone();
+    resource.attributes = from
+        .attributes
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    for op in &patch.ops {
+        match op.kind {
+            PatchOpKind::Add | PatchOpKind::Replace => {
+                if let Some(ref v) = op.value {
+                    resource.attributes.insert(op.key.clone(), v.clone());
+                }
+            }
+            PatchOpKind::Remove => {
+                resource.attributes.shift_remove(&op.key);
+            }
+        }
+    }
+    resource
+}
+
 /// Generic wait/poll loop for EC2 resources.
 ///
 /// Polls at 5-second intervals for up to `max_iterations` iterations.
@@ -165,14 +209,14 @@ where
             PollState::Ready => return Ok(()),
             PollState::Gone => return Ok(()),
             PollState::Failed => {
-                return Err(ProviderError::new(failure_msg).for_resource(id.clone()));
+                return Err(ProviderError::api_error(failure_msg).for_resource(id.clone()));
             }
             PollState::Pending => {}
         }
         sleep(Duration::from_secs(5)).await;
     }
 
-    Err(ProviderError::new(timeout_msg).for_resource(id.clone()))
+    Err(ProviderError::timeout(timeout_msg).for_resource(id.clone()))
 }
 
 #[cfg(test)]
@@ -187,6 +231,73 @@ mod tests {
                 .insert(k.to_string(), Value::String(v.to_string()));
         }
         resource
+    }
+
+    #[test]
+    fn test_apply_patch_to_state_add_replace_remove() {
+        use carina_core::provider::{PatchOp, PatchOpKind, UpdatePatch};
+        use std::collections::HashMap;
+
+        // from-state has two attrs; patch adds one, replaces one, removes one.
+        let id = ResourceId::with_provider("aws", "ec2.Vpc", "test");
+        let mut from_attrs: HashMap<String, Value> = HashMap::new();
+        from_attrs.insert("cidr_block".into(), Value::String("10.0.0.0/16".into()));
+        from_attrs.insert(
+            "tags".into(),
+            Value::Map(
+                [("Name".to_string(), Value::String("old".into()))]
+                    .into_iter()
+                    .collect(),
+            ),
+        );
+        let from = State::existing(id, from_attrs);
+
+        let patch = UpdatePatch {
+            ops: vec![
+                // Add a brand-new attribute
+                PatchOp {
+                    kind: PatchOpKind::Add,
+                    key: "instance_tenancy".into(),
+                    value: Some(Value::String("default".into())),
+                },
+                // Replace the existing tags
+                PatchOp {
+                    kind: PatchOpKind::Replace,
+                    key: "tags".into(),
+                    value: Some(Value::Map(
+                        [("Name".to_string(), Value::String("new".into()))]
+                            .into_iter()
+                            .collect(),
+                    )),
+                },
+                // Remove cidr_block
+                PatchOp {
+                    kind: PatchOpKind::Remove,
+                    key: "cidr_block".into(),
+                    value: None,
+                },
+            ],
+        };
+
+        let to = apply_patch_to_state(&from, &patch);
+
+        assert!(
+            !to.attributes.contains_key("cidr_block"),
+            "Remove op should drop the key"
+        );
+        assert_eq!(
+            to.attributes.get("instance_tenancy"),
+            Some(&Value::String("default".into())),
+            "Add op should insert the new value"
+        );
+        match to.attributes.get("tags") {
+            Some(Value::Map(m)) => {
+                assert_eq!(m.get("Name"), Some(&Value::String("new".into())));
+            }
+            other => panic!("expected tags map, got {:?}", other),
+        }
+        // ResourceId is preserved from `from`
+        assert_eq!(to.id.resource_type, "ec2.Vpc");
     }
 
     #[test]

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -4,7 +4,12 @@ mod convert;
 use carina_plugin_sdk::CarinaProvider;
 use carina_provider_protocol::types as proto;
 
-use carina_core::provider::{Provider, ProviderError as CoreProviderError, ProviderNormalizer};
+use carina_core::provider::{
+    CreateRequest as CoreCreateRequest, DeleteRequest as CoreDeleteRequest, PatchOp as CorePatchOp,
+    PatchOpKind as CorePatchOpKind, Provider, ProviderError as CoreProviderError,
+    ProviderNormalizer, ReadRequest as CoreReadRequest, UpdatePatch as CoreUpdatePatch,
+    UpdateRequest as CoreUpdateRequest,
+};
 use carina_core::resource::Value as CoreValue;
 use carina_core::schema::SchemaRegistry;
 
@@ -40,13 +45,23 @@ impl AwsProcessProvider {
     }
 
     fn convert_error(e: CoreProviderError) -> proto::ProviderError {
+        let kind = match e {
+            CoreProviderError::InvalidInput(_) => proto::ProviderErrorKind::InvalidInput,
+            CoreProviderError::ApiError(_) => proto::ProviderErrorKind::ApiError,
+            CoreProviderError::NotFound(_) => proto::ProviderErrorKind::NotFound,
+            CoreProviderError::Timeout(_) => proto::ProviderErrorKind::Timeout,
+            CoreProviderError::Internal(_) => proto::ProviderErrorKind::Internal,
+        };
+        let detail = e.detail();
         proto::ProviderError {
-            message: e.to_string(),
-            resource_id: e
+            kind,
+            message: detail.message.clone(),
+            resource_id: detail
                 .resource_id
                 .as_ref()
-                .map(convert::core_to_proto_resource_id),
-            is_timeout: e.is_timeout,
+                .map(|id| convert::core_to_proto_resource_id(id)),
+            cause: detail.cause.as_ref().map(|c| c.to_string()),
+            provider_name: detail.provider_name.clone(),
         }
     }
 
@@ -177,12 +192,13 @@ impl CarinaProvider for AwsProcessProvider {
     fn read(
         &self,
         id: &proto::ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        _request: proto::ReadRequest,
     ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
-        let result = self
-            .runtime
-            .block_on(self.provider().read(&core_id, identifier));
+        let result =
+            self.runtime
+                .block_on(self.provider().read(&core_id, identifier, CoreReadRequest));
         match result {
             Ok(state) => Ok(convert::core_to_proto_state(&state)),
             Err(e) => Err(Self::convert_error(e)),
@@ -203,11 +219,19 @@ impl CarinaProvider for AwsProcessProvider {
         }
     }
 
-    fn create(&self, resource: &proto::Resource) -> Result<proto::State, proto::ProviderError> {
-        let core_resource = convert::proto_to_core_resource(resource);
+    fn create(
+        &self,
+        id: &proto::ResourceId,
+        request: proto::CreateRequest,
+    ) -> Result<proto::State, proto::ProviderError> {
+        let core_id = convert::proto_to_core_resource_id(id);
+        let core_resource = convert::proto_to_core_resource(&request.resource);
+        let core_request = CoreCreateRequest {
+            resource: core_resource,
+        };
         let result = self
             .runtime
-            .block_on(self.provider().create(&core_resource));
+            .block_on(self.provider().create(&core_id, core_request));
         match result {
             Ok(state) => Ok(convert::core_to_proto_state(&state)),
             Err(e) => Err(Self::convert_error(e)),
@@ -218,16 +242,33 @@ impl CarinaProvider for AwsProcessProvider {
         &self,
         id: &proto::ResourceId,
         identifier: &str,
-        from: &proto::State,
-        to: &proto::Resource,
+        request: proto::UpdateRequest,
     ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
-        let core_from = convert::proto_to_core_state(from);
-        let core_to = convert::proto_to_core_resource(to);
-        let result = self.runtime.block_on(
-            self.provider()
-                .update(&core_id, identifier, &core_from, &core_to),
-        );
+        let core_from = convert::proto_to_core_state(&request.from);
+        let core_patch = CoreUpdatePatch {
+            ops: request
+                .patch
+                .ops
+                .iter()
+                .map(|op| CorePatchOp {
+                    kind: match op.kind {
+                        proto::PatchOpKind::Add => CorePatchOpKind::Add,
+                        proto::PatchOpKind::Replace => CorePatchOpKind::Replace,
+                        proto::PatchOpKind::Remove => CorePatchOpKind::Remove,
+                    },
+                    key: op.key.clone(),
+                    value: op.value.as_ref().map(convert::proto_to_core_value),
+                })
+                .collect(),
+        };
+        let core_request = CoreUpdateRequest {
+            from: core_from,
+            patch: core_patch,
+        };
+        let result =
+            self.runtime
+                .block_on(self.provider().update(&core_id, identifier, core_request));
         match result {
             Ok(state) => Ok(convert::core_to_proto_state(&state)),
             Err(e) => Err(Self::convert_error(e)),
@@ -238,19 +279,20 @@ impl CarinaProvider for AwsProcessProvider {
         &self,
         id: &proto::ResourceId,
         identifier: &str,
-        lifecycle: &proto::LifecycleConfig,
+        request: proto::DeleteRequest,
     ) -> Result<(), proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_lifecycle = carina_core::resource::LifecycleConfig {
-            force_delete: lifecycle.force_delete,
-            create_before_destroy: lifecycle.create_before_destroy,
-            prevent_destroy: lifecycle.prevent_destroy,
+            force_delete: request.lifecycle.force_delete,
+            create_before_destroy: request.lifecycle.create_before_destroy,
+            prevent_destroy: request.lifecycle.prevent_destroy,
         };
-        let result = self.runtime.block_on(self.provider().delete(
-            &core_id,
-            identifier,
-            &core_lifecycle,
-        ));
+        let core_request = CoreDeleteRequest {
+            lifecycle: core_lifecycle,
+        };
+        let result =
+            self.runtime
+                .block_on(self.provider().delete(&core_id, identifier, core_request));
         match result {
             Ok(()) => Ok(()),
             Err(e) => Err(Self::convert_error(e)),

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -1,9 +1,13 @@
 //! Provider trait implementation for AWS
 
-use carina_core::provider::{BoxFuture, Provider, ProviderError, ProviderResult};
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State};
+use carina_core::provider::{
+    BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderResult, ReadRequest,
+    UpdateRequest,
+};
+use carina_core::resource::{Resource, ResourceId, State};
 
 use crate::AwsProvider;
+use crate::helpers::apply_patch_to_state;
 use crate::normalizer::normalize_state_enums;
 
 impl Provider for AwsProvider {
@@ -14,10 +18,11 @@ impl Provider for AwsProvider {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
-        let identifier = identifier.map(String::from);
+        let identifier = Some(identifier.to_string());
         Box::pin(async move {
             let mut state = match id.resource_type.as_str() {
                 "s3.Bucket" => self.read_s3_bucket(&id, identifier.as_deref()).await,
@@ -129,7 +134,7 @@ impl Provider for AwsProvider {
                     self.read_route53_record_set(&id, identifier.as_deref())
                         .await
                 }
-                _ => Err(ProviderError::new(format!(
+                _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     id.resource_type
                 ))
@@ -157,8 +162,12 @@ impl Provider for AwsProvider {
         })
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        let resource = resource.clone();
+    fn create(
+        &self,
+        _id: &ResourceId,
+        request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let resource = request.resource;
         Box::pin(async move {
             match resource.id.resource_type.as_str() {
                 "s3.Bucket" => self.create_s3_bucket(resource).await,
@@ -233,7 +242,7 @@ impl Provider for AwsProvider {
                 "iam.Role" => self.create_iam_role(resource).await,
                 "logs.LogGroup" => self.create_logs_log_group(resource).await,
                 "route53.RecordSet" => self.create_route53_record_set(resource).await,
-                _ => Err(ProviderError::new(format!(
+                _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     resource.id.resource_type
                 ))
@@ -246,13 +255,18 @@ impl Provider for AwsProvider {
         &self,
         id: &ResourceId,
         identifier: &str,
-        from: &State,
-        to: &Resource,
+        request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
         let identifier = identifier.to_string();
-        let from = from.clone();
-        let to = to.clone();
+        let from = request.from.clone();
+        // The aws provider's per-resource `update_*` methods predate the
+        // Level 3 patch contract and accept a full `to: Resource`.
+        // Reconstruct that from `(from, patch)` here so each method's
+        // existing logic continues to work without per-resource churn.
+        // Future per-resource updates can read `request.patch` directly
+        // for partial-update API paths once those are wired in.
+        let to = apply_patch_to_state(&request.from, &request.patch);
         Box::pin(async move {
             match id.resource_type.as_str() {
                 "s3.Bucket" => self.update_s3_bucket(id, &identifier, &from, to).await,
@@ -379,7 +393,7 @@ impl Provider for AwsProvider {
                 "iam.Role" => self.update_iam_role(id, &identifier, &from, to).await,
                 "logs.LogGroup" => self.update_logs_log_group(id, &identifier, &from, to).await,
                 "route53.RecordSet" => self.update_route53_record_set(id, &identifier, to).await,
-                _ => Err(ProviderError::new(format!(
+                _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     id.resource_type
                 ))
@@ -392,11 +406,11 @@ impl Provider for AwsProvider {
         &self,
         id: &ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         let id = id.clone();
         let identifier = identifier.to_string();
-        let lifecycle = lifecycle.clone();
+        let lifecycle = request.lifecycle;
         Box::pin(async move {
             match id.resource_type.as_str() {
                 "s3.Bucket" => self.delete_s3_bucket(id, &identifier, &lifecycle).await,
@@ -495,7 +509,7 @@ impl Provider for AwsProvider {
                 "iam.Role" => self.delete_iam_role(id, &identifier).await,
                 "logs.LogGroup" => self.delete_logs_log_group(id, &identifier).await,
                 "route53.RecordSet" => self.delete_route53_record_set(id, &identifier).await,
-                _ => Err(ProviderError::new(format!(
+                _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     id.resource_type
                 ))

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -30,7 +30,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete vpc", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete vpc", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -48,7 +48,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete subnet", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete subnet", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -66,7 +66,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete route table", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete route table", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -84,7 +84,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete security group", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete security group", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -716,7 +716,7 @@ pub(crate) fn dispatch_read_data_source<'a>(
             let id = resource.id.clone();
             let resource_type = resource.id.resource_type.clone();
             Box::pin(async move {
-                Err(ProviderError::new(format!(
+                Err(ProviderError::internal(format!(
                     "aws provider does not implement read_data_source for '{}'",
                     resource_type
                 ))

--- a/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
@@ -24,7 +24,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to describe egress-only internet gateways",
                     &e,
                 ))
@@ -74,7 +74,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message(
+            ProviderError::api_error(sdk_error_message(
                 "Failed to create egress-only internet gateway",
                 &e,
             ))
@@ -85,7 +85,7 @@ impl AwsProvider {
             .egress_only_internet_gateway()
             .and_then(|eigw| eigw.egress_only_internet_gateway_id())
             .ok_or_else(|| {
-                ProviderError::new("Egress-Only Internet Gateway created but no ID returned")
+                ProviderError::api_error("Egress-Only Internet Gateway created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -125,7 +125,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to delete egress-only internet gateway",
                     &e,
                 ))

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -32,7 +32,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe addresses", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe addresses", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -72,12 +72,12 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to allocate address", &e))
+            ProviderError::api_error(sdk_error_message("Failed to allocate address", &e))
                 .for_resource(resource.id.clone())
         })?;
 
         let alloc_id = result.allocation_id().ok_or_else(|| {
-            ProviderError::new("EIP allocated but no allocation ID returned")
+            ProviderError::api_error("EIP allocated but no allocation ID returned")
                 .for_resource(resource.id.clone())
         })?;
 
@@ -124,7 +124,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to release address", &e))
+                ProviderError::api_error(sdk_error_message("Failed to release address", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -32,7 +32,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe flow logs", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe flow logs", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -85,7 +85,7 @@ impl AwsProvider {
             _ => Vec::new(),
         };
         if resource_ids_val.is_empty() {
-            return Err(ProviderError::new(
+            return Err(ProviderError::invalid_input(
                 "resource_ids must be a non-empty list of resource identifiers",
             )
             .for_resource(resource.id.clone()));
@@ -94,7 +94,7 @@ impl AwsProvider {
         let resource_type_val = match resource.get_attr("resource_type") {
             Some(Value::String(s)) => extract_enum_value(s).to_string(),
             _ => {
-                return Err(ProviderError::new("resource_type is required")
+                return Err(ProviderError::invalid_input("resource_type is required")
                     .for_resource(resource.id.clone()));
             }
         };
@@ -173,7 +173,7 @@ impl AwsProvider {
                     {
                         continue;
                     }
-                    return Err(ProviderError::new(sdk_error_message(
+                    return Err(ProviderError::api_error(sdk_error_message(
                         "Failed to create flow logs",
                         &e,
                     ))
@@ -197,10 +197,11 @@ impl AwsProvider {
                 {
                     continue;
                 }
-                return Err(
-                    ProviderError::new(format!("Failed to create flow log: {}", msg))
-                        .for_resource(resource.id.clone()),
-                );
+                return Err(ProviderError::api_error(format!(
+                    "Failed to create flow log: {}",
+                    msg
+                ))
+                .for_resource(resource.id.clone()));
             }
 
             result = Some(resp);
@@ -208,7 +209,7 @@ impl AwsProvider {
         }
 
         let result = result.ok_or_else(|| {
-            ProviderError::new(format!(
+            ProviderError::api_error(format!(
                 "Failed to create flow log after retries: {}",
                 last_error
             ))
@@ -216,7 +217,7 @@ impl AwsProvider {
         })?;
 
         let flow_log_id = result.flow_log_ids().first().ok_or_else(|| {
-            ProviderError::new("Flow Log created but no ID returned")
+            ProviderError::api_error("Flow Log created but no ID returned")
                 .for_resource(resource.id.clone())
         })?;
 
@@ -256,7 +257,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete flow logs", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete flow logs", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -267,7 +268,7 @@ impl AwsProvider {
                 .and_then(|e| e.message())
                 .unwrap_or("unknown error");
             return Err(
-                ProviderError::new(format!("Failed to delete flow log: {}", msg))
+                ProviderError::api_error(format!("Failed to delete flow log: {}", msg))
                     .for_resource(id.clone()),
             );
         }

--- a/carina-provider-aws/src/services/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/internet_gateway.rs
@@ -31,7 +31,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to describe internet gateways",
                     &e,
                 ))
@@ -80,7 +80,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to create internet gateway", &e))
+                ProviderError::api_error(sdk_error_message("Failed to create internet gateway", &e))
                     .for_resource(resource.id.clone())
             })?;
 
@@ -88,7 +88,7 @@ impl AwsProvider {
             .internet_gateway()
             .and_then(|igw| igw.internet_gateway_id())
             .ok_or_else(|| {
-                ProviderError::new("Internet Gateway created but no ID returned")
+                ProviderError::api_error("Internet Gateway created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -105,8 +105,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to attach internet gateway", &e))
-                        .for_resource(resource.id.clone())
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to attach internet gateway",
+                        &e,
+                    ))
+                    .for_resource(resource.id.clone())
                 })?;
         }
 
@@ -129,8 +132,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe internet gateway", &e))
-                    .for_resource(id.clone())
+                ProviderError::api_error(sdk_error_message(
+                    "Failed to describe internet gateway",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         if let Some(igw) = result.internet_gateways().first() {
@@ -145,7 +151,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to detach internet gateway",
                             &e,
                         ))
@@ -161,7 +167,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete internet gateway", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete internet gateway", &e))
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -36,7 +36,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe NAT gateways", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe NAT gateways", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -89,7 +89,7 @@ impl AwsProvider {
             let rid = rid.clone();
             async move {
                 req.send().await.map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to create NAT gateway", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to create NAT gateway", &e))
                         .for_resource(rid)
                 })
             }
@@ -100,7 +100,7 @@ impl AwsProvider {
             .nat_gateway()
             .and_then(|ngw| ngw.nat_gateway_id())
             .ok_or_else(|| {
-                ProviderError::new("NAT Gateway created but no ID returned")
+                ProviderError::api_error("NAT Gateway created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -146,7 +146,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete NAT gateway", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete NAT gateway", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -173,8 +173,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message("Failed to describe NAT gateway", &e))
-                            .for_resource(rid.clone())
+                        ProviderError::api_error(sdk_error_message(
+                            "Failed to describe NAT gateway",
+                            &e,
+                        ))
+                        .for_resource(rid.clone())
                     })?;
                 Ok(
                     if let Some(ngw) = result.nat_gateways().first()
@@ -217,8 +220,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message("Failed to describe NAT gateway", &e))
-                            .for_resource(rid.clone())
+                        ProviderError::api_error(sdk_error_message(
+                            "Failed to describe NAT gateway",
+                            &e,
+                        ))
+                        .for_resource(rid.clone())
                     })?;
                 Ok(if let Some(ngw) = result.nat_gateways().first() {
                     if ngw.state() == Some(&NatGatewayState::Deleted) {

--- a/carina-provider-aws/src/services/ec2/route.rs
+++ b/carina-provider-aws/src/services/ec2/route.rs
@@ -30,7 +30,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe route table", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe route table", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -81,7 +81,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create route", &e))
+            ProviderError::api_error(sdk_error_message("Failed to create route", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -103,17 +103,18 @@ impl AwsProvider {
         let route_table_id = match to.get_attr("route_table_id") {
             Some(Value::String(s)) => s.clone(),
             _ => {
-                return Err(
-                    ProviderError::new("route_table_id is required").for_resource(id.clone())
-                );
+                return Err(ProviderError::invalid_input("route_table_id is required")
+                    .for_resource(id.clone()));
             }
         };
 
         let destination_cidr = match to.get_attr("destination_cidr_block") {
             Some(Value::String(s)) => s.clone(),
             _ => {
-                return Err(ProviderError::new("destination_cidr_block is required")
-                    .for_resource(id.clone()));
+                return Err(
+                    ProviderError::invalid_input("destination_cidr_block is required")
+                        .for_resource(id.clone()),
+                );
             }
         };
 
@@ -134,7 +135,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to update route", &e))
+            ProviderError::api_error(sdk_error_message("Failed to update route", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -151,10 +152,11 @@ impl AwsProvider {
     ) -> ProviderResult<()> {
         // Parse composite identifier: route_table_id|destination_cidr_block
         let Some((route_table_id, destination_cidr_block)) = identifier.split_once('|') else {
-            return Err(
-                ProviderError::new(format!("Invalid route identifier: {}", identifier))
-                    .for_resource(id),
-            );
+            return Err(ProviderError::invalid_input(format!(
+                "Invalid route identifier: {}",
+                identifier
+            ))
+            .for_resource(id));
         };
 
         self.ec2_client
@@ -164,7 +166,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete route", &e)).for_resource(id)
+                ProviderError::api_error(sdk_error_message("Failed to delete route", &e))
+                    .for_resource(id)
             })?;
 
         Ok(())

--- a/carina-provider-aws/src/services/ec2/route_table.rs
+++ b/carina-provider-aws/src/services/ec2/route_table.rs
@@ -32,7 +32,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe route tables", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe route tables", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -88,7 +88,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to create route table", &e))
+                ProviderError::api_error(sdk_error_message("Failed to create route table", &e))
                     .for_resource(resource.id.clone())
             })?;
 
@@ -96,7 +96,7 @@ impl AwsProvider {
             .route_table()
             .and_then(|rt| rt.route_table_id())
             .ok_or_else(|| {
-                ProviderError::new("Route Table created but no ID returned")
+                ProviderError::api_error("Route Table created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -132,8 +132,11 @@ impl AwsProvider {
                             .send()
                             .await
                             .map_err(|e| {
-                                ProviderError::new(sdk_error_message("Failed to create route", &e))
-                                    .for_resource(resource.id.clone())
+                                ProviderError::api_error(sdk_error_message(
+                                    "Failed to create route",
+                                    &e,
+                                ))
+                                .for_resource(resource.id.clone())
                             })?;
                     }
                 }

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -31,8 +31,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe security groups", &e))
-                    .for_resource(id.clone())
+                ProviderError::api_error(sdk_error_message(
+                    "Failed to describe security groups",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         if let Some(sg) = result.security_groups().first() {
@@ -91,15 +94,18 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message("Failed to create security group", &e))
-                            .for_resource(rid)
+                        ProviderError::api_error(sdk_error_message(
+                            "Failed to create security group",
+                            &e,
+                        ))
+                        .for_resource(rid)
                     })
             }
         })
         .await?;
 
         let sg_id = result.group_id().ok_or_else(|| {
-            ProviderError::new("Security Group created but no ID returned")
+            ProviderError::api_error("Security Group created but no ID returned")
                 .for_resource(resource.id.clone())
         })?;
 

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -33,7 +33,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe subnets", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe subnets", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -81,12 +81,12 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create subnet", &e))
+            ProviderError::api_error(sdk_error_message("Failed to create subnet", &e))
                 .for_resource(resource.id.clone())
         })?;
 
         let subnet_id = result.subnet().and_then(|s| s.subnet_id()).ok_or_else(|| {
-            ProviderError::new("Subnet created but no ID returned")
+            ProviderError::api_error("Subnet created but no ID returned")
                 .for_resource(resource.id.clone())
         })?;
 
@@ -139,7 +139,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message(
+                    ProviderError::api_error(sdk_error_message(
                         "Failed to set map_public_ip_on_launch",
                         &e,
                     ))
@@ -157,7 +157,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message(
+                    ProviderError::api_error(sdk_error_message(
                         "Failed to set assign_ipv6_address_on_creation",
                         &e,
                     ))
@@ -173,7 +173,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to set enable_dns64", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to set enable_dns64", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -190,7 +190,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to set private_dns_name_options_on_launch.hostname_type",
                             &e,
                         ))
@@ -207,7 +207,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_a_record",
                             &e,
                         ))
@@ -224,7 +224,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_aaaa_record",
                             &e,
                         ))

--- a/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
@@ -37,7 +37,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe route tables", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe route tables", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -88,13 +88,15 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to associate route table", &e))
+                ProviderError::api_error(sdk_error_message("Failed to associate route table", &e))
                     .for_resource(resource.id.clone())
             })?;
 
         let assoc_id = result.association_id().ok_or_else(|| {
-            ProviderError::new("Route table association created but no association ID returned")
-                .for_resource(resource.id.clone())
+            ProviderError::api_error(
+                "Route table association created but no association ID returned",
+            )
+            .for_resource(resource.id.clone())
         })?;
 
         // Composite identifier: association_id|subnet_id
@@ -112,7 +114,7 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         // Parse composite identifier: association_id|subnet_id
         let Some((association_id, subnet_id)) = identifier.split_once('|') else {
-            return Err(ProviderError::new(format!(
+            return Err(ProviderError::invalid_input(format!(
                 "Invalid association identifier: {}",
                 identifier
             ))
@@ -122,9 +124,8 @@ impl AwsProvider {
         let route_table_id = match to.get_attr("route_table_id") {
             Some(Value::String(s)) => s.clone(),
             _ => {
-                return Err(
-                    ProviderError::new("route_table_id is required").for_resource(id.clone())
-                );
+                return Err(ProviderError::invalid_input("route_table_id is required")
+                    .for_resource(id.clone()));
             }
         };
 
@@ -137,7 +138,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to replace route table association",
                     &e,
                 ))
@@ -145,7 +146,7 @@ impl AwsProvider {
             })?;
 
         let new_assoc_id = result.new_association_id().ok_or_else(|| {
-            ProviderError::new(
+            ProviderError::api_error(
                 "Route table association replaced but no new association ID returned",
             )
             .for_resource(id.clone())
@@ -164,7 +165,7 @@ impl AwsProvider {
     ) -> ProviderResult<()> {
         // Parse composite identifier: association_id|subnet_id
         let Some((association_id, _subnet_id)) = identifier.split_once('|') else {
-            return Err(ProviderError::new(format!(
+            return Err(ProviderError::invalid_input(format!(
                 "Invalid association identifier: {}",
                 identifier
             ))
@@ -177,8 +178,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to disassociate route table", &e))
-                    .for_resource(id.clone())
+                ProviderError::api_error(sdk_error_message(
+                    "Failed to disassociate route table",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         Ok(())

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -25,8 +25,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe transit gateways", &e))
-                    .for_resource(id.clone())
+                ProviderError::api_error(sdk_error_message(
+                    "Failed to describe transit gateways",
+                    &e,
+                ))
+                .for_resource(id.clone())
             })?;
 
         if let Some(tgw) = result.transit_gateways().first() {
@@ -124,7 +127,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create transit gateway", &e))
+            ProviderError::api_error(sdk_error_message("Failed to create transit gateway", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -132,7 +135,7 @@ impl AwsProvider {
             .transit_gateway()
             .and_then(|tgw| tgw.transit_gateway_id())
             .ok_or_else(|| {
-                ProviderError::new("Transit Gateway created but no ID returned")
+                ProviderError::api_error("Transit Gateway created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -175,7 +178,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete transit gateway", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete transit gateway", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -203,7 +206,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to describe transit gateway",
                             &e,
                         ))
@@ -247,7 +250,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to describe transit gateway",
                             &e,
                         ))

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -26,7 +26,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to describe transit gateway VPC attachments",
                     &e,
                 ))
@@ -77,15 +77,14 @@ impl AwsProvider {
                     }
                 }
                 if result.is_empty() {
-                    return Err(ProviderError::new("subnet_ids must not be empty")
+                    return Err(ProviderError::invalid_input("subnet_ids must not be empty")
                         .for_resource(resource.id.clone()));
                 }
                 result
             }
             _ => {
-                return Err(
-                    ProviderError::new("subnet_ids is required").for_resource(resource.id.clone())
-                );
+                return Err(ProviderError::invalid_input("subnet_ids is required")
+                    .for_resource(resource.id.clone()));
             }
         };
 
@@ -108,7 +107,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message(
+            ProviderError::api_error(sdk_error_message(
                 "Failed to create transit gateway VPC attachment",
                 &e,
             ))
@@ -119,7 +118,7 @@ impl AwsProvider {
             .transit_gateway_vpc_attachment()
             .and_then(|att| att.transit_gateway_attachment_id())
             .ok_or_else(|| {
-                ProviderError::new("Transit Gateway Attachment created but no ID returned")
+                ProviderError::api_error("Transit Gateway Attachment created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -163,7 +162,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to delete transit gateway VPC attachment",
                     &e,
                 ))
@@ -194,7 +193,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to describe transit gateway VPC attachment",
                             &e,
                         ))
@@ -238,7 +237,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to describe transit gateway VPC attachment",
                             &e,
                         ))

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -29,7 +29,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe VPCs", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe VPCs", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -114,7 +114,7 @@ impl AwsProvider {
             let rid = rid.clone();
             async move {
                 builder.send().await.map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to create VPC", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to create VPC", &e))
                         .for_resource(rid)
                 })
             }
@@ -122,7 +122,8 @@ impl AwsProvider {
         .await?;
 
         let vpc_id = result.vpc().and_then(|v| v.vpc_id()).ok_or_else(|| {
-            ProviderError::new("VPC created but no ID returned").for_resource(resource.id.clone())
+            ProviderError::api_error("VPC created but no ID returned")
+                .for_resource(resource.id.clone())
         })?;
 
         // Apply tags
@@ -142,7 +143,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to set DNS support", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to set DNS support", &e))
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -160,7 +161,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to set DNS hostnames", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to set DNS hostnames", &e))
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -193,7 +194,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to update DNS support", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to update DNS support", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -211,8 +212,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to update DNS hostnames", &e))
-                        .for_resource(id.clone())
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to update DNS hostnames",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
         }
 

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -25,7 +25,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe VPC endpoints", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe VPC endpoints", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -111,8 +111,11 @@ impl AwsProvider {
             let json_str =
                 crate::services::iam::role::value_to_iam_policy_json(&Value::Map(map.clone()))
                     .map_err(|e| {
-                        ProviderError::new(format!("Failed to serialize policy_document: {}", e))
-                            .for_resource(resource.id.clone())
+                        ProviderError::internal(format!(
+                            "Failed to serialize policy_document: {}",
+                            e
+                        ))
+                        .for_resource(resource.id.clone())
                     })?;
             req = req.policy_document(&json_str);
         }
@@ -123,7 +126,7 @@ impl AwsProvider {
             let rid = rid.clone();
             async move {
                 req.send().await.map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to create VPC endpoint", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to create VPC endpoint", &e))
                         .for_resource(rid)
                 })
             }
@@ -134,7 +137,7 @@ impl AwsProvider {
             .vpc_endpoint()
             .and_then(|ep| ep.vpc_endpoint_id())
             .ok_or_else(|| {
-                ProviderError::new("VPC Endpoint created but no ID returned")
+                ProviderError::api_error("VPC Endpoint created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -304,8 +307,11 @@ impl AwsProvider {
             let json_str =
                 crate::services::iam::role::value_to_iam_policy_json(&Value::Map(map.clone()))
                     .map_err(|e| {
-                        ProviderError::new(format!("Failed to serialize policy_document: {}", e))
-                            .for_resource(id.clone())
+                        ProviderError::internal(format!(
+                            "Failed to serialize policy_document: {}",
+                            e
+                        ))
+                        .for_resource(id.clone())
                     })?;
             req = req.policy_document(&json_str);
             has_modifications = true;
@@ -313,7 +319,7 @@ impl AwsProvider {
 
         if has_modifications {
             req.send().await.map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to modify VPC endpoint", &e))
+                ProviderError::api_error(sdk_error_message("Failed to modify VPC endpoint", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -343,7 +349,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete VPC endpoint", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete VPC endpoint", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -353,10 +359,11 @@ impl AwsProvider {
                 .error()
                 .and_then(|e| e.message())
                 .unwrap_or("unknown error");
-            return Err(
-                ProviderError::new(format!("Failed to delete VPC endpoint: {}", msg))
-                    .for_resource(id.clone()),
-            );
+            return Err(ProviderError::api_error(format!(
+                "Failed to delete VPC endpoint: {}",
+                msg
+            ))
+            .for_resource(id.clone()));
         }
 
         Ok(())

--- a/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
@@ -58,7 +58,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to describe internet gateways",
                     &e,
                 ))
@@ -106,7 +106,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe VPN gateways", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe VPN gateways", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -148,8 +148,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to attach internet gateway", &e))
-                        .for_resource(resource.id.clone())
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to attach internet gateway",
+                        &e,
+                    ))
+                    .for_resource(resource.id.clone())
                 })?;
 
             let composite = format!("{}|{}", vpc_id, igw_id);
@@ -164,7 +167,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to attach VPN gateway", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to attach VPN gateway", &e))
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -172,10 +175,10 @@ impl AwsProvider {
             self.read_ec2_vpc_gateway_attachment(&resource.id, Some(&composite))
                 .await
         } else {
-            Err(
-                ProviderError::new("Either internet_gateway_id or vpn_gateway_id is required")
-                    .for_resource(resource.id.clone()),
+            Err(ProviderError::invalid_input(
+                "Either internet_gateway_id or vpn_gateway_id is required",
             )
+            .for_resource(resource.id.clone()))
         }
     }
 
@@ -198,7 +201,7 @@ impl AwsProvider {
         identifier: &str,
     ) -> ProviderResult<()> {
         let Some((vpc_id, gateway_id)) = identifier.split_once('|') else {
-            return Err(ProviderError::new(format!(
+            return Err(ProviderError::invalid_input(format!(
                 "Invalid gateway attachment identifier: {}",
                 identifier
             ))
@@ -213,8 +216,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to detach internet gateway", &e))
-                        .for_resource(id.clone())
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to detach internet gateway",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
         } else if gateway_id.starts_with("vgw-") {
             self.ec2_client
@@ -224,11 +230,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to detach VPN gateway", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to detach VPN gateway", &e))
                         .for_resource(id.clone())
                 })?;
         } else {
-            return Err(ProviderError::new(format!(
+            return Err(ProviderError::invalid_input(format!(
                 "Unknown gateway type in identifier: {}",
                 identifier
             ))

--- a/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
@@ -24,7 +24,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to describe VPC peering connections",
                     &e,
                 ))
@@ -96,7 +96,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message(
+            ProviderError::api_error(sdk_error_message(
                 "Failed to create VPC peering connection",
                 &e,
             ))
@@ -107,7 +107,7 @@ impl AwsProvider {
             .vpc_peering_connection()
             .and_then(|pcx| pcx.vpc_peering_connection_id())
             .ok_or_else(|| {
-                ProviderError::new("VPC Peering Connection created but no ID returned")
+                ProviderError::api_error("VPC Peering Connection created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -147,7 +147,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to delete VPC peering connection",
                     &e,
                 ))

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -32,7 +32,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe VPN gateways", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe VPN gateways", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -67,9 +67,8 @@ impl AwsProvider {
         let gw_type = match resource.get_attr("type") {
             Some(Value::String(s)) => extract_enum_value_with_values(s, &["ipsec.1"]).to_string(),
             _ => {
-                return Err(
-                    ProviderError::new("type is required").for_resource(resource.id.clone())
-                );
+                return Err(ProviderError::invalid_input("type is required")
+                    .for_resource(resource.id.clone()));
             }
         };
 
@@ -83,7 +82,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create VPN gateway", &e))
+            ProviderError::api_error(sdk_error_message("Failed to create VPN gateway", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -91,7 +90,7 @@ impl AwsProvider {
             .vpn_gateway()
             .and_then(|vgw| vgw.vpn_gateway_id())
             .ok_or_else(|| {
-                ProviderError::new("VPN Gateway created but no ID returned")
+                ProviderError::api_error("VPN Gateway created but no ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -133,7 +132,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete VPN gateway", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete VPN gateway", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -64,7 +64,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::new(sdk_error_message("Failed to get IAM role", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to get IAM role", &e))
                         .for_resource(id.clone()),
                 )
             }
@@ -105,7 +105,7 @@ impl AwsProvider {
                         .value(val)
                         .build()
                         .map_err(|e| {
-                            ProviderError::new(sdk_error_message("Failed to build tag", &e))
+                            ProviderError::api_error(sdk_error_message("Failed to build tag", &e))
                                 .for_resource(resource.id.clone())
                         })?;
                     req = req.tags(tag);
@@ -114,7 +114,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create IAM role", &e))
+            ProviderError::api_error(sdk_error_message("Failed to create IAM role", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -139,8 +139,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to update assume role policy", &e))
-                        .for_resource(id.clone())
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to update assume role policy",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
         }
 
@@ -160,7 +163,7 @@ impl AwsProvider {
 
         if needs_update {
             req.send().await.map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to update IAM role", &e))
+                ProviderError::api_error(sdk_error_message("Failed to update IAM role", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -189,7 +192,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete IAM role", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete IAM role", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -225,7 +228,7 @@ impl AwsProvider {
                 req = req.tag_keys(key);
             }
             req.send().await.map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to untag IAM role", &e))
+                ProviderError::api_error(sdk_error_message("Failed to untag IAM role", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -244,7 +247,7 @@ impl AwsProvider {
                         .value(val)
                         .build()
                         .map_err(|e| {
-                            ProviderError::new(sdk_error_message("Failed to build tag", &e))
+                            ProviderError::api_error(sdk_error_message("Failed to build tag", &e))
                                 .for_resource(id.clone())
                         })?;
                     tags_to_add.push(tag);
@@ -258,7 +261,7 @@ impl AwsProvider {
                 req = req.tags(tag);
             }
             req.send().await.map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to tag IAM role", &e))
+                ProviderError::api_error(sdk_error_message("Failed to tag IAM role", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -348,10 +351,10 @@ pub fn resolve_iam_policy_attr(resource: &Resource, attr_name: &str) -> Provider
     match resource.get_attr(attr_name) {
         Some(Value::String(s)) => Ok(s.clone()),
         Some(value @ Value::Map(_)) => value_to_iam_policy_json(value).map_err(|e| {
-            ProviderError::new(format!("Failed to convert {}: {}", attr_name, e))
+            ProviderError::invalid_input(format!("Failed to convert {}: {}", attr_name, e))
                 .for_resource(resource.id.clone())
         }),
-        _ => Err(ProviderError::new(format!(
+        _ => Err(ProviderError::invalid_input(format!(
             "{} is required (must be a JSON string or block)",
             attr_name
         ))

--- a/carina-provider-aws/src/services/identitystore/user.rs
+++ b/carina-provider-aws/src/services/identitystore/user.rs
@@ -28,7 +28,7 @@ impl AwsProvider {
                 .get_attr("identity_store_id")
                 .and_then(value_as_str)
                 .ok_or_else(|| {
-                    ProviderError::new("identitystore.user requires `identity_store_id`")
+                    ProviderError::invalid_input("identitystore.user requires `identity_store_id`")
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -43,7 +43,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message(
+                    ProviderError::api_error(sdk_error_message(
                         &format!("Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'"),
                         &e,
                     ))
@@ -73,8 +73,10 @@ async fn resolve_user_id(
         .get_attr("user_name")
         .and_then(value_as_str)
         .ok_or_else(|| {
-            ProviderError::new("identitystore.user requires either `user_id` or `user_name`")
-                .for_resource(resource.id.clone())
+            ProviderError::invalid_input(
+                "identitystore.user requires either `user_id` or `user_name`",
+            )
+            .for_resource(resource.id.clone())
         })?;
 
     let unique_attribute = UniqueAttribute::builder()
@@ -82,7 +84,7 @@ async fn resolve_user_id(
         .attribute_value(aws_smithy_types::Document::String(user_name.to_string()))
         .build()
         .map_err(|e| {
-            ProviderError::new(sdk_error_message(
+            ProviderError::api_error(sdk_error_message(
                 "Failed to build userName lookup request",
                 &e,
             ))
@@ -98,7 +100,7 @@ async fn resolve_user_id(
         .send()
         .await
         .map_err(|e| {
-            ProviderError::new(sdk_error_message(
+            ProviderError::api_error(sdk_error_message(
                 &format!("Failed to look up user_id for user_name '{user_name}' in store '{identity_store_id}'"),
                 &e,
             ))

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -26,7 +26,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to describe log groups", &e))
+                ProviderError::api_error(sdk_error_message("Failed to describe log groups", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -126,7 +126,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create log group", &e))
+            ProviderError::api_error(sdk_error_message("Failed to create log group", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -139,8 +139,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to set retention policy", &e))
-                        .for_resource(resource.id.clone())
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to set retention policy",
+                        &e,
+                    ))
+                    .for_resource(resource.id.clone())
                 })?;
         }
 
@@ -166,8 +169,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message("Failed to set retention policy", &e))
-                            .for_resource(id.clone())
+                        ProviderError::api_error(sdk_error_message(
+                            "Failed to set retention policy",
+                            &e,
+                        ))
+                        .for_resource(id.clone())
                     })?;
             }
             None if from.attributes.contains_key("retention_in_days") => {
@@ -178,7 +184,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to delete retention policy",
                             &e,
                         ))
@@ -197,7 +203,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to associate KMS key", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to associate KMS key", &e))
                         .for_resource(id.clone())
                 })?;
         } else if from.attributes.contains_key("kms_key_id") {
@@ -207,8 +213,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to disassociate KMS key", &e))
-                        .for_resource(id.clone())
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to disassociate KMS key",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
         }
 
@@ -236,7 +245,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete log group", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete log group", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -276,7 +285,7 @@ impl AwsProvider {
                 req = req.tags(key);
             }
             req.send().await.map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to untag log group", &e))
+                ProviderError::api_error(sdk_error_message("Failed to untag log group", &e))
                     .for_resource(id.clone())
             })?;
         }
@@ -304,7 +313,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to tag log group", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to tag log group", &e))
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -133,7 +133,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::new(sdk_error_message("Failed to describe account", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to describe account", &e))
                         .for_resource(id.clone()),
                 )
             }
@@ -173,7 +173,7 @@ impl AwsProvider {
                         .value(val)
                         .build()
                         .map_err(|e| {
-                            ProviderError::new(sdk_error_message("Failed to build tag", &e))
+                            ProviderError::api_error(sdk_error_message("Failed to build tag", &e))
                                 .for_resource(resource.id.clone())
                         })?;
                     req = req.tags(tag);
@@ -182,16 +182,17 @@ impl AwsProvider {
         }
 
         let response = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create account", &e))
+            ProviderError::api_error(sdk_error_message("Failed to create account", &e))
                 .for_resource(resource.id.clone())
         })?;
 
         let create_status = response.create_account_status().ok_or_else(|| {
-            ProviderError::new("CreateAccount returned no status").for_resource(resource.id.clone())
+            ProviderError::api_error("CreateAccount returned no status")
+                .for_resource(resource.id.clone())
         })?;
 
         let request_id = create_status.id().ok_or_else(|| {
-            ProviderError::new("CreateAccount returned no request ID")
+            ProviderError::api_error("CreateAccount returned no request ID")
                 .for_resource(resource.id.clone())
         })?;
 
@@ -208,7 +209,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to describe create account status",
                             &e,
                         ))
@@ -242,7 +243,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to get final create account status",
                     &e,
                 ))
@@ -253,7 +254,7 @@ impl AwsProvider {
             .create_account_status()
             .and_then(|s| s.account_id())
             .ok_or_else(|| {
-                ProviderError::new("CreateAccount succeeded but no account ID returned")
+                ProviderError::api_error("CreateAccount succeeded but no account ID returned")
                     .for_resource(resource.id.clone())
             })?;
 
@@ -267,7 +268,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message(
+                    ProviderError::api_error(sdk_error_message(
                         "Failed to list parents for new account",
                         &e,
                     ))
@@ -286,7 +287,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to move account to parent",
                             &e,
                         ))
@@ -328,7 +329,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to move account", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to move account", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -357,7 +358,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to close account", &e))
+                ProviderError::api_error(sdk_error_message("Failed to close account", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -395,7 +396,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to untag account", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to untag account", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -414,7 +415,7 @@ impl AwsProvider {
                         .value(val)
                         .build()
                         .map_err(|e| {
-                            ProviderError::new(sdk_error_message("Failed to build tag", &e))
+                            ProviderError::api_error(sdk_error_message("Failed to build tag", &e))
                                 .for_resource(id.clone())
                         })?;
                     tags_to_add.push(tag);
@@ -430,7 +431,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to tag account", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to tag account", &e))
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -88,10 +88,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(
-                    ProviderError::new(sdk_error_message("Failed to describe organization", &e))
-                        .for_resource(id.clone()),
-                )
+                Err(ProviderError::api_error(sdk_error_message(
+                    "Failed to describe organization",
+                    &e,
+                ))
+                .for_resource(id.clone()))
             }
         }
     }
@@ -111,7 +112,7 @@ impl AwsProvider {
         }
 
         let response = req.send().await.map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to create organization", &e))
+            ProviderError::api_error(sdk_error_message("Failed to create organization", &e))
                 .for_resource(resource.id.clone())
         })?;
 
@@ -126,7 +127,7 @@ impl AwsProvider {
             })
         } else {
             Err(
-                ProviderError::new("CreateOrganization returned no organization")
+                ProviderError::api_error("CreateOrganization returned no organization")
                     .for_resource(resource.id),
             )
         }
@@ -143,7 +144,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete organization", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete organization", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -93,7 +93,7 @@ fn build_alias_target_from_map(
         .evaluate_target_health(evaluate)
         .build()
         .map_err(|e| {
-            ProviderError::new(sdk_error_message("Invalid alias_target", &e))
+            ProviderError::api_error(sdk_error_message("Invalid alias_target", &e))
                 .for_resource(id.clone())
         })
 }
@@ -120,7 +120,7 @@ fn build_record_set(resource: &Resource) -> ProviderResult<ResourceRecordSet> {
     }
 
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message("Failed to build ResourceRecordSet", &e))
+        ProviderError::api_error(sdk_error_message("Failed to build ResourceRecordSet", &e))
             .for_resource(resource.id.clone())
     })
 }
@@ -138,7 +138,7 @@ async fn change_record_set(
         .resource_record_set(record_set)
         .build()
         .map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to build change", &e))
+            ProviderError::api_error(sdk_error_message("Failed to build change", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -146,7 +146,7 @@ async fn change_record_set(
         .changes(change)
         .build()
         .map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to build change batch", &e))
+            ProviderError::api_error(sdk_error_message("Failed to build change batch", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -157,7 +157,7 @@ async fn change_record_set(
         .send()
         .await
         .map_err(|e| {
-            ProviderError::new(sdk_error_message("ChangeResourceRecordSets failed", &e))
+            ProviderError::api_error(sdk_error_message("ChangeResourceRecordSets failed", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -241,7 +241,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to list record sets", &e))
+                ProviderError::api_error(sdk_error_message("Failed to list record sets", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -313,7 +313,7 @@ impl AwsProvider {
         identifier: &str,
     ) -> ProviderResult<()> {
         let Some((zone_id, name, record_type)) = parse_identifier(identifier) else {
-            return Err(ProviderError::new(format!(
+            return Err(ProviderError::invalid_input(format!(
                 "Invalid record set identifier: {}",
                 identifier
             ))
@@ -345,7 +345,7 @@ impl AwsProvider {
         }
 
         let record_set = builder.build().map_err(|e| {
-            ProviderError::new(sdk_error_message(
+            ProviderError::api_error(sdk_error_message(
                 "Failed to build record set for deletion",
                 &e,
             ))

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -44,13 +44,13 @@ impl AwsProvider {
 
                 match error_kind {
                     HeadBucketErrorKind::NotFound => Ok(State::not_found(id.clone())),
-                    HeadBucketErrorKind::AccessDenied => Err(ProviderError::new(format!(
+                    HeadBucketErrorKind::AccessDenied => Err(ProviderError::api_error(format!(
                         "Access denied for bucket '{}'. This may indicate insufficient IAM \
                          permissions or the bucket is owned by a different AWS account.",
                         name
                     ))
                     .for_resource(id.clone())),
-                    HeadBucketErrorKind::Other => Err(ProviderError::new(sdk_error_message(
+                    HeadBucketErrorKind::Other => Err(ProviderError::api_error(sdk_error_message(
                         "Failed to read bucket",
                         &err,
                     ))
@@ -65,9 +65,8 @@ impl AwsProvider {
         let bucket_name = match resource.get_attr("bucket") {
             Some(Value::String(s)) => s.clone(),
             _ => {
-                return Err(
-                    ProviderError::new("Bucket name is required").for_resource(resource.id.clone())
-                );
+                return Err(ProviderError::invalid_input("Bucket name is required")
+                    .for_resource(resource.id.clone()));
             }
         };
 
@@ -106,7 +105,7 @@ impl AwsProvider {
             let rid = rid.clone();
             async move {
                 req.send().await.map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to create bucket", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to create bucket", &e))
                         .for_resource(rid)
                 })
             }
@@ -142,7 +141,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to delete bucket tags", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to delete bucket tags", &e))
                         .for_resource(id.clone())
                 })?;
         } else {
@@ -170,7 +169,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to delete bucket", &e))
+                ProviderError::api_error(sdk_error_message("Failed to delete bucket", &e))
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -195,7 +194,7 @@ impl AwsProvider {
             }
 
             let response = req.send().await.map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to list object versions", &e))
+                ProviderError::api_error(sdk_error_message("Failed to list object versions", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -209,7 +208,7 @@ impl AwsProvider {
                         oid = oid.version_id(vid);
                     }
                     objects_to_delete.push(oid.build().map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to build ObjectIdentifier",
                             &e,
                         ))
@@ -226,7 +225,7 @@ impl AwsProvider {
                         oid = oid.version_id(vid);
                     }
                     objects_to_delete.push(oid.build().map_err(|e| {
-                        ProviderError::new(sdk_error_message(
+                        ProviderError::api_error(sdk_error_message(
                             "Failed to build ObjectIdentifier",
                             &e,
                         ))
@@ -242,8 +241,11 @@ impl AwsProvider {
                     .quiet(true)
                     .build()
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message("Failed to build Delete request", &e))
-                            .for_resource(id.clone())
+                        ProviderError::api_error(sdk_error_message(
+                            "Failed to build Delete request",
+                            &e,
+                        ))
+                        .for_resource(id.clone())
                     })?;
 
                 self.s3_client
@@ -253,7 +255,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message("Failed to delete objects", &e))
+                        ProviderError::api_error(sdk_error_message("Failed to delete objects", &e))
                             .for_resource(id.clone())
                     })?;
             }
@@ -297,7 +299,7 @@ impl AwsProvider {
             }
             Err(err) => {
                 if !is_s3_not_configured_error(&err, "NoSuchTagSet") {
-                    return Err(ProviderError::new(sdk_error_message(
+                    return Err(ProviderError::api_error(sdk_error_message(
                         "Failed to read bucket tagging",
                         &err,
                     ))
@@ -332,7 +334,7 @@ impl AwsProvider {
                 .set_tag_set(Some(tags))
                 .build()
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to build tagging", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to build tagging", &e))
                         .for_resource(id.clone())
                 })?;
 
@@ -343,7 +345,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to put bucket tags", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to put bucket tags", &e))
                         .for_resource(id.clone())
                 })?;
         }
@@ -368,7 +370,7 @@ impl AwsProvider {
             let bucket = match resource.get_attr("bucket") {
                 Some(Value::String(s)) => s.clone(),
                 _ => {
-                    return Err(ProviderError::new("`bucket` is required")
+                    return Err(ProviderError::invalid_input("`bucket` is required")
                         .for_resource(resource.id.clone()));
                 }
             };
@@ -394,19 +396,20 @@ impl AwsProvider {
                     };
                     match kind {
                         HeadBucketErrorKind::NotFound => {
-                            ProviderError::new(format!("Bucket '{bucket}' not found"))
+                            ProviderError::not_found(format!("Bucket '{bucket}' not found"))
                                 .for_resource(resource.id.clone())
                         }
-                        HeadBucketErrorKind::AccessDenied => ProviderError::new(format!(
+                        HeadBucketErrorKind::AccessDenied => ProviderError::api_error(format!(
                             "Access denied for bucket '{bucket}'. This may indicate \
                              insufficient IAM permissions or the bucket is owned by a \
                              different AWS account."
                         ))
                         .for_resource(resource.id.clone()),
-                        HeadBucketErrorKind::Other => {
-                            ProviderError::new(sdk_error_message("Failed to head bucket", &err))
-                                .for_resource(resource.id.clone())
-                        }
+                        HeadBucketErrorKind::Other => ProviderError::api_error(sdk_error_message(
+                            "Failed to head bucket",
+                            &err,
+                        ))
+                        .for_resource(resource.id.clone()),
                     }
                 })?;
 
@@ -419,7 +422,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to get bucket location", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to get bucket location", &e))
                         .for_resource(resource.id.clone())
                 })?
                 .location_constraint()
@@ -432,7 +435,7 @@ impl AwsProvider {
             let bucket_domain_name = format!("{}.s3.amazonaws.com", bucket);
             let bucket_regional_domain_name = format!("{}.s3.{}.amazonaws.com", bucket, region);
             let hosted_zone_id = s3_hosted_zone_id(&region)
-                .map_err(|m| ProviderError::new(m).for_resource(resource.id.clone()))?;
+                .map_err(|m| ProviderError::internal(m).for_resource(resource.id.clone()))?;
 
             let mut attrs = HashMap::new();
             attrs.insert("bucket".into(), Value::String(bucket.clone()));

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -39,7 +39,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::new(sdk_error_message("Failed to get bucket ACL", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to get bucket ACL", &e))
                         .for_resource(id.clone()),
                 )
             }
@@ -74,7 +74,9 @@ impl AwsProvider {
             // (`public_read` ⇄ `public-read`) back to AWS canonical form.
             Some(Value::String(s)) => convert_enum_value(s).to_string(),
             _ => {
-                return Err(ProviderError::new("acl is required").for_resource(id.clone()));
+                return Err(
+                    ProviderError::invalid_input("acl is required").for_resource(id.clone())
+                );
             }
         };
 
@@ -85,7 +87,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket ACL", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put bucket ACL", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -110,10 +112,11 @@ impl AwsProvider {
         match result {
             Ok(_) => Ok(()),
             Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
-            Err(e) => Err(
-                ProviderError::new(sdk_error_message("Failed to reset bucket ACL", &e))
-                    .for_resource(id.clone()),
-            ),
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+                "Failed to reset bucket ACL",
+                &e,
+            ))
+            .for_resource(id.clone())),
         }
     }
 }

--- a/carina-provider-aws/src/services/s3/bucket_cors.rs
+++ b/carina-provider-aws/src/services/s3/bucket_cors.rs
@@ -35,7 +35,7 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::new(sdk_error_message(
+                Err(ProviderError::api_error(sdk_error_message(
                     "Failed to get bucket cors configuration",
                     &e,
                 ))
@@ -72,10 +72,10 @@ impl AwsProvider {
         let rules = match resource.get_attr("cors_rules") {
             Some(Value::List(items)) => items,
             _ => {
-                return Err(
-                    ProviderError::new("cors_rules is required and must be a list")
-                        .for_resource(id.clone()),
-                );
+                return Err(ProviderError::invalid_input(
+                    "cors_rules is required and must be a list",
+                )
+                .for_resource(id.clone()));
             }
         };
 
@@ -88,7 +88,7 @@ impl AwsProvider {
             .set_cors_rules(Some(sdk_rules))
             .build()
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to build CorsConfiguration", &e))
+                ProviderError::api_error(sdk_error_message("Failed to build CorsConfiguration", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -99,7 +99,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket cors", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put bucket cors", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -127,7 +127,7 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to delete bucket cors configuration",
                 &e,
             ))
@@ -138,7 +138,9 @@ impl AwsProvider {
 
 fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<CorsRule> {
     let Value::Map(map) = rule_value else {
-        return Err(ProviderError::new("each cors rule must be a map").for_resource(id.clone()));
+        return Err(
+            ProviderError::invalid_input("each cors rule must be a map").for_resource(id.clone())
+        );
     };
 
     let allowed_methods = require_string_list(id, map, "allowed_methods")?;
@@ -163,7 +165,7 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<CorsRule> {
     }
 
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message("Failed to build CorsRule", &e))
+        ProviderError::api_error(sdk_error_message("Failed to build CorsRule", &e))
             .for_resource(id.clone())
     })
 }
@@ -175,10 +177,10 @@ fn require_string_list(
 ) -> ProviderResult<Vec<String>> {
     match map.get(field) {
         Some(Value::List(items)) => strings_from_list(id, items, field),
-        _ => {
-            Err(ProviderError::new(format!("cors_rule.{field} is required"))
-                .for_resource(id.clone()))
-        }
+        _ => Err(
+            ProviderError::invalid_input(format!("cors_rule.{field} is required"))
+                .for_resource(id.clone()),
+        ),
     }
 }
 
@@ -187,10 +189,10 @@ fn strings_from_list(id: &ResourceId, items: &[Value], field: &str) -> ProviderR
         .iter()
         .map(|v| match v {
             Value::String(s) => Ok(s.clone()),
-            _ => Err(
-                ProviderError::new(format!("cors_rule.{field} must be a list of strings"))
-                    .for_resource(id.clone()),
-            ),
+            _ => Err(ProviderError::invalid_input(format!(
+                "cors_rule.{field} must be a list of strings"
+            ))
+            .for_resource(id.clone())),
         })
         .collect()
 }

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -48,10 +48,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(
-                    ProviderError::new(sdk_error_message("Failed to get bucket encryption", &e))
-                        .for_resource(id.clone()),
-                )
+                Err(ProviderError::api_error(sdk_error_message(
+                    "Failed to get bucket encryption",
+                    &e,
+                ))
+                .for_resource(id.clone()))
             }
         }
     }
@@ -84,8 +85,10 @@ impl AwsProvider {
         let rules = match resource.get_attr("rules") {
             Some(Value::List(items)) => items,
             _ => {
-                return Err(ProviderError::new("rules is required and must be a list")
-                    .for_resource(id.clone()));
+                return Err(
+                    ProviderError::invalid_input("rules is required and must be a list")
+                        .for_resource(id.clone()),
+                );
             }
         };
 
@@ -98,7 +101,7 @@ impl AwsProvider {
             .set_rules(Some(sdk_rules))
             .build()
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to build server-side encryption configuration",
                     &e,
                 ))
@@ -112,7 +115,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket encryption", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put bucket encryption", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -142,7 +145,7 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to delete bucket encryption",
                 &e,
             ))
@@ -153,7 +156,9 @@ impl AwsProvider {
 
 fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ServerSideEncryptionRule> {
     let Value::Map(rule_map) = rule_value else {
-        return Err(ProviderError::new("each rule must be a map").for_resource(id.clone()));
+        return Err(
+            ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
+        );
     };
 
     let mut builder = ServerSideEncryptionRule::builder();
@@ -174,15 +179,17 @@ fn build_by_default(
     value: &Value,
 ) -> ProviderResult<ServerSideEncryptionByDefault> {
     let Value::Map(map) = value else {
-        return Err(
-            ProviderError::new("apply_server_side_encryption_by_default must be a map")
-                .for_resource(id.clone()),
-        );
+        return Err(ProviderError::invalid_input(
+            "apply_server_side_encryption_by_default must be a map",
+        )
+        .for_resource(id.clone()));
     };
     let algorithm_str = match map.get("sse_algorithm") {
         Some(Value::String(s)) => extract_enum_value(s).to_string(),
         _ => {
-            return Err(ProviderError::new("sse_algorithm is required").for_resource(id.clone()));
+            return Err(
+                ProviderError::invalid_input("sse_algorithm is required").for_resource(id.clone())
+            );
         }
     };
     let mut builder = ServerSideEncryptionByDefault::builder()
@@ -191,7 +198,7 @@ fn build_by_default(
         builder = builder.kms_master_key_id(k);
     }
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message(
+        ProviderError::api_error(sdk_error_message(
             "Failed to build apply_server_side_encryption_by_default",
             &e,
         ))

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -47,7 +47,7 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::new(sdk_error_message(
+                Err(ProviderError::api_error(sdk_error_message(
                     "Failed to get bucket lifecycle configuration",
                     &e,
                 ))
@@ -84,8 +84,10 @@ impl AwsProvider {
         let rules = match resource.get_attr("rules") {
             Some(Value::List(items)) => items,
             _ => {
-                return Err(ProviderError::new("rules is required and must be a list")
-                    .for_resource(id.clone()));
+                return Err(
+                    ProviderError::invalid_input("rules is required and must be a list")
+                        .for_resource(id.clone()),
+                );
             }
         };
 
@@ -98,7 +100,7 @@ impl AwsProvider {
             .set_rules(Some(sdk_rules))
             .build()
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to build BucketLifecycleConfiguration",
                     &e,
                 ))
@@ -112,7 +114,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to put bucket lifecycle configuration",
                     &e,
                 ))
@@ -143,7 +145,7 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to delete bucket lifecycle configuration",
                 &e,
             ))
@@ -154,13 +156,17 @@ impl AwsProvider {
 
 fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRule> {
     let Value::Map(map) = rule_value else {
-        return Err(ProviderError::new("each rule must be a map").for_resource(id.clone()));
+        return Err(
+            ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
+        );
     };
 
     let status_str = match map.get("status") {
         Some(Value::String(s)) => extract_enum_value(s).to_string(),
         _ => {
-            return Err(ProviderError::new("rule.status is required").for_resource(id.clone()));
+            return Err(
+                ProviderError::invalid_input("rule.status is required").for_resource(id.clone())
+            );
         }
     };
 
@@ -198,14 +204,16 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRu
     }
 
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message("Failed to build LifecycleRule", &e))
+        ProviderError::api_error(sdk_error_message("Failed to build LifecycleRule", &e))
             .for_resource(id.clone())
     })
 }
 
 fn build_expiration(id: &ResourceId, value: &Value) -> ProviderResult<LifecycleExpiration> {
     let Value::Map(map) = value else {
-        return Err(ProviderError::new("expiration must be a map").for_resource(id.clone()));
+        return Err(
+            ProviderError::invalid_input("expiration must be a map").for_resource(id.clone())
+        );
     };
     let mut builder = LifecycleExpiration::builder();
     if let Some(Value::Int(d)) = map.get("days") {
@@ -219,13 +227,16 @@ fn build_expiration(id: &ResourceId, value: &Value) -> ProviderResult<LifecycleE
 
 fn build_transition(id: &ResourceId, value: &Value) -> ProviderResult<Transition> {
     let Value::Map(map) = value else {
-        return Err(ProviderError::new("transition must be a map").for_resource(id.clone()));
+        return Err(
+            ProviderError::invalid_input("transition must be a map").for_resource(id.clone())
+        );
     };
     let storage_class_str = match map.get("storage_class") {
         Some(Value::String(s)) => extract_enum_value(s).to_string(),
         _ => {
             return Err(
-                ProviderError::new("transition.storage_class is required").for_resource(id.clone())
+                ProviderError::invalid_input("transition.storage_class is required")
+                    .for_resource(id.clone()),
             );
         }
     };
@@ -243,7 +254,7 @@ fn build_ncv_expiration(
 ) -> ProviderResult<NoncurrentVersionExpiration> {
     let Value::Map(map) = value else {
         return Err(
-            ProviderError::new("noncurrent_version_expiration must be a map")
+            ProviderError::invalid_input("noncurrent_version_expiration must be a map")
                 .for_resource(id.clone()),
         );
     };
@@ -263,14 +274,14 @@ fn build_ncv_transition(
 ) -> ProviderResult<NoncurrentVersionTransition> {
     let Value::Map(map) = value else {
         return Err(
-            ProviderError::new("noncurrent_version_transition must be a map")
+            ProviderError::invalid_input("noncurrent_version_transition must be a map")
                 .for_resource(id.clone()),
         );
     };
     let storage_class_str = match map.get("storage_class") {
         Some(Value::String(s)) => extract_enum_value(s).to_string(),
         _ => {
-            return Err(ProviderError::new(
+            return Err(ProviderError::invalid_input(
                 "noncurrent_version_transition.storage_class is required",
             )
             .for_resource(id.clone()));
@@ -292,10 +303,10 @@ fn build_abort_multipart(
     value: &Value,
 ) -> ProviderResult<AbortIncompleteMultipartUpload> {
     let Value::Map(map) = value else {
-        return Err(
-            ProviderError::new("abort_incomplete_multipart_upload must be a map")
-                .for_resource(id.clone()),
-        );
+        return Err(ProviderError::invalid_input(
+            "abort_incomplete_multipart_upload must be a map",
+        )
+        .for_resource(id.clone()));
     };
     let mut builder = AbortIncompleteMultipartUpload::builder();
     if let Some(Value::Int(d)) = map.get("days_after_initiation") {

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -57,7 +57,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::new(sdk_error_message("Failed to get bucket logging", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to get bucket logging", &e))
                         .for_resource(id.clone()),
                 )
             }
@@ -95,7 +95,8 @@ impl AwsProvider {
             None => String::new(),
             _ => {
                 return Err(
-                    ProviderError::new("target_prefix must be a string").for_resource(id.clone())
+                    ProviderError::invalid_input("target_prefix must be a string")
+                        .for_resource(id.clone()),
                 );
             }
         };
@@ -109,7 +110,7 @@ impl AwsProvider {
         }
 
         let le = le_builder.build().map_err(|e| {
-            ProviderError::new(sdk_error_message("Failed to build LoggingEnabled", &e))
+            ProviderError::api_error(sdk_error_message("Failed to build LoggingEnabled", &e))
                 .for_resource(id.clone())
         })?;
 
@@ -122,7 +123,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket logging", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put bucket logging", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -146,7 +147,7 @@ impl AwsProvider {
         match result {
             Ok(_) => Ok(()),
             Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to clear bucket logging",
                 &e,
             ))
@@ -158,7 +159,8 @@ impl AwsProvider {
 fn build_key_format(id: &ResourceId, value: &Value) -> ProviderResult<TargetObjectKeyFormat> {
     let Value::Map(map) = value else {
         return Err(
-            ProviderError::new("target_object_key_format must be a map").for_resource(id.clone())
+            ProviderError::invalid_input("target_object_key_format must be a map")
+                .for_resource(id.clone()),
         );
     };
 

--- a/carina-provider-aws/src/services/s3/bucket_notification.rs
+++ b/carina-provider-aws/src/services/s3/bucket_notification.rs
@@ -75,7 +75,7 @@ impl AwsProvider {
                 if is_s3_not_configured_error(&e, "NoSuchBucket") {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::new(sdk_error_message(
+                Err(ProviderError::api_error(sdk_error_message(
                     "Failed to get bucket notification configuration",
                     &e,
                 ))
@@ -162,7 +162,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to put bucket notification configuration",
                     &e,
                 ))
@@ -190,7 +190,7 @@ impl AwsProvider {
         match result {
             Ok(_) => Ok(()),
             Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to clear bucket notification configuration",
                 &e,
             ))
@@ -202,7 +202,8 @@ impl AwsProvider {
 fn build_topic(id: &ResourceId, value: &Value) -> ProviderResult<TopicConfiguration> {
     let Value::Map(map) = value else {
         return Err(
-            ProviderError::new("topic_configurations entry must be a map").for_resource(id.clone()),
+            ProviderError::invalid_input("topic_configurations entry must be a map")
+                .for_resource(id.clone()),
         );
     };
     let topic_arn = require_string_field(id, map, "topic_arn", "topic_configurations")?;
@@ -218,7 +219,7 @@ fn build_topic(id: &ResourceId, value: &Value) -> ProviderResult<TopicConfigurat
         builder = builder.filter(filter);
     }
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message("Failed to build TopicConfiguration", &e))
+        ProviderError::api_error(sdk_error_message("Failed to build TopicConfiguration", &e))
             .for_resource(id.clone())
     })
 }
@@ -226,7 +227,8 @@ fn build_topic(id: &ResourceId, value: &Value) -> ProviderResult<TopicConfigurat
 fn build_queue(id: &ResourceId, value: &Value) -> ProviderResult<QueueConfiguration> {
     let Value::Map(map) = value else {
         return Err(
-            ProviderError::new("queue_configurations entry must be a map").for_resource(id.clone()),
+            ProviderError::invalid_input("queue_configurations entry must be a map")
+                .for_resource(id.clone()),
         );
     };
     let queue_arn = require_string_field(id, map, "queue_arn", "queue_configurations")?;
@@ -242,17 +244,17 @@ fn build_queue(id: &ResourceId, value: &Value) -> ProviderResult<QueueConfigurat
         builder = builder.filter(filter);
     }
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message("Failed to build QueueConfiguration", &e))
+        ProviderError::api_error(sdk_error_message("Failed to build QueueConfiguration", &e))
             .for_resource(id.clone())
     })
 }
 
 fn build_lambda(id: &ResourceId, value: &Value) -> ProviderResult<LambdaFunctionConfiguration> {
     let Value::Map(map) = value else {
-        return Err(
-            ProviderError::new("lambda_function_configurations entry must be a map")
-                .for_resource(id.clone()),
-        );
+        return Err(ProviderError::invalid_input(
+            "lambda_function_configurations entry must be a map",
+        )
+        .for_resource(id.clone()));
     };
     let lambda_arn = require_string_field(
         id,
@@ -272,7 +274,7 @@ fn build_lambda(id: &ResourceId, value: &Value) -> ProviderResult<LambdaFunction
         builder = builder.filter(filter);
     }
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message(
+        ProviderError::api_error(sdk_error_message(
             "Failed to build LambdaFunctionConfiguration",
             &e,
         ))
@@ -288,10 +290,10 @@ fn require_string_field(
 ) -> ProviderResult<String> {
     match map.get(field) {
         Some(Value::String(s)) => Ok(s.clone()),
-        _ => {
-            Err(ProviderError::new(format!("{parent}.{field} is required"))
-                .for_resource(id.clone()))
-        }
+        _ => Err(
+            ProviderError::invalid_input(format!("{parent}.{field} is required"))
+                .for_resource(id.clone()),
+        ),
     }
 }
 
@@ -305,15 +307,16 @@ fn build_events(
             .iter()
             .map(|v| match v {
                 Value::String(s) => Ok(Event::from(s.as_str())),
-                _ => Err(
-                    ProviderError::new(format!("{parent}.events must be a list of strings"))
-                        .for_resource(id.clone()),
-                ),
+                _ => Err(ProviderError::invalid_input(format!(
+                    "{parent}.events must be a list of strings"
+                ))
+                .for_resource(id.clone())),
             })
             .collect(),
-        _ => {
-            Err(ProviderError::new(format!("{parent}.events is required")).for_resource(id.clone()))
-        }
+        _ => Err(
+            ProviderError::invalid_input(format!("{parent}.events is required"))
+                .for_resource(id.clone()),
+        ),
     }
 }
 
@@ -333,7 +336,7 @@ fn build_filter(
         .iter()
         .map(|v| {
             let Value::Map(rule_map) = v else {
-                return Err(ProviderError::new(format!(
+                return Err(ProviderError::invalid_input(format!(
                     "{parent}.filter.filter_rules entry must be a map"
                 ))
                 .for_resource(id.clone()));

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -46,7 +46,7 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::new(sdk_error_message(
+                Err(ProviderError::api_error(sdk_error_message(
                     "Failed to get bucket ownership controls",
                     &e,
                 ))
@@ -84,9 +84,8 @@ impl AwsProvider {
         let ownership_str = match resource.get_attr("object_ownership") {
             Some(Value::String(s)) => extract_enum_value(s).to_string(),
             _ => {
-                return Err(
-                    ProviderError::new("object_ownership is required").for_resource(id.clone())
-                );
+                return Err(ProviderError::invalid_input("object_ownership is required")
+                    .for_resource(id.clone()));
             }
         };
 
@@ -94,7 +93,7 @@ impl AwsProvider {
             .object_ownership(ObjectOwnership::from(ownership_str.as_str()))
             .build()
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to build OwnershipControlsRule",
                     &e,
                 ))
@@ -104,7 +103,7 @@ impl AwsProvider {
             .rules(rule)
             .build()
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to build OwnershipControls", &e))
+                ProviderError::api_error(sdk_error_message("Failed to build OwnershipControls", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -115,7 +114,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to put bucket ownership controls",
                     &e,
                 ))
@@ -146,7 +145,7 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to delete bucket ownership controls",
                 &e,
             ))

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -36,8 +36,11 @@ impl AwsProvider {
 
                 if let Some(policy_json) = output.policy() {
                     let policy_value = iam_policy_json_to_value(policy_json).map_err(|e| {
-                        ProviderError::new(format!("Failed to parse bucket policy: {}", e))
-                            .for_resource(id.clone())
+                        ProviderError::invalid_input(format!(
+                            "Failed to parse bucket policy: {}",
+                            e
+                        ))
+                        .for_resource(id.clone())
                     })?;
                     attributes.insert("policy".to_string(), policy_value);
                 }
@@ -49,7 +52,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::new(sdk_error_message("Failed to get bucket policy", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to get bucket policy", &e))
                         .for_resource(id.clone()),
                 )
             }
@@ -92,7 +95,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket policy", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put bucket policy", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -125,7 +128,7 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to delete bucket policy",
                 &e,
             ))

--- a/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
@@ -56,10 +56,11 @@ impl AwsProvider {
                 if is_s3_not_configured_error(&e, "NoSuchPublicAccessBlockConfiguration") {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(
-                    ProviderError::new(sdk_error_message("Failed to get public access block", &e))
-                        .for_resource(id.clone()),
-                )
+                Err(ProviderError::api_error(sdk_error_message(
+                    "Failed to get public access block",
+                    &e,
+                ))
+                .for_resource(id.clone()))
             }
         }
     }
@@ -112,7 +113,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put public access block", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put public access block", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -144,7 +145,7 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to delete public access block",
                 &e,
             ))

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -48,10 +48,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(
-                    ProviderError::new(sdk_error_message("Failed to get bucket replication", &e))
-                        .for_resource(id.clone()),
-                )
+                Err(ProviderError::api_error(sdk_error_message(
+                    "Failed to get bucket replication",
+                    &e,
+                ))
+                .for_resource(id.clone()))
             }
         }
     }
@@ -85,8 +86,10 @@ impl AwsProvider {
         let rules = match resource.get_attr("rules") {
             Some(Value::List(items)) => items,
             _ => {
-                return Err(ProviderError::new("rules is required and must be a list")
-                    .for_resource(id.clone()));
+                return Err(
+                    ProviderError::invalid_input("rules is required and must be a list")
+                        .for_resource(id.clone()),
+                );
             }
         };
 
@@ -100,7 +103,7 @@ impl AwsProvider {
             .set_rules(Some(sdk_rules))
             .build()
             .map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to build replication configuration",
                     &e,
                 ))
@@ -114,7 +117,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket replication", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put bucket replication", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -142,7 +145,7 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to delete bucket replication",
                 &e,
             ))
@@ -153,19 +156,24 @@ impl AwsProvider {
 
 fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ReplicationRule> {
     let Value::Map(map) = rule_value else {
-        return Err(ProviderError::new("each rule must be a map").for_resource(id.clone()));
+        return Err(
+            ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
+        );
     };
 
     let status_str = match map.get("status") {
         Some(Value::String(s)) => extract_enum_value(s).to_string(),
         _ => {
-            return Err(ProviderError::new("rule.status is required").for_resource(id.clone()));
+            return Err(
+                ProviderError::invalid_input("rule.status is required").for_resource(id.clone())
+            );
         }
     };
     let destination = match map.get("destination") {
         Some(v) => build_destination(id, v)?,
         None => {
-            return Err(ProviderError::new("rule.destination is required").for_resource(id.clone()));
+            return Err(ProviderError::invalid_input("rule.destination is required")
+                .for_resource(id.clone()));
         }
     };
 
@@ -187,20 +195,23 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<Replication
     }
 
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message("Failed to build ReplicationRule", &e))
+        ProviderError::api_error(sdk_error_message("Failed to build ReplicationRule", &e))
             .for_resource(id.clone())
     })
 }
 
 fn build_destination(id: &ResourceId, value: &Value) -> ProviderResult<Destination> {
     let Value::Map(map) = value else {
-        return Err(ProviderError::new("destination must be a map").for_resource(id.clone()));
+        return Err(
+            ProviderError::invalid_input("destination must be a map").for_resource(id.clone())
+        );
     };
     let bucket = match map.get("bucket") {
         Some(Value::String(s)) => s.clone(),
         _ => {
             return Err(
-                ProviderError::new("destination.bucket is required").for_resource(id.clone())
+                ProviderError::invalid_input("destination.bucket is required")
+                    .for_resource(id.clone()),
             );
         }
     };
@@ -213,7 +224,7 @@ fn build_destination(id: &ResourceId, value: &Value) -> ProviderResult<Destinati
         builder = builder.storage_class(StorageClass::from(normalized));
     }
     builder.build().map_err(|e| {
-        ProviderError::new(sdk_error_message("Failed to build Destination", &e))
+        ProviderError::api_error(sdk_error_message("Failed to build Destination", &e))
             .for_resource(id.clone())
     })
 }

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -54,10 +54,11 @@ impl AwsProvider {
                 if is_s3_not_configured_error(&e, "NoSuchBucket") {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(
-                    ProviderError::new(sdk_error_message("Failed to get bucket versioning", &e))
-                        .for_resource(id.clone()),
-                )
+                Err(ProviderError::api_error(sdk_error_message(
+                    "Failed to get bucket versioning",
+                    &e,
+                ))
+                .for_resource(id.clone()))
             }
         }
     }
@@ -90,7 +91,9 @@ impl AwsProvider {
         let status_str = match resource.get_attr("status") {
             Some(Value::String(s)) => extract_enum_value(s).to_string(),
             _ => {
-                return Err(ProviderError::new("status is required").for_resource(id.clone()));
+                return Err(
+                    ProviderError::invalid_input("status is required").for_resource(id.clone())
+                );
             }
         };
         let status = BucketVersioningStatus::from(status_str.as_str());
@@ -108,7 +111,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket versioning", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put bucket versioning", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -141,7 +144,7 @@ impl AwsProvider {
         match result {
             Ok(_) => Ok(()),
             Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to suspend bucket versioning",
                 &e,
             ))

--- a/carina-provider-aws/src/services/s3/bucket_website.rs
+++ b/carina-provider-aws/src/services/s3/bucket_website.rs
@@ -68,7 +68,7 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::new(sdk_error_message(
+                Err(ProviderError::api_error(sdk_error_message(
                     "Failed to get bucket website configuration",
                     &e,
                 ))
@@ -108,8 +108,10 @@ impl AwsProvider {
             let suffix = match map.get("suffix") {
                 Some(Value::String(s)) => s.clone(),
                 _ => {
-                    return Err(ProviderError::new("index_document.suffix is required")
-                        .for_resource(id.clone()));
+                    return Err(
+                        ProviderError::invalid_input("index_document.suffix is required")
+                            .for_resource(id.clone()),
+                    );
                 }
             };
             config_builder = config_builder.index_document(
@@ -117,8 +119,11 @@ impl AwsProvider {
                     .suffix(suffix)
                     .build()
                     .map_err(|e| {
-                        ProviderError::new(sdk_error_message("Failed to build IndexDocument", &e))
-                            .for_resource(id.clone())
+                        ProviderError::api_error(sdk_error_message(
+                            "Failed to build IndexDocument",
+                            &e,
+                        ))
+                        .for_resource(id.clone())
                     })?,
             );
         }
@@ -126,13 +131,15 @@ impl AwsProvider {
             let key = match map.get("key") {
                 Some(Value::String(s)) => s.clone(),
                 _ => {
-                    return Err(ProviderError::new("error_document.key is required")
-                        .for_resource(id.clone()));
+                    return Err(
+                        ProviderError::invalid_input("error_document.key is required")
+                            .for_resource(id.clone()),
+                    );
                 }
             };
             config_builder = config_builder.error_document(
                 ErrorDocument::builder().key(key).build().map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to build ErrorDocument", &e))
+                    ProviderError::api_error(sdk_error_message("Failed to build ErrorDocument", &e))
                         .for_resource(id.clone())
                 })?,
             );
@@ -141,7 +148,7 @@ impl AwsProvider {
             let host_name = match map.get("host_name") {
                 Some(Value::String(s)) => s.clone(),
                 _ => {
-                    return Err(ProviderError::new(
+                    return Err(ProviderError::invalid_input(
                         "redirect_all_requests_to.host_name is required",
                     )
                     .for_resource(id.clone()));
@@ -153,7 +160,7 @@ impl AwsProvider {
                 rb = rb.protocol(Protocol::from(normalized));
             }
             config_builder = config_builder.redirect_all_requests_to(rb.build().map_err(|e| {
-                ProviderError::new(sdk_error_message(
+                ProviderError::api_error(sdk_error_message(
                     "Failed to build RedirectAllRequestsTo",
                     &e,
                 ))
@@ -170,7 +177,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(sdk_error_message("Failed to put bucket website", &e))
+                ProviderError::api_error(sdk_error_message("Failed to put bucket website", &e))
                     .for_resource(id.clone())
             })?;
 
@@ -198,7 +205,7 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::new(sdk_error_message(
+            Err(e) => Err(ProviderError::api_error(sdk_error_message(
                 "Failed to delete bucket website",
                 &e,
             ))

--- a/carina-provider-aws/src/services/sts/caller_identity.rs
+++ b/carina-provider-aws/src/services/sts/caller_identity.rs
@@ -24,8 +24,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(sdk_error_message("Failed to get STS caller identity", &e))
-                        .for_resource(id.clone())
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to get STS caller identity",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
                 })?;
 
             let mut attributes = HashMap::new();


### PR DESCRIPTION
## Summary

Step 3a of meta tracker `carina-rs/carina#2564`. Adopts the Level 3
`Provider` trait shipped in `carina-rs/carina#2569` so the aws
provider compiles against post-Step-2 carina core.

This is a **pure signature-compatibility change with no behavior
change.** The aws provider does not yet take advantage of the
partial-update patch channel that Level 3 makes available — that
remains a future enhancement (per-resource update paths can adopt
it incrementally when the savings outweigh the porting cost).

The user-visible bug `carina-rs/carina#2559` is not directly fixed
here; the awscc Step 3b PR carries that fix. This PR's job is to
keep the aws provider building.

## Trait shape adopted

- `read(id, identifier: &str, request: ReadRequest)` — `identifier`
  is non-optional under Level 3; `ReadRequest` is unit-like today.
- `create(id, request: CreateRequest)` — extracts `request.resource`
  and forwards to the existing per-resource create methods.
- `update(id, identifier, request: UpdateRequest)` — reconstructs
  `to: Resource` from `(request.from, request.patch)` via a new
  `apply_patch_to_state` helper, then dispatches to the existing
  per-resource update methods. The aws provider's APIs are mostly
  full-replace style, so reusing existing methods unchanged is the
  simplest faithful translation.
- `delete(id, identifier, request: DeleteRequest)` — extracts
  `request.lifecycle`.

## `ProviderError::new` migration (304 sites)

Every call site is rewritten to a specific variant per the spec:

| Variant         | Count | Use                                          |
| --------------- | ----- | -------------------------------------------- |
| ` ` `api_error` ` `     |   229 | AWS SDK errors, AccessDenied, ` ` `X but no ID returned` ` `, retry exhaustion |
| ` ` `invalid_input` ` ` |    63 | ` ` `X is required` ` `, ` ` `must be` ` `, invalid identifiers, parse / convert failures |
| ` ` `internal` ` `      |    13 | Unknown resource type, schema-miss, serialize failures, ` ` `should not happen` ` ` |
| ` ` `not_found` ` `     |     2 | HeadBucket NotFound, security group rule lookup miss |
| ` ` `timeout` ` `       |     1 | ` ` `wait_for_ec2_state` ` ` poll-loop exhaustion    |

The 4 codegen template sites in `carina-codegen-aws/src/main.rs`
are also updated so regenerating `provider_generated.rs` produces
output consistent with the hand-edited variants.

`AwsProcessProvider::convert_error` (host-protocol bridge in
`main.rs`) maps the variant enum onto the new flat
`proto::ProviderError` shape (`kind` + flattened `cause`).
`AwsProviderFactory::create_provider` updates to the new
`BoxFuture<'_, ProviderResult<Box<dyn Provider>>>` return type.

## Dependency bumps

- `carina-plugin-wit` submodule: `940b966` → `1f8c4b9`
- `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol`
  git pins: `carina-rs/carina@f6d7aa6` (Step 2 merge).

## Test plan

- [x] `cargo nextest run --workspace` — 338 passed (337 pre-existing + 1 new for `apply_patch_to_state`)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — clean
- [x] Helper unit test covers Add / Replace / Remove patch-op kinds.

## Related

Closes carina-rs/carina-provider-aws#236
Refs carina-rs/carina#2564 (meta tracker)
Refs carina-rs/carina#2569 (Step 2)
Refs carina-rs/carina#2559 (user-visible bug — not fixed here; awscc Step 3b carries that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)