### PR TITLE
Adopt Option<&str> identifier in Provider::read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
+source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
 dependencies = [
  "argon2",
  "futures",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
+source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
+source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -192,7 +192,7 @@ impl CarinaProvider for AwsProcessProvider {
     fn read(
         &self,
         id: &proto::ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         _request: proto::ReadRequest,
     ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -18,11 +18,11 @@ impl Provider for AwsProvider {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
-        let identifier = Some(identifier.to_string());
+        let identifier = identifier.map(|s| s.to_string());
         Box::pin(async move {
             let mut state = match id.resource_type.as_str() {
                 "s3.Bucket" => self.read_s3_bucket(&id, identifier.as_deref()).await,


### PR DESCRIPTION
Closes #240.
Refs carina-rs/carina#2596.

Adopts the WIT + core trait migration that turned `Provider::read`'s `identifier` from `&str` to `Option<&str>`. Internally `AwsProvider::read` already wrapped the identifier as `Option<&str>` before dispatching to the per-resource handlers; this PR removes the `Some(identifier.to_string())` re-wrap at the trait boundary so the option flows straight through.

## Changes

- Bump `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` git pins to the post-migration commit, and the local `carina-aws-types` pin in lockstep.
- Bump the `carina-plugin-wit` submodule to the merged `option<string>` contract.
- `impl Provider for AwsProvider` (`provider.rs::read`) takes `Option<&str>`.
- WIT host glue (`main.rs::read`) accepts `Option<&str>` and forwards it unchanged.

## Test plan

- [x] `cargo nextest run --workspace`: 338 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)