### PR TITLE
codegen: emit snake_case DSL aliases for every StringEnum (D7)

### DIFF
--- a/acceptance-tests/ec2_flow_log/basic.crn
+++ b/acceptance-tests/ec2_flow_log/basic.crn
@@ -47,8 +47,8 @@ let flow_log_role = aws.iam.Role {
 
 aws.ec2.FlowLog {
   resource_ids                = [vpc.vpc_id]
-  resource_type               = aws.ec2.FlowLog.ResourceType.VPC
-  traffic_type                = aws.ec2.FlowLog.TrafficType.ALL
+  resource_type               = aws.ec2.FlowLog.ResourceType.vpc
+  traffic_type                = aws.ec2.FlowLog.TrafficType.all
   log_destination_type        = aws.ec2.FlowLog.LogDestinationType.cloud_watch_logs
   log_group_name              = log_group.log_group_name
   deliver_logs_permission_arn = flow_log_role.arn

--- a/acceptance-tests/ec2_vpc_endpoint/basic.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/basic.crn
@@ -25,7 +25,7 @@ let rt = aws.ec2.RouteTable {
 aws.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
-  vpc_endpoint_type = aws.ec2.VpcEndpoint.VpcEndpointType.Gateway
+  vpc_endpoint_type = aws.ec2.VpcEndpoint.VpcEndpointType.gateway
   route_table_ids   = [rt.route_table_id]
 
   tags = {

--- a/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -16,5 +16,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = bucket.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
 }

--- a/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -17,5 +17,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = bucket.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Suspended
+  status = aws.s3.BucketVersioning.VersioningStatus.suspended
 }

--- a/acceptance-tests/s3_bucket_acl/basic.crn
+++ b/acceptance-tests/s3_bucket_acl/basic.crn
@@ -14,7 +14,7 @@ let bucket = aws.s3.Bucket {
 
 let ownership = aws.s3.BucketOwnershipControls {
   bucket           = bucket.bucket
-  object_ownership = aws.s3.BucketOwnershipControls.ObjectOwnership.BucketOwnerPreferred
+  object_ownership = aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_preferred
 }
 
 aws.s3.BucketAcl {

--- a/acceptance-tests/s3_bucket_lifecycle_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_lifecycle_configuration/basic.crn
@@ -18,11 +18,11 @@ aws.s3.BucketLifecycleConfiguration {
   rules = [
     {
       id     = 'transition-then-expire'
-      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.Enabled
+      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.enabled
       transitions = [
         {
           days          = 30
-          storage_class = aws.s3.BucketLifecycleConfiguration.TransitionStorageClass.STANDARD_IA
+          storage_class = aws.s3.BucketLifecycleConfiguration.TransitionStorageClass.standard_ia
         },
       ]
       expiration = {

--- a/acceptance-tests/s3_bucket_ownership_controls/basic.crn
+++ b/acceptance-tests/s3_bucket_ownership_controls/basic.crn
@@ -10,5 +10,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketOwnershipControls {
   bucket           = bucket.bucket
-  object_ownership = aws.s3.BucketOwnershipControls.ObjectOwnership.BucketOwnerEnforced
+  object_ownership = aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced
 }

--- a/acceptance-tests/s3_bucket_replication_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/basic.crn
@@ -14,7 +14,7 @@ let source = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = source.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
 }
 
 let dest = aws.s3.Bucket {
@@ -23,7 +23,7 @@ let dest = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = dest.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
 }
 
 let role = aws.iam.Role {
@@ -48,7 +48,7 @@ aws.s3.BucketReplicationConfiguration {
   rules = [
     {
       id     = 'replicate-all'
-      status = aws.s3.BucketReplicationConfiguration.ReplicationRuleStatus.Enabled
+      status = aws.s3.BucketReplicationConfiguration.ReplicationRuleStatus.enabled
       destination = {
         bucket = 'arn:aws:s3:::carina-acc-test-aws-s3-repl-dst-v1'
       }

--- a/acceptance-tests/s3_bucket_server_side_encryption_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_server_side_encryption_configuration/basic.crn
@@ -17,7 +17,7 @@ aws.s3.BucketServerSideEncryptionConfiguration {
   rules = [
     {
       apply_server_side_encryption_by_default = {
-        sse_algorithm = aws.s3.BucketServerSideEncryptionConfiguration.SseAlgorithm.AES256
+        sse_algorithm = aws.s3.BucketServerSideEncryptionConfiguration.SseAlgorithm.aes256
       }
       bucket_key_enabled = true
     },

--- a/acceptance-tests/s3_bucket_versioning/basic.crn
+++ b/acceptance-tests/s3_bucket_versioning/basic.crn
@@ -12,5 +12,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = bucket.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
 }

--- a/carina-codegen-aws/src/dsl.rs
+++ b/carina-codegen-aws/src/dsl.rs
@@ -1,0 +1,117 @@
+//! DSL-side spelling helpers for AWS provider codegen.
+//!
+//! Per the naming-conventions design (D7) in
+//! `carina-rs/carina/docs/specs/2026-04-22-naming-conventions-design.md`,
+//! every `StringEnum` value emitted by codegen must have a snake_case DSL
+//! spelling so the validator and generated docs agree with the project-wide
+//! convention.
+//!
+//! Sibling implementation: the awscc provider's
+//! `carina-provider-awscc/src/bin/codegen.rs::dsl_enum_value`. The two must
+//! stay behaviorally identical so the providers don't drift on what users
+//! type in their `.crn` files.
+//!
+//! Rules from D7:
+//! - Empty input passes through unchanged.
+//! - Numeric / dotted-numeric values (`"1"`, `"ipsec.1"`) pass through.
+//! - SHOUTY_SNAKE (`GROUP`, `AWS_ACCOUNT`, `AES256`) → lowercase.
+//! - Already lowercase / kebab (no uppercase letters) → `-` to `_`.
+//! - PascalCase / mixed (`Enabled`, `BucketOwnerEnforced`) → `to_snake_case`.
+
+use heck::ToSnakeCase;
+
+/// Convert an AWS API enum value to its DSL (snake_case) spelling.
+///
+/// See module-level docs for the full rules.
+pub fn dsl_enum_value(value: &str) -> String {
+    if value.is_empty() {
+        return String::new();
+    }
+
+    // Passthrough for already-numeric or dotted values (e.g. "ipsec.1", "1").
+    if value.chars().all(|c| c.is_ascii_digit() || c == '.') {
+        return value.to_string();
+    }
+
+    // SHOUTY_SNAKE: uppercase ASCII letters (+ underscores / digits), with at
+    // least one uppercase letter to distinguish from pure-digit strings.
+    if value
+        .chars()
+        .all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit())
+        && value.chars().any(|c| c.is_ascii_uppercase())
+    {
+        return value.to_ascii_lowercase();
+    }
+
+    // Already snake / kebab (no uppercase): just normalize hyphens.
+    if !value.chars().any(|c| c.is_ascii_uppercase()) {
+        return value.replace('-', "_");
+    }
+
+    // PascalCase or anything else mixed: route through heck's ToSnakeCase.
+    value.to_snake_case()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_passes_through() {
+        assert_eq!(dsl_enum_value(""), "");
+    }
+
+    #[test]
+    fn pure_digits_pass_through() {
+        assert_eq!(dsl_enum_value("1"), "1");
+        assert_eq!(dsl_enum_value("123"), "123");
+    }
+
+    #[test]
+    fn dotted_numeric_passes_through() {
+        // IPSec / IKE-style values that AWS APIs occasionally surface.
+        assert_eq!(dsl_enum_value("ipsec.1"), "ipsec.1");
+        assert_eq!(dsl_enum_value("1.0"), "1.0");
+    }
+
+    #[test]
+    fn shouty_snake_lowercases() {
+        assert_eq!(dsl_enum_value("GROUP"), "group");
+        assert_eq!(dsl_enum_value("AWS_ACCOUNT"), "aws_account");
+        assert_eq!(dsl_enum_value("AES256"), "aes256");
+        assert_eq!(dsl_enum_value("STANDARD_IA"), "standard_ia");
+        assert_eq!(dsl_enum_value("ALL"), "all");
+        assert_eq!(dsl_enum_value("VPC"), "vpc");
+    }
+
+    #[test]
+    fn already_snake_or_kebab_normalizes_hyphens() {
+        // ap-northeast-1 has digits, hyphens, lowercase only.
+        assert_eq!(dsl_enum_value("ap-northeast-1"), "ap_northeast_1");
+        assert_eq!(dsl_enum_value("already_snake"), "already_snake");
+        assert_eq!(dsl_enum_value("with-dashes"), "with_dashes");
+    }
+
+    #[test]
+    fn pascal_case_to_snake_case() {
+        assert_eq!(dsl_enum_value("Enabled"), "enabled");
+        assert_eq!(dsl_enum_value("Suspended"), "suspended");
+        assert_eq!(dsl_enum_value("VersioningStatus"), "versioning_status");
+        assert_eq!(
+            dsl_enum_value("BucketOwnerEnforced"),
+            "bucket_owner_enforced"
+        );
+        assert_eq!(dsl_enum_value("ObjectWriter"), "object_writer");
+        assert_eq!(dsl_enum_value("Gateway"), "gateway");
+    }
+
+    #[test]
+    fn route53_record_types_lowercase() {
+        // Pure SHOUTY abbreviations from RecordSet.Type.
+        assert_eq!(dsl_enum_value("A"), "a");
+        assert_eq!(dsl_enum_value("AAAA"), "aaaa");
+        assert_eq!(dsl_enum_value("CNAME"), "cname");
+        assert_eq!(dsl_enum_value("MX"), "mx");
+        assert_eq!(dsl_enum_value("TXT"), "txt");
+    }
+}

--- a/carina-codegen-aws/src/lib.rs
+++ b/carina-codegen-aws/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod dsl;
 pub mod resource_defs;

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -15,6 +15,7 @@ use carina_smithy::{ShapeKind, SmithyModel};
 use clap::Parser;
 use heck::ToSnakeCase;
 
+use carina_codegen_aws::dsl::dsl_enum_value;
 use carina_codegen_aws::resource_defs::{self, ResourceDef};
 
 #[derive(Parser, Debug)]
@@ -61,6 +62,53 @@ struct EnumInfo {
     type_name: String,
     /// Valid enum values (e.g., ["default", "dedicated", "host"])
     values: Vec<String>,
+}
+
+/// Build the `to_dsl: ...` code fragment for an enum attribute.
+///
+/// Per naming-conventions design D7, every `StringEnum` value must be
+/// addressable in snake_case from the DSL, with the API spelling preserved
+/// for the underlying SDK call. This helper emits a closure that maps each
+/// canonical (API) value to its DSL spelling, layering in any explicit
+/// aliases configured via `ResourceDef::enum_aliases`.
+///
+/// Returned source compiles into a `Some(|s: &str| match s { ... })`. We
+/// always return `Some(_)` (rather than `None`) when at least one value
+/// needs translation, because the validator's `matches_alias` path only
+/// fires when `to_dsl` is set.
+fn build_to_dsl_code(values: &[String], explicit_aliases: Option<&Vec<(&str, &str)>>) -> String {
+    // Collect (canonical, dsl_form) pairs. Explicit aliases take precedence
+    // over the auto-derived `dsl_enum_value` form.
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    let mut seen_canonical: HashSet<String> = HashSet::new();
+
+    if let Some(aliases) = explicit_aliases {
+        for (canonical, alias) in aliases {
+            if seen_canonical.insert(canonical.to_string()) {
+                pairs.push((canonical.to_string(), alias.to_string()));
+            }
+        }
+    }
+    for value in values {
+        if seen_canonical.insert(value.clone()) {
+            let dsl_form = dsl_enum_value(value);
+            if dsl_form != *value {
+                pairs.push((value.clone(), dsl_form));
+            }
+        }
+    }
+
+    if pairs.is_empty() {
+        // No translation needed; passthrough fallback would be a no-op.
+        return "None".to_string();
+    }
+
+    let mut match_arms: Vec<String> = pairs
+        .iter()
+        .map(|(canonical, dsl)| format!("\"{}\" => \"{}\".to_string()", canonical, dsl))
+        .collect();
+    match_arms.push("_ => s.to_string()".to_string());
+    format!("Some(|s: &str| match s {{ {} }})", match_arms.join(", "))
 }
 
 /// Information about an attribute to generate
@@ -776,20 +824,34 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     ));
 
     // Generate enum constants.
+    //
+    // The constant lists every spelling the validator must accept: the
+    // canonical AWS values, any explicit aliases, and the auto-derived
+    // snake_case DSL aliases (D7). Listing both forms keeps callers that
+    // walk `enum_valid_values()` (e.g. legacy reflection paths) consistent
+    // with what `to_dsl` already accepts at runtime.
     for (prop_name, enum_info) in &all_enums {
         let const_name = format!("VALID_{}", prop_name.to_snake_case().to_uppercase());
 
-        // Generate constant
         let mut all_values: Vec<String> = enum_info
             .values
             .iter()
             .map(|v| format!("\"{}\"", v))
             .collect();
-        // Add alias values (avoiding duplicates)
         let snake = prop_name.to_snake_case();
         if let Some(aliases) = enum_alias_map.get(snake.as_str()) {
             for (_, alias) in aliases {
                 let formatted = format!("\"{}\"", alias);
+                if !all_values.contains(&formatted) {
+                    all_values.push(formatted);
+                }
+            }
+        }
+        // Auto-derived snake_case DSL aliases per D7.
+        for value in &enum_info.values {
+            let dsl_form = dsl_enum_value(value);
+            if dsl_form != *value {
+                let formatted = format!("\"{}\"", dsl_form);
                 if !all_values.contains(&formatted) {
                     all_values.push(formatted);
                 }
@@ -866,31 +928,19 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     for attr in &attrs {
         let type_code = if let Some(ref ei) = attr.enum_info {
             // Use shared schema enum type for constrained strings.
+            //
+            // Per naming-conventions design D7, every enum value gets a
+            // snake_case DSL alias. `build_to_dsl_code` derives the per-value
+            // mapping from `dsl_enum_value()` and layers in explicit aliases
+            // from `ResourceDef::enum_aliases`. Explicit `to_dsl_overrides`
+            // wins over both.
             let to_dsl_code =
                 if let Some(override_code) = to_dsl_overrides.get(attr.snake_name.as_str()) {
                     override_code.to_string()
                 } else {
-                    let has_hyphens = ei.values.iter().any(|v| v.contains('-'));
                     let snake = attr.provider_name.to_snake_case();
-                    if let Some(aliases) = enum_alias_map.get(snake.as_str()) {
-                        let mut match_arms: Vec<String> = aliases
-                            .iter()
-                            .map(|(canonical, alias)| {
-                                format!("\"{}\" => \"{}\".to_string()", canonical, alias)
-                            })
-                            .collect();
-                        let fallback = if has_hyphens {
-                            "_ => s.replace('-', \"_\")"
-                        } else {
-                            "_ => s.to_string()"
-                        };
-                        match_arms.push(fallback.to_string());
-                        format!("Some(|s: &str| match s {{ {} }})", match_arms.join(", "))
-                    } else if has_hyphens {
-                        "Some(|s: &str| s.replace('-', \"_\"))".to_string()
-                    } else {
-                        "None".to_string()
-                    }
+                    let explicit = enum_alias_map.get(snake.as_str());
+                    build_to_dsl_code(&ei.values, explicit)
                 };
             let values_str = ei
                 .values
@@ -1006,15 +1056,18 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         }
     }
 
-    // Add to_dsl reverse mappings for values containing hyphens.
+    // Add auto-derived DSL aliases for every enum value.
+    //
+    // Per naming-conventions design D7, the DSL spelling is the snake_case
+    // form of the API value (`Enabled` → `enabled`, `BucketOwnerEnforced` →
+    // `bucket_owner_enforced`, etc.). The runtime uses these entries to
+    // rewrite SDK responses into DSL-flavored values for state diffing.
     for (prop_name, enum_info) in &all_enums {
         let attr_name = prop_name.to_snake_case();
         for value in &enum_info.values {
-            if value.contains('-') {
-                let dsl_form = value.replace('-', "_");
-                if dsl_form != *value && seen.insert((attr_name.clone(), dsl_form.clone())) {
-                    alias_entries.push((attr_name.clone(), dsl_form, value.clone()));
-                }
+            let dsl_form = dsl_enum_value(value);
+            if dsl_form != *value && seen.insert((attr_name.clone(), dsl_form.clone())) {
+                alias_entries.push((attr_name.clone(), dsl_form, value.clone()));
             }
         }
     }
@@ -1237,30 +1290,15 @@ fn generate_struct_type(
 
         // If enum detected, use shared schema enum type.
         let field_type = if let Some(ei) = enum_info {
+            // Same D7 rule as the top-level enum attribute path: derive a
+            // snake_case DSL alias for every API value, layer in explicit
+            // aliases, and let `to_dsl_overrides` take precedence over both.
             let to_dsl_code =
                 if let Some(override_code) = ctx.to_dsl_overrides.get(snake_name.as_str()) {
                     override_code.to_string()
                 } else {
-                    let has_hyphens = ei.values.iter().any(|v| v.contains('-'));
-                    if let Some(aliases) = ctx.enum_alias_map.get(snake_name.as_str()) {
-                        let mut match_arms: Vec<String> = aliases
-                            .iter()
-                            .map(|(canonical, alias)| {
-                                format!("\"{}\" => \"{}\".to_string()", canonical, alias)
-                            })
-                            .collect();
-                        let fallback = if has_hyphens {
-                            "_ => s.replace('-', \"_\")"
-                        } else {
-                            "_ => s.to_string()"
-                        };
-                        match_arms.push(fallback.to_string());
-                        format!("Some(|s: &str| match s {{ {} }})", match_arms.join(", "))
-                    } else if has_hyphens {
-                        "Some(|s: &str| s.replace('-', \"_\"))".to_string()
-                    } else {
-                        "None".to_string()
-                    }
+                    let explicit = ctx.enum_alias_map.get(snake_name.as_str());
+                    build_to_dsl_code(&ei.values, explicit)
                 };
             let values_str = ei
                 .values
@@ -3004,51 +3042,40 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
     }
 
     // Enum Values section
+    //
+    // Per naming-conventions design D7, the documented "DSL Identifier" and
+    // "Shorthand formats" use the snake_case spelling. Explicit aliases in
+    // `ResourceDef::enum_aliases` win over the auto-derived form so that
+    // existing documented overrides (e.g. `IpProtocol.all` for `-1`) keep
+    // their intentional spelling.
     if !all_enums.is_empty() {
         md.push_str("## Enum Values\n\n");
         for (prop_name, enum_info) in &all_enums {
             let attr_name = prop_name.to_snake_case();
-            let has_hyphens = enum_info.values.iter().any(|v| v.contains('-'));
             let prop_aliases = enum_alias_map.get(attr_name.as_str());
+
+            let dsl_for = |value: &str| -> String {
+                if let Some(alias_list) = prop_aliases
+                    && let Some((_, alias)) = alias_list.iter().find(|(c, _)| *c == value)
+                {
+                    return alias.to_string();
+                }
+                dsl_enum_value(value)
+            };
 
             md.push_str(&format!("### {} ({})\n\n", attr_name, enum_info.type_name));
             md.push_str("| Value | DSL Identifier |\n");
             md.push_str("|-------|----------------|\n");
 
             for value in &enum_info.values {
-                let dsl_value = if let Some(alias_list) = prop_aliases {
-                    if let Some((_, alias)) = alias_list.iter().find(|(c, _)| *c == value.as_str())
-                    {
-                        alias.to_string()
-                    } else if has_hyphens {
-                        value.replace('-', "_")
-                    } else {
-                        value.clone()
-                    }
-                } else if has_hyphens {
-                    value.replace('-', "_")
-                } else {
-                    value.clone()
-                };
+                let dsl_value = dsl_for(value);
                 let dsl_id = format!("{}.{}.{}", namespace, enum_info.type_name, dsl_value);
                 md.push_str(&format!("| `{}` | `{}` |\n", value, dsl_id));
             }
             md.push('\n');
 
             let first_value = enum_info.values.first().map(|s| s.as_str()).unwrap_or("");
-            let first_dsl = if let Some(alias_list) = prop_aliases {
-                if let Some((_, alias)) = alias_list.iter().find(|(c, _)| *c == first_value) {
-                    alias.to_string()
-                } else if has_hyphens {
-                    first_value.replace('-', "_")
-                } else {
-                    first_value.to_string()
-                }
-            } else if has_hyphens {
-                first_value.replace('-', "_")
-            } else {
-                first_value.to_string()
-            };
+            let first_dsl = dsl_for(first_value);
             md.push_str(&format!(
                 "Shorthand formats: `{}` or `{}.{}`\n\n",
                 first_dsl, enum_info.type_name, first_dsl,
@@ -4115,6 +4142,79 @@ mod tests {
         assert!(md.contains("### `account_id`"), "{md}");
         assert!(md.contains("### `arn`"), "{md}");
         assert!(md.contains("### `user_id`"), "{md}");
+    }
+
+    /// Per naming-conventions design D7 the codegen must emit a `to_dsl`
+    /// closure for every `StringEnum`, not just the hyphen-only case.
+    /// route53.RecordSet's Type enum (`A`, `AAAA`, `CNAME`, ...) is the
+    /// canonical SHOUTY-snake case: each value gets a snake_case alias
+    /// (`a`, `aaaa`, `cname`) so users can write `aws.route53.RecordSet.Type.a`.
+    #[test]
+    fn generate_resource_emits_to_dsl_and_alias_entries_for_pascal_enum() {
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../carina-provider-aws/tests/fixtures/smithy/route53.json");
+        if !fixture.exists() {
+            eprintln!(
+                "Skipping: Smithy fixture not found: {}\nRun scripts/download-smithy-models.sh to enable this test",
+                fixture.display()
+            );
+            return;
+        }
+        let file = std::fs::File::open(&fixture).expect("failed to open route53 fixture");
+        let model = carina_smithy::parse_reader(std::io::BufReader::new(file))
+            .expect("failed to parse route53 fixture");
+        let resource = resource_defs::route53_resources()
+            .into_iter()
+            .find(|res| res.name == "route53.RecordSet")
+            .expect("missing route53.RecordSet resource def");
+
+        let generated = generate_resource(&resource, &model).expect("failed to generate resource");
+
+        // The validator's allow-list (VALID_TYPE) must include both API
+        // and DSL spellings so reflection paths see both forms.
+        assert!(
+            generated.contains("\"A\"") && generated.contains("\"a\""),
+            "VALID_TYPE should list both API and DSL spellings: {generated}"
+        );
+        // The StringEnum's `to_dsl` must be a closure mapping API → DSL,
+        // not the previous `None`.
+        assert!(
+            generated.contains("\"A\" => \"a\".to_string()"),
+            "to_dsl should map A -> a: {generated}"
+        );
+        assert!(
+            generated.contains("\"CNAME\" => \"cname\".to_string()"),
+            "to_dsl should map CNAME -> cname: {generated}"
+        );
+        // The runtime alias table must include the same pairs so state
+        // normalization rewrites SDK responses into DSL spellings.
+        assert!(
+            generated.contains("(\"type\", \"a\") => Some(\"A\")"),
+            "enum_alias_reverse should map (type, a) -> A: {generated}"
+        );
+        assert!(
+            generated.contains("(\"type\", \"cname\", \"CNAME\")"),
+            "enum_alias_entries should include (type, cname, CNAME): {generated}"
+        );
+    }
+
+    /// PascalCase mixed-case enums (e.g. `BucketOwnerEnforced`) must also
+    /// produce `bucket_owner_enforced` aliases. Exercises s3.Bucket's
+    /// ObjectOwnership-style enum if available, falling back to a check
+    /// that the codegen at least emits `to_dsl` rather than `None` for
+    /// PascalCase values.
+    #[test]
+    fn generate_resource_to_dsl_handles_pascal_case_mixed() {
+        // Use the dsl helper directly so the assertion does not depend on
+        // a specific Smithy fixture being present.
+        use carina_codegen_aws::dsl::dsl_enum_value;
+        assert_eq!(
+            dsl_enum_value("BucketOwnerEnforced"),
+            "bucket_owner_enforced"
+        );
+        assert_eq!(dsl_enum_value("VersioningStatus"), "versioning_status");
+        assert_eq!(dsl_enum_value("Enabled"), "enabled");
+        assert_eq!(dsl_enum_value("AES256"), "aes256");
     }
 
     #[test]

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -9,7 +9,13 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-const VALID_LOG_DESTINATION_TYPE: &[&str] = &["cloud-watch-logs", "kinesis-data-firehose", "s3"];
+const VALID_LOG_DESTINATION_TYPE: &[&str] = &[
+    "cloud-watch-logs",
+    "kinesis-data-firehose",
+    "s3",
+    "cloud_watch_logs",
+    "kinesis_data_firehose",
+];
 
 const VALID_RESOURCE_TYPE: &[&str] = &[
     "NetworkInterface",
@@ -18,9 +24,15 @@ const VALID_RESOURCE_TYPE: &[&str] = &[
     "TransitGateway",
     "TransitGatewayAttachment",
     "VPC",
+    "network_interface",
+    "regional_nat_gateway",
+    "subnet",
+    "transit_gateway",
+    "transit_gateway_attachment",
+    "vpc",
 ];
 
-const VALID_TRAFFIC_TYPE: &[&str] = &["ACCEPT", "ALL", "REJECT"];
+const VALID_TRAFFIC_TYPE: &[&str] = &["ACCEPT", "ALL", "REJECT", "accept", "all", "reject"];
 
 /// Returns the schema config for ec2.FlowLog (Smithy: com.amazonaws.ec2)
 pub fn ec2_flow_log_config() -> AwsSchemaConfig {
@@ -83,7 +95,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
                 name: "ResourceType".to_string(),
                 values: vec!["NetworkInterface".to_string(), "RegionalNatGateway".to_string(), "Subnet".to_string(), "TransitGateway".to_string(), "TransitGatewayAttachment".to_string(), "VPC".to_string()],
                 namespace: Some("aws.ec2.FlowLog".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "NetworkInterface" => "network_interface".to_string(), "RegionalNatGateway" => "regional_nat_gateway".to_string(), "Subnet" => "subnet".to_string(), "TransitGateway" => "transit_gateway".to_string(), "TransitGatewayAttachment" => "transit_gateway_attachment".to_string(), "VPC" => "vpc".to_string(), _ => s.to_string() }),
             })
                 .required()
                 .create_only()
@@ -95,7 +107,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
                 name: "TrafficType".to_string(),
                 values: vec!["ACCEPT".to_string(), "ALL".to_string(), "REJECT".to_string()],
                 namespace: Some("aws.ec2.FlowLog".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "ACCEPT" => "accept".to_string(), "ALL" => "all".to_string(), "REJECT" => "reject".to_string(), _ => s.to_string() }),
             })
                 .create_only()
                 .with_description("The type of traffic to monitor (accepted traffic, rejected traffic, or all traffic). This parameter is not supported for transit gateway resource type...")
@@ -136,6 +148,15 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     match (attr_name, value) {
         ("log_destination_type", "cloud_watch_logs") => Some("cloud-watch-logs"),
         ("log_destination_type", "kinesis_data_firehose") => Some("kinesis-data-firehose"),
+        ("resource_type", "network_interface") => Some("NetworkInterface"),
+        ("resource_type", "regional_nat_gateway") => Some("RegionalNatGateway"),
+        ("resource_type", "subnet") => Some("Subnet"),
+        ("resource_type", "transit_gateway") => Some("TransitGateway"),
+        ("resource_type", "transit_gateway_attachment") => Some("TransitGatewayAttachment"),
+        ("resource_type", "vpc") => Some("VPC"),
+        ("traffic_type", "accept") => Some("ACCEPT"),
+        ("traffic_type", "all") => Some("ALL"),
+        ("traffic_type", "reject") => Some("REJECT"),
         _ => None,
     }
 }
@@ -153,5 +174,22 @@ pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static s
             "kinesis_data_firehose",
             "kinesis-data-firehose",
         ),
+        ("resource_type", "network_interface", "NetworkInterface"),
+        (
+            "resource_type",
+            "regional_nat_gateway",
+            "RegionalNatGateway",
+        ),
+        ("resource_type", "subnet", "Subnet"),
+        ("resource_type", "transit_gateway", "TransitGateway"),
+        (
+            "resource_type",
+            "transit_gateway_attachment",
+            "TransitGatewayAttachment",
+        ),
+        ("resource_type", "vpc", "VPC"),
+        ("traffic_type", "accept", "ACCEPT"),
+        ("traffic_type", "all", "ALL"),
+        ("traffic_type", "reject", "REJECT"),
     ]
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -10,7 +10,7 @@ use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
 
-const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
+const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all", "_1"];
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {
     if let Value::Int(n) = value {

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -10,7 +10,7 @@ use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
 
-const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
+const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all", "_1"];
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {
     if let Value::Int(n) = value {

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -12,7 +12,7 @@ use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator, types,
 };
 
-const VALID_HOSTNAME_TYPE: &[&str] = &["ip-name", "resource-name"];
+const VALID_HOSTNAME_TYPE: &[&str] = &["ip-name", "resource-name", "ip_name", "resource_name"];
 
 fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
     if let Value::Int(n) = value {
@@ -152,7 +152,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 name: "HostnameType".to_string(),
                 values: vec!["ip-name".to_string(), "resource-name".to_string()],
                 namespace: Some("aws.ec2.Subnet".to_string()),
-                to_dsl: Some(|s: &str| s.replace('-', "_")),
+                to_dsl: Some(|s: &str| match s { "ip-name" => "ip_name".to_string(), "resource-name" => "resource_name".to_string(), _ => s.to_string() }),
             }).with_description("The type of hostname for EC2 instances. For IPv4 only subnets, an instance DNS name must be based on the instance IPv4 address. For IPv6 only subnets,...").with_provider_name("HostnameType")
                     ],
                 })

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -15,6 +15,11 @@ const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
     "Interface",
     "Resource",
     "ServiceNetwork",
+    "gateway",
+    "gateway_load_balancer",
+    "interface",
+    "resource",
+    "service_network",
 ];
 
 /// Returns the schema config for ec2.VpcEndpoint (Smithy: com.amazonaws.ec2)
@@ -83,7 +88,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsSchemaConfig {
                 name: "VpcEndpointType".to_string(),
                 values: vec!["Gateway".to_string(), "GatewayLoadBalancer".to_string(), "Interface".to_string(), "Resource".to_string(), "ServiceNetwork".to_string()],
                 namespace: Some("aws.ec2.VpcEndpoint".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "Gateway" => "gateway".to_string(), "GatewayLoadBalancer" => "gateway_load_balancer".to_string(), "Interface" => "interface".to_string(), "Resource" => "resource".to_string(), "ServiceNetwork" => "service_network".to_string(), _ => s.to_string() }),
             })
                 .create_only()
                 .with_description("The type of endpoint. Default: Gateway")
@@ -124,11 +129,27 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("vpc_endpoint_type", "gateway") => Some("Gateway"),
+        ("vpc_endpoint_type", "gateway_load_balancer") => Some("GatewayLoadBalancer"),
+        ("vpc_endpoint_type", "interface") => Some("Interface"),
+        ("vpc_endpoint_type", "resource") => Some("Resource"),
+        ("vpc_endpoint_type", "service_network") => Some("ServiceNetwork"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("vpc_endpoint_type", "gateway", "Gateway"),
+        (
+            "vpc_endpoint_type",
+            "gateway_load_balancer",
+            "GatewayLoadBalancer",
+        ),
+        ("vpc_endpoint_type", "interface", "Interface"),
+        ("vpc_endpoint_type", "resource", "Resource"),
+        ("vpc_endpoint_type", "service_network", "ServiceNetwork"),
+    ]
 }

--- a/carina-provider-aws/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-aws/src/schemas/generated/logs/log_group.rs
@@ -9,7 +9,14 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-const VALID_LOG_GROUP_CLASS: &[&str] = &["DELIVERY", "INFREQUENT_ACCESS", "STANDARD"];
+const VALID_LOG_GROUP_CLASS: &[&str] = &[
+    "DELIVERY",
+    "INFREQUENT_ACCESS",
+    "STANDARD",
+    "delivery",
+    "infrequent_access",
+    "standard",
+];
 
 /// Returns the schema config for logs.LogGroup (Smithy: com.amazonaws.cloudwatchlogs)
 pub fn logs_log_group_config() -> AwsSchemaConfig {
@@ -36,7 +43,7 @@ pub fn logs_log_group_config() -> AwsSchemaConfig {
                 name: "LogGroupClass".to_string(),
                 values: vec!["DELIVERY".to_string(), "INFREQUENT_ACCESS".to_string(), "STANDARD".to_string()],
                 namespace: Some("aws.logs.LogGroup".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "DELIVERY" => "delivery".to_string(), "INFREQUENT_ACCESS" => "infrequent_access".to_string(), "STANDARD" => "standard".to_string(), _ => s.to_string() }),
             })
                 .create_only()
                 .with_description("Use this parameter to specify the log group class for this log group. There are three classes: The Standard log class supports all CloudWatch Logs fea...")
@@ -83,11 +90,19 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("log_group_class", "delivery") => Some("DELIVERY"),
+        ("log_group_class", "infrequent_access") => Some("INFREQUENT_ACCESS"),
+        ("log_group_class", "standard") => Some("STANDARD"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("log_group_class", "delivery", "DELIVERY"),
+        ("log_group_class", "infrequent_access", "INFREQUENT_ACCESS"),
+        ("log_group_class", "standard", "STANDARD"),
+    ]
 }

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -9,11 +9,18 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
-const VALID_IAM_USER_ACCESS_TO_BILLING: &[&str] = &["ALLOW", "DENY"];
+const VALID_IAM_USER_ACCESS_TO_BILLING: &[&str] = &["ALLOW", "DENY", "allow", "deny"];
 
-const VALID_JOINED_METHOD: &[&str] = &["CREATED", "INVITED"];
+const VALID_JOINED_METHOD: &[&str] = &["CREATED", "INVITED", "created", "invited"];
 
-const VALID_STATUS: &[&str] = &["ACTIVE", "PENDING_CLOSURE", "SUSPENDED"];
+const VALID_STATUS: &[&str] = &[
+    "ACTIVE",
+    "PENDING_CLOSURE",
+    "SUSPENDED",
+    "active",
+    "pending_closure",
+    "suspended",
+];
 
 /// Returns the schema config for organizations.Account (Smithy: com.amazonaws.organizations)
 pub fn organizations_account_config() -> AwsSchemaConfig {
@@ -42,7 +49,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
                 name: "IamUserAccessToBilling".to_string(),
                 values: vec!["ALLOW".to_string(), "DENY".to_string()],
                 namespace: Some("aws.organizations.Account".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "ALLOW" => "allow".to_string(), "DENY" => "deny".to_string(), _ => s.to_string() }),
             })
                 .create_only()
                 .with_description("If set to ALLOW, the new account enables IAM users to access account billing information if they have the required permissions. If set to DENY, only t...")
@@ -69,7 +76,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
                 name: "JoinedMethod".to_string(),
                 values: vec!["CREATED".to_string(), "INVITED".to_string()],
                 namespace: Some("aws.organizations.Account".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "CREATED" => "created".to_string(), "INVITED" => "invited".to_string(), _ => s.to_string() }),
             })
                 .with_description("The method by which the account joined the organization. (read-only)")
                 .with_provider_name("JoinedMethod"),
