### PR TITLE
provider: track WIT rename lifecycle-config to directives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
+source = "git+https://github.com/carina-rs/carina?rev=3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6#3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6"
 dependencies = [
  "argon2",
  "futures",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
+source = "git+https://github.com/carina-rs/carina?rev=3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6#3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
+source = "git+https://github.com/carina-rs/carina?rev=3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6#3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use carina_core::resource::{
-    LifecycleConfig as CoreLifecycle, Resource as CoreResource, ResourceId as CoreResourceId,
+    Directives as CoreDirectives, Resource as CoreResource, ResourceId as CoreResourceId,
     State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
@@ -17,7 +17,7 @@ use carina_core::schema::{
 };
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
-    LifecycleConfig as ProtoLifecycle, OperationConfig as ProtoOperationConfig,
+    Directives as ProtoDirectives, OperationConfig as ProtoOperationConfig,
     Resource as ProtoResource, ResourceId as ProtoResourceId,
     ResourceSchema as ProtoResourceSchema, SchemaKind as ProtoSchemaKind, State as ProtoState,
     StructField as ProtoStructField, Value as ProtoValue,
@@ -114,14 +114,14 @@ pub fn core_to_proto_resource(r: &CoreResource) -> ProtoResource {
     ProtoResource {
         id: core_to_proto_resource_id(&r.id),
         attributes: core_to_proto_value_map(&r.resolved_attributes()),
-        lifecycle: core_to_proto_lifecycle(&r.lifecycle),
+        directives: core_to_proto_directives(&r.directives),
     }
 }
 
-// -- LifecycleConfig --
+// -- Directives --
 
-pub fn core_to_proto_lifecycle(l: &CoreLifecycle) -> ProtoLifecycle {
-    ProtoLifecycle {
+pub fn core_to_proto_directives(l: &CoreDirectives) -> ProtoDirectives {
+    ProtoDirectives {
         force_delete: l.force_delete,
         create_before_destroy: l.create_before_destroy,
         prevent_destroy: l.prevent_destroy,
@@ -137,10 +137,10 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
         .iter()
         .map(|(k, v)| (k.clone(), proto_to_core_value(v)))
         .collect();
-    resource.lifecycle = CoreLifecycle {
-        force_delete: r.lifecycle.force_delete,
-        create_before_destroy: r.lifecycle.create_before_destroy,
-        prevent_destroy: r.lifecycle.prevent_destroy,
+    resource.directives = CoreDirectives {
+        force_delete: r.directives.force_delete,
+        create_before_destroy: r.directives.create_before_destroy,
+        prevent_destroy: r.directives.prevent_destroy,
     };
     resource
 }

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -160,7 +160,7 @@ fn is_retryable_error(error_msg: &str) -> bool {
 /// they always did.
 ///
 /// The returned `Resource` carries `from`'s `ResourceId` and an empty
-/// `LifecycleConfig` (lifecycle is delete-only and is not consulted on
+/// `Directives` (directives are delete-only and are not consulted on
 /// update paths in this provider).
 pub fn apply_patch_to_state(from: &State, patch: &UpdatePatch) -> Resource {
     let mut resource = Resource::new(from.id.resource_type.clone(), from.id.name.to_string());

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -282,13 +282,13 @@ impl CarinaProvider for AwsProcessProvider {
         request: proto::DeleteRequest,
     ) -> Result<(), proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
-        let core_lifecycle = carina_core::resource::LifecycleConfig {
-            force_delete: request.lifecycle.force_delete,
-            create_before_destroy: request.lifecycle.create_before_destroy,
-            prevent_destroy: request.lifecycle.prevent_destroy,
+        let core_directives = carina_core::resource::Directives {
+            force_delete: request.directives.force_delete,
+            create_before_destroy: request.directives.create_before_destroy,
+            prevent_destroy: request.directives.prevent_destroy,
         };
         let core_request = CoreDeleteRequest {
-            lifecycle: core_lifecycle,
+            directives: core_directives,
         };
         let result =
             self.runtime

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -410,10 +410,10 @@ impl Provider for AwsProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         let id = id.clone();
         let identifier = identifier.to_string();
-        let lifecycle = request.lifecycle;
+        let directives = request.directives;
         Box::pin(async move {
             match id.resource_type.as_str() {
-                "s3.Bucket" => self.delete_s3_bucket(id, &identifier, &lifecycle).await,
+                "s3.Bucket" => self.delete_s3_bucket(id, &identifier, &directives).await,
                 "s3.BucketPolicy" => {
                     self.delete_s3_bucket_policy_idempotent(id, &identifier)
                         .await

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
+use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
@@ -156,10 +156,10 @@ impl AwsProvider {
         &self,
         id: ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        directives: &Directives,
     ) -> ProviderResult<()> {
         // If force_delete is enabled, empty the bucket before deletion
-        if lifecycle.force_delete {
+        if directives.force_delete {
             self.empty_s3_bucket(&id, identifier).await?;
         }
 


### PR DESCRIPTION
## Summary

Track the WIT contract rename `lifecycle-config` → `directives` from carina-rs/carina-plugin-wit#13. This PR bumps the `carina-plugin-wit` submodule and the `carina-*` crate `rev` to point at the merged carina-rs/carina#2827, then renames the local Rust type aliases and the `Provider::delete` bridge.

## Scope

- Submodule `carina-plugin-wit` bumped to `eb29474` (wit#13).
- `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` crate `rev` bumped to `3ea08a6` (carina#2827).
- Type alias rename: `LifecycleConfig as CoreLifecycle` / `as ProtoLifecycle` → `Directives as CoreDirectives` / `as ProtoDirectives`.
- Helper rename: `core_to_proto_lifecycle` → `core_to_proto_directives`.
- `Provider::delete` bridge: `request.lifecycle` → `request.directives`, `DeleteRequest { lifecycle: ... }` → `DeleteRequest { directives: ... }`.
- `delete_s3_bucket` parameter and `force_delete` field access renamed accordingly.
- The S3 resource attribute name `LifecycleConfiguration` (e.g. `s3.BucketLifecycleConfiguration`) is unrelated to the Carina meta-block and is deliberately preserved.

## BREAKING CHANGE

This provider build is incompatible with carina hosts on the old WIT contract. Coordinated with carina#2827 (already merged).

## Test plan

- [x] `cargo nextest run --workspace` — 338 tests pass
- [x] `cargo test --workspace --doc` — doctests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] CI on PR

Refs carina-rs/carina#2826
Closes #245