@@ -89,7 +96,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
                 name: "Status".to_string(),
                 values: vec!["ACTIVE".to_string(), "PENDING_CLOSURE".to_string(), "SUSPENDED".to_string()],
                 namespace: Some("aws.organizations.Account".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "ACTIVE" => "active".to_string(), "PENDING_CLOSURE" => "pending_closure".to_string(), "SUSPENDED" => "suspended".to_string(), _ => s.to_string() }),
             })
                 .with_description("The status of the account in the organization. The Status parameter in the Account object will be retired on September 9, 2026. Although both the acco... (read-only)")
                 .with_provider_name("Status"),
@@ -124,11 +131,27 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("iam_user_access_to_billing", "allow") => Some("ALLOW"),
+        ("iam_user_access_to_billing", "deny") => Some("DENY"),
+        ("joined_method", "created") => Some("CREATED"),
+        ("joined_method", "invited") => Some("INVITED"),
+        ("status", "active") => Some("ACTIVE"),
+        ("status", "pending_closure") => Some("PENDING_CLOSURE"),
+        ("status", "suspended") => Some("SUSPENDED"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("iam_user_access_to_billing", "allow", "ALLOW"),
+        ("iam_user_access_to_billing", "deny", "DENY"),
+        ("joined_method", "created", "CREATED"),
+        ("joined_method", "invited", "INVITED"),
+        ("status", "active", "ACTIVE"),
+        ("status", "pending_closure", "PENDING_CLOSURE"),
+        ("status", "suspended", "SUSPENDED"),
+    ]
 }

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
-const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING"];
+const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING", "all", "consolidated_billing"];
 
 /// Returns the schema config for organizations.Organization (Smithy: com.amazonaws.organizations)
 pub fn organizations_organization_config() -> AwsSchemaConfig {
@@ -22,7 +22,7 @@ pub fn organizations_organization_config() -> AwsSchemaConfig {
                 name: "FeatureSet".to_string(),
                 values: vec!["ALL".to_string(), "CONSOLIDATED_BILLING".to_string()],
                 namespace: Some("aws.organizations.Organization".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "ALL" => "all".to_string(), "CONSOLIDATED_BILLING" => "consolidated_billing".to_string(), _ => s.to_string() }),
             })
                 .create_only()
                 .with_description("Specifies the feature set supported by the new organization. Each feature set supports different levels of functionality. CONSOLIDATED_BILLING: All me...")
@@ -70,11 +70,21 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("feature_set", "all") => Some("ALL"),
+        ("feature_set", "consolidated_billing") => Some("CONSOLIDATED_BILLING"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("feature_set", "all", "ALL"),
+        (
+            "feature_set",
+            "consolidated_billing",
+            "CONSOLIDATED_BILLING",
+        ),
+    ]
 }

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -12,7 +12,8 @@ use carina_core::schema::{
 
 const VALID_TYPE: &[&str] = &[
     "A", "AAAA", "CAA", "CNAME", "DS", "HTTPS", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF", "SRV",
-    "SSHFP", "SVCB", "TLSA", "TXT",
+    "SSHFP", "SVCB", "TLSA", "TXT", "a", "aaaa", "caa", "cname", "ds", "https", "mx", "naptr",
+    "ns", "ptr", "soa", "spf", "srv", "sshfp", "svcb", "tlsa", "txt",
 ];
 
 fn validate_ttl_range(value: &Value) -> Result<(), String> {
@@ -77,7 +78,7 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
                 name: "Type".to_string(),
                 values: vec!["A".to_string(), "AAAA".to_string(), "CAA".to_string(), "CNAME".to_string(), "DS".to_string(), "HTTPS".to_string(), "MX".to_string(), "NAPTR".to_string(), "NS".to_string(), "PTR".to_string(), "SOA".to_string(), "SPF".to_string(), "SRV".to_string(), "SSHFP".to_string(), "SVCB".to_string(), "TLSA".to_string(), "TXT".to_string()],
                 namespace: Some("aws.route53.RecordSet".to_string()),
-                to_dsl: None,
+                to_dsl: Some(|s: &str| match s { "A" => "a".to_string(), "AAAA" => "aaaa".to_string(), "CAA" => "caa".to_string(), "CNAME" => "cname".to_string(), "DS" => "ds".to_string(), "HTTPS" => "https".to_string(), "MX" => "mx".to_string(), "NAPTR" => "naptr".to_string(), "NS" => "ns".to_string(), "PTR" => "ptr".to_string(), "SOA" => "soa".to_string(), "SPF" => "spf".to_string(), "SRV" => "srv".to_string(), "SSHFP" => "sshfp".to_string(), "SVCB" => "svcb".to_string(), "TLSA" => "tlsa".to_string(), "TXT" => "txt".to_string(), _ => s.to_string() }),
             })
                 .required()
                 .identity()
@@ -104,11 +105,47 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("type", "a") => Some("A"),
+        ("type", "aaaa") => Some("AAAA"),
+        ("type", "caa") => Some("CAA"),
+        ("type", "cname") => Some("CNAME"),
+        ("type", "ds") => Some("DS"),
+        ("type", "https") => Some("HTTPS"),
+        ("type", "mx") => Some("MX"),
+        ("type", "naptr") => Some("NAPTR"),
+        ("type", "ns") => Some("NS"),
+        ("type", "ptr") => Some("PTR"),
+        ("type", "soa") => Some("SOA"),
+        ("type", "spf") => Some("SPF"),
+        ("type", "srv") => Some("SRV"),
+        ("type", "sshfp") => Some("SSHFP"),
+        ("type", "svcb") => Some("SVCB"),
+        ("type", "tlsa") => Some("TLSA"),
+        ("type", "txt") => Some("TXT"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("type", "a", "A"),
+        ("type", "aaaa", "AAAA"),
+        ("type", "caa", "CAA"),
+        ("type", "cname", "CNAME"),
+        ("type", "ds", "DS"),
+        ("type", "https", "HTTPS"),
+        ("type", "mx", "MX"),
+        ("type", "naptr", "NAPTR"),
+        ("type", "ns", "NS"),
+        ("type", "ptr", "PTR"),
+        ("type", "soa", "SOA"),
+        ("type", "spf", "SPF"),
+        ("type", "srv", "SRV"),
+        ("type", "sshfp", "SSHFP"),
+        ("type", "svcb", "SVCB"),
+        ("type", "tlsa", "TLSA"),
+        ("type", "txt", "TXT"),
+    ]
 }

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -9,7 +9,7 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-const VALID_BUCKET_NAMESPACE: &[&str] = &["account-regional", "global"];
+const VALID_BUCKET_NAMESPACE: &[&str] = &["account-regional", "global", "account_regional"];
 
 /// Returns the schema config for s3.Bucket (Smithy: com.amazonaws.s3)
 pub fn s3_bucket_config() -> AwsSchemaConfig {
@@ -30,7 +30,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
                 name: "BucketNamespace".to_string(),
                 values: vec!["account-regional".to_string(), "global".to_string()],
                 namespace: Some("aws.s3.Bucket".to_string()),
-                to_dsl: Some(|s: &str| s.replace('-', "_")),
+                to_dsl: Some(|s: &str| match s { "account-regional" => "account_regional".to_string(), _ => s.to_string() }),
             })
                 .create_only()
                 .with_description("Specifies the namespace where you want to create your general purpose bucket. When you create a general purpose bucket, you can choose to create a buc...")

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_acl.rs
@@ -40,7 +40,7 @@ pub fn s3_bucket_acl_config() -> AwsSchemaConfig {
                             "authenticated-read" => "authenticated_read".to_string(),
                             "public-read" => "public_read".to_string(),
                             "public-read-write" => "public_read_write".to_string(),
-                            _ => s.replace('-', "_"),
+                            _ => s.to_string(),
                         }),
                     },
                 )

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -1436,3 +1436,80 @@ fn test_security_group_ingress_schema_includes_all_variant() {
         panic!("ip_protocol should be StringEnum");
     }
 }
+
+// --- Issue #247: D7 snake_case enum DSL spelling ---
+
+/// Per naming-conventions design D7, every `StringEnum` emitted by codegen
+/// must carry a `to_dsl` closure that maps each canonical AWS value to its
+/// snake_case DSL alias. The validator's `matches_alias` path then accepts
+/// the snake_case form alongside the canonical form.
+#[test]
+fn test_organization_feature_set_validates_snake_case_alias() {
+    use carina_core::resource::Value;
+
+    let config =
+        crate::schemas::generated::organizations::organization::organizations_organization_config();
+    let feature_set = config
+        .schema
+        .attributes
+        .get("feature_set")
+        .expect("feature_set attribute not found");
+
+    // Both the API form (`ALL`) and the DSL form (`all`) must validate.
+    feature_set
+        .attr_type
+        .validate(&Value::String("ALL".to_string()))
+        .expect("API spelling ALL should be accepted");
+    feature_set
+        .attr_type
+        .validate(&Value::String("all".to_string()))
+        .expect("DSL spelling all should be accepted");
+    feature_set
+        .attr_type
+        .validate(&Value::String("CONSOLIDATED_BILLING".to_string()))
+        .expect("API spelling CONSOLIDATED_BILLING should be accepted");
+    feature_set
+        .attr_type
+        .validate(&Value::String("consolidated_billing".to_string()))
+        .expect("DSL spelling consolidated_billing should be accepted");
+    // Bogus values still rejected.
+    assert!(
+        feature_set
+            .attr_type
+            .validate(&Value::String("not_a_value".to_string()))
+            .is_err(),
+        "unknown values must still be rejected"
+    );
+}
+
+/// Sibling check for a PascalCase StringEnum: route53.RecordSet's `Type`
+/// should accept both `A`, `AAAA`, ... (the API spellings, which happen to
+/// be SHOUTY) and their lowercase DSL aliases.
+#[test]
+fn test_route53_record_type_validates_snake_case_alias() {
+    use carina_core::resource::Value;
+
+    let config = crate::schemas::generated::route53::record_set::route53_record_set_config();
+    let type_attr = config
+        .schema
+        .attributes
+        .get("type")
+        .expect("type attribute not found");
+
+    type_attr
+        .attr_type
+        .validate(&Value::String("A".to_string()))
+        .expect("API spelling A should be accepted");
+    type_attr
+        .attr_type
+        .validate(&Value::String("a".to_string()))
+        .expect("DSL spelling a should be accepted");
+    type_attr
+        .attr_type
+        .validate(&Value::String("CNAME".to_string()))
+        .expect("API spelling CNAME should be accepted");
+    type_attr
+        .attr_type
+        .validate(&Value::String("cname".to_string()))
+        .expect("DSL spelling cname should be accepted");
+}

--- a/examples/s3_bucket/main.crn
+++ b/examples/s3_bucket/main.crn
@@ -17,5 +17,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = bucket.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
 }

--- a/generated-docs/aws/logs/log_group.md
+++ b/generated-docs/aws/logs/log_group.md
@@ -65,9 +65,9 @@ The tags for the resource.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `DELIVERY` | `aws.logs.LogGroup.LogGroupClass.DELIVERY` |
-| `INFREQUENT_ACCESS` | `aws.logs.LogGroup.LogGroupClass.INFREQUENT_ACCESS` |
-| `STANDARD` | `aws.logs.LogGroup.LogGroupClass.STANDARD` |
+| `DELIVERY` | `aws.logs.LogGroup.LogGroupClass.delivery` |
+| `INFREQUENT_ACCESS` | `aws.logs.LogGroup.LogGroupClass.infrequent_access` |
+| `STANDARD` | `aws.logs.LogGroup.LogGroupClass.standard` |
 
-Shorthand formats: `DELIVERY` or `LogGroupClass.DELIVERY`
+Shorthand formats: `delivery` or `LogGroupClass.delivery`
 

--- a/generated-docs/aws/route53/record_set.md
+++ b/generated-docs/aws/route53/record_set.md
@@ -58,25 +58,25 @@ The ID of the hosted zone that contains this record set.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `A` | `aws.route53.RecordSet.Type.A` |
-| `AAAA` | `aws.route53.RecordSet.Type.AAAA` |
-| `CAA` | `aws.route53.RecordSet.Type.CAA` |
-| `CNAME` | `aws.route53.RecordSet.Type.CNAME` |
-| `DS` | `aws.route53.RecordSet.Type.DS` |
-| `HTTPS` | `aws.route53.RecordSet.Type.HTTPS` |
-| `MX` | `aws.route53.RecordSet.Type.MX` |
-| `NAPTR` | `aws.route53.RecordSet.Type.NAPTR` |
-| `NS` | `aws.route53.RecordSet.Type.NS` |
-| `PTR` | `aws.route53.RecordSet.Type.PTR` |
-| `SOA` | `aws.route53.RecordSet.Type.SOA` |
-| `SPF` | `aws.route53.RecordSet.Type.SPF` |
-| `SRV` | `aws.route53.RecordSet.Type.SRV` |
-| `SSHFP` | `aws.route53.RecordSet.Type.SSHFP` |
-| `SVCB` | `aws.route53.RecordSet.Type.SVCB` |
-| `TLSA` | `aws.route53.RecordSet.Type.TLSA` |
-| `TXT` | `aws.route53.RecordSet.Type.TXT` |
+| `A` | `aws.route53.RecordSet.Type.a` |
+| `AAAA` | `aws.route53.RecordSet.Type.aaaa` |
+| `CAA` | `aws.route53.RecordSet.Type.caa` |
+| `CNAME` | `aws.route53.RecordSet.Type.cname` |
+| `DS` | `aws.route53.RecordSet.Type.ds` |
+| `HTTPS` | `aws.route53.RecordSet.Type.https` |
+| `MX` | `aws.route53.RecordSet.Type.mx` |
+| `NAPTR` | `aws.route53.RecordSet.Type.naptr` |
+| `NS` | `aws.route53.RecordSet.Type.ns` |
+| `PTR` | `aws.route53.RecordSet.Type.ptr` |
+| `SOA` | `aws.route53.RecordSet.Type.soa` |
+| `SPF` | `aws.route53.RecordSet.Type.spf` |
+| `SRV` | `aws.route53.RecordSet.Type.srv` |
+| `SSHFP` | `aws.route53.RecordSet.Type.sshfp` |
+| `SVCB` | `aws.route53.RecordSet.Type.svcb` |
+| `TLSA` | `aws.route53.RecordSet.Type.tlsa` |
+| `TXT` | `aws.route53.RecordSet.Type.txt` |
 
-Shorthand formats: `A` or `Type.A`
+Shorthand formats: `a` or `Type.a`
 
 ## Struct Definitions
 


### PR DESCRIPTION
## Summary

Per the naming-conventions design D3 / D7 in `carina-rs/carina` `docs/specs/2026-04-22-naming-conventions-design.md`, every `StringEnum` value emitted by the aws-provider codegen must have a snake_case DSL spelling, with the canonical AWS spelling preserved for the underlying SDK call.

Before this PR, codegen emitted a `to_dsl` closure only when an enum value contained a literal hyphen. PascalCase values (`Enabled`, `BucketOwnerEnforced`) and SHOUTY_SNAKE values (`A`, `STANDARD_IA`) were rejected by the validator when written in their snake_case DSL form, and `generated-docs/aws/**` documented them in the AWS spelling in violation of the project-wide rule.

## Changes

- New `carina-codegen-aws::dsl::dsl_enum_value` ports the awscc-side `dsl_enum_value` (in `carina-provider-awscc/src/bin/codegen.rs`) into a reusable module, with the same D7 rules: empty / numeric passthrough, SHOUTY_SNAKE → lowercase, PascalCase → snake_case, kebab → snake.
- `build_to_dsl_code` derives a per-value match closure for every `StringEnum`, layering explicit `ResourceDef::enum_aliases` on top of the auto-derived form. `to_dsl_overrides` still wins over both. The helper is shared by the top-level enum attribute path and the struct-field enum path.
- `enum_alias_reverse` / `enum_alias_entries` now cover every value whose DSL form differs from the API form (was: only hyphenated).
- `VALID_*` constants list both API and DSL spellings so reflection paths stay consistent with what the validator's `to_dsl` already accepts.
- Markdown docs: "DSL Identifier" column and "Shorthand formats" now use the snake_case spelling.
- Acceptance-test fixtures and the `s3_bucket` example are rewritten to the snake_case form.

## Before / after

`generated-docs/aws/route53/record_set.md` (excerpt):

| | Before | After |
|---|---|---|
| DSL Identifier for `A` | `aws.route53.RecordSet.Type.A` | `aws.route53.RecordSet.Type.a` |
| Shorthand | `A` or `Type.A` | `a` or `Type.a` |

Generated schema (`carina-provider-aws/src/schemas/generated/route53/record_set.rs`):

```rust
// Before
to_dsl: None,
```

```rust
// After
to_dsl: Some(|s: &str| match s {
    "A" => "a".to_string(),
    "AAAA" => "aaaa".to_string(),
    "CNAME" => "cname".to_string(),
    // ...
    _ => s.to_string()
}),
```

## Sibling change

This PR mirrors the awscc-side fix tracked in `carina-rs/carina-provider-awscc#199`. The two `dsl_enum_value` implementations stay behaviorally identical so the providers don't drift on what users type in their `.crn` files.

## Regenerated files

13 generated schema files (`schemas/generated/**`) and 2 generated docs (`generated-docs/aws/**`) carry the new DSL aliases. 10 acceptance-test fixtures and the `s3_bucket` example were rewritten from PascalCase to snake_case.

## State-file note (D9)

Existing `carina.state.json` files are **not** migrated. `to_dsl` only translates user input at validate time; state files continue to store the canonical AWS spelling returned by the SDK, so existing state remains usable. The validator now accepts both spellings, so a `.crn` rewritten to snake_case still matches state captured under the old spelling.

## Test plan

- [x] `cargo nextest run` (349 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`
- [x] New unit tests for `dsl_enum_value` covering D7's four cases
- [x] New integration tests asserting the validator accepts both API (`ALL`, `A`, `CNAME`) and DSL (`all`, `a`, `cname`) spellings against real generated schemas (`organizations.Organization.feature_set`, `route53.RecordSet.type`)
- [x] `./scripts/generate-schemas-smithy.sh` regenerates clean
- [x] `./scripts/generate-docs.sh` regenerates clean

Closes #247
