### PR TITLE
Sync to carina-core RFC #2972 Phase 5a: Value Concrete/Deferred split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1d5f1a24233aff498fb523f3316148031be56348#1d5f1a24233aff498fb523f3316148031be56348"
+source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
 dependencies = [
  "argon2",
  "futures",
@@ -676,13 +676,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
  "uuid",
 ]
 
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1d5f1a24233aff498fb523f3316148031be56348#1d5f1a24233aff498fb523f3316148031be56348"
+source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -728,7 +729,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=1d5f1a24233aff498fb523f3316148031be56348#1d5f1a24233aff498fb523f3316148031be56348"
+source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1d5f1a24233aff498fb523f3316148031be56348" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -4,7 +4,7 @@
 //! and `carina-provider-awscc`. Provider-specific types (region with namespace,
 //! schema config structs) remain in their respective crates.
 
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeType, CompletionValue, StructField, legacy_validator};
 
 // ========== Enum helpers ==========
@@ -202,7 +202,7 @@ pub fn tags_type() -> AttributeType {
 pub fn validate_tags_map(
     attributes: &std::collections::HashMap<String, Value>,
 ) -> Result<(), Vec<carina_core::schema::TypeError>> {
-    if let Some(Value::Map(map)) = attributes.get("tags") {
+    if let Some(Value::Concrete(ConcreteValue::Map(map))) = attributes.get("tags") {
         let has_key = map.keys().any(|k| k.eq_ignore_ascii_case("key"));
         let has_value = map.keys().any(|k| k.eq_ignore_ascii_case("value"));
         if has_key && has_value {
@@ -269,7 +269,7 @@ pub fn aws_resource_id() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_aws_resource_id(s)
                     .map_err(|reason| format!("Invalid resource ID '{}': {}", s, reason))
             } else {
@@ -289,7 +289,7 @@ pub fn vpc_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "vpc")
                     .map_err(|reason| format!("Invalid VPC ID '{}': {}", s, reason))
             } else {
@@ -309,7 +309,7 @@ pub fn subnet_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "subnet")
                     .map_err(|reason| format!("Invalid Subnet ID '{}': {}", s, reason))
             } else {
@@ -329,7 +329,7 @@ pub fn security_group_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "sg")
                     .map_err(|reason| format!("Invalid Security Group ID '{}': {}", s, reason))
             } else {
@@ -349,7 +349,7 @@ pub fn internet_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "igw")
                     .map_err(|reason| format!("Invalid Internet Gateway ID '{}': {}", s, reason))
             } else {
@@ -369,7 +369,7 @@ pub fn route_table_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "rtb")
                     .map_err(|reason| format!("Invalid Route Table ID '{}': {}", s, reason))
             } else {
@@ -389,7 +389,7 @@ pub fn nat_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "nat")
                     .map_err(|reason| format!("Invalid NAT Gateway ID '{}': {}", s, reason))
             } else {
@@ -409,7 +409,7 @@ pub fn vpc_peering_connection_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "pcx").map_err(|reason| {
                     format!("Invalid VPC Peering Connection ID '{}': {}", s, reason)
                 })
@@ -430,7 +430,7 @@ pub fn transit_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "tgw")
                     .map_err(|reason| format!("Invalid Transit Gateway ID '{}': {}", s, reason))
             } else {
@@ -450,7 +450,7 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "vpc-cidr-assoc").map_err(|reason| {
                     format!("Invalid VPC CIDR Block Association ID '{}': {}", s, reason)
                 })
@@ -471,7 +471,7 @@ pub fn tgw_route_table_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "tgw-rtb")
                     .map_err(|reason| format!("Invalid TGW Route Table ID '{}': {}", s, reason))
             } else {
@@ -491,7 +491,7 @@ pub fn vpn_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "vgw")
                     .map_err(|reason| format!("Invalid VPN Gateway ID '{}': {}", s, reason))
             } else {
@@ -516,7 +516,7 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "eigw").map_err(|reason| {
                     format!(
                         "Invalid Egress Only Internet Gateway ID '{}': {}",
@@ -540,7 +540,7 @@ pub fn vpc_endpoint_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "vpce")
                     .map_err(|reason| format!("Invalid VPC Endpoint ID '{}': {}", s, reason))
             } else {
@@ -560,7 +560,7 @@ pub fn instance_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "i")
                     .map_err(|reason| format!("Invalid Instance ID '{}': {}", s, reason))
             } else {
@@ -580,7 +580,7 @@ pub fn network_interface_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "eni")
                     .map_err(|reason| format!("Invalid Network Interface ID '{}': {}", s, reason))
             } else {
@@ -601,7 +601,7 @@ pub fn allocation_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "eipalloc")
                     .map_err(|reason| format!("Invalid Allocation ID '{}': {}", s, reason))
             } else {
@@ -621,7 +621,7 @@ pub fn prefix_list_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "pl")
                     .map_err(|reason| format!("Invalid Prefix List ID '{}': {}", s, reason))
             } else {
@@ -641,7 +641,7 @@ pub fn carrier_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "cagw")
                     .map_err(|reason| format!("Invalid Carrier Gateway ID '{}': {}", s, reason))
             } else {
@@ -661,7 +661,7 @@ pub fn local_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "lgw")
                     .map_err(|reason| format!("Invalid Local Gateway ID '{}': {}", s, reason))
             } else {
@@ -682,7 +682,7 @@ pub fn network_acl_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "acl")
                     .map_err(|reason| format!("Invalid Network ACL ID '{}': {}", s, reason))
             } else {
@@ -702,7 +702,7 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "tgw-attach").map_err(|reason| {
                     format!("Invalid Transit Gateway Attachment ID '{}': {}", s, reason)
                 })
@@ -723,7 +723,7 @@ pub fn flow_log_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "fl")
                     .map_err(|reason| format!("Invalid Flow Log ID '{}': {}", s, reason))
             } else {
@@ -743,7 +743,7 @@ pub fn ipam_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "ipam")
                     .map_err(|reason| format!("Invalid IPAM ID '{}': {}", s, reason))
             } else {
@@ -763,7 +763,7 @@ pub fn subnet_route_table_association_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "rtbassoc").map_err(|reason| {
                     format!(
                         "Invalid Subnet Route Table Association ID '{}': {}",
@@ -787,7 +787,7 @@ pub fn security_group_rule_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "sgr")
                     .map_err(|reason| format!("Invalid Security Group Rule ID '{}': {}", s, reason))
             } else {
@@ -821,7 +821,7 @@ pub fn iam_role_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_iam_role_id(s)
                     .map_err(|reason| format!("Invalid IAM Role ID '{}': {}", s, reason))
             } else {
@@ -857,7 +857,7 @@ pub fn aws_account_id() -> AttributeType {
         length: Some((Some(12), Some(12))),
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_aws_account_id(s)
                     .map_err(|reason| format!("Invalid AWS Account ID '{}': {}", s, reason))
             } else {
@@ -996,7 +996,7 @@ pub fn arn() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_arn(s).map_err(|reason| format!("Invalid ARN '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
@@ -1016,7 +1016,7 @@ pub fn iam_role_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_iam_arn(s, "role/")
                     .map_err(|reason| format!("Invalid IAM Role ARN '{}': {}", s, reason))
             } else {
@@ -1037,7 +1037,7 @@ pub fn iam_policy_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_iam_arn(s, "policy/")
                     .map_err(|reason| format!("Invalid IAM Policy ARN '{}': {}", s, reason))
             } else {
@@ -1058,7 +1058,7 @@ pub fn kms_key_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_service_arn(s, "kms", Some("key/"))
                     .map_err(|reason| format!("Invalid KMS Key ARN '{}': {}", s, reason))
             } else {
@@ -1128,7 +1128,7 @@ pub fn kms_key_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_kms_key_id(s)
                     .map_err(|reason| format!("Invalid KMS key identifier '{}': {}", s, reason))
             } else {
@@ -1164,7 +1164,7 @@ pub fn ipam_pool_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_ipam_pool_id(s)
                     .map_err(|reason| format!("Invalid IPAM Pool ID '{}': {}", s, reason))
             } else {
@@ -1273,7 +1273,7 @@ pub fn availability_zone_id() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_availability_zone_id(s)
                     .map_err(|reason| format!("Invalid availability zone ID '{}': {}", s, reason))
             } else {
@@ -1326,7 +1326,7 @@ fn iam_policy_effect() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 match s.as_str() {
                     "Allow" | "Deny" => Ok(()),
                     _ => Err(format!(
@@ -1352,7 +1352,7 @@ fn iam_policy_version() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 match s.as_str() {
                     "2012-10-17" | "2008-10-17" => Ok(()),
                     _ => Err(format!(
@@ -2043,18 +2043,18 @@ pub fn is_valid_condition_operator(key: &str) -> bool {
 /// Walks the document looking for `condition` maps and validates that
 /// all operator keys are valid snake_case condition operators.
 pub fn validate_condition_operators(value: &Value) -> Result<(), String> {
-    let Value::Map(doc) = value else {
+    let Value::Concrete(ConcreteValue::Map(doc)) = value else {
         return Ok(());
     };
     // Look for "statement" list
-    let Some(Value::List(statements)) = doc.get("statement") else {
+    let Some(Value::Concrete(ConcreteValue::List(statements))) = doc.get("statement") else {
         return Ok(());
     };
     for (i, stmt) in statements.iter().enumerate() {
-        let Value::Map(stmt_map) = stmt else {
+        let Value::Concrete(ConcreteValue::Map(stmt_map)) = stmt else {
             continue;
         };
-        let Some(Value::Map(condition)) = stmt_map.get("condition") else {
+        let Some(Value::Concrete(ConcreteValue::Map(condition))) = stmt_map.get("condition") else {
             continue;
         };
         for key in condition.keys() {
@@ -2159,14 +2159,21 @@ mod tests {
     fn validate_arn_type_with_value() {
         let t = arn();
         assert!(
-            t.validate(&Value::String("arn:aws:s3:::my-bucket".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "arn:aws:s3:::my-bucket".to_string()
+            )))
+            .is_ok()
         );
         assert!(
-            t.validate(&Value::String("not-an-arn".to_string()))
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "not-an-arn".to_string()
+            )))
+            .is_err()
+        );
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
                 .is_err()
         );
-        assert!(t.validate(&Value::Int(42)).is_err());
         assert!(
             t.validate(&Value::resource_ref(
                 "role".to_string(),
@@ -2202,11 +2209,19 @@ mod tests {
     fn validate_aws_resource_id_type_with_value() {
         let t = aws_resource_id();
         assert!(
-            t.validate(&Value::String("vpc-1a2b3c4d".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "vpc-1a2b3c4d".to_string()
+            )))
+            .is_ok()
         );
-        assert!(t.validate(&Value::String("vpc".to_string())).is_err());
-        assert!(t.validate(&Value::Int(42)).is_err());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String("vpc".to_string())))
+                .is_err()
+        );
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+                .is_err()
+        );
         assert!(
             t.validate(&Value::resource_ref(
                 "my_vpc".to_string(),
@@ -2221,13 +2236,15 @@ mod tests {
     fn validate_vpc_cidr_block_association_id_valid() {
         let t = vpc_cidr_block_association_id();
         assert!(
-            t.validate(&Value::String("vpc-cidr-assoc-12345678".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "vpc-cidr-assoc-12345678".to_string()
+            )))
+            .is_ok()
         );
         assert!(
-            t.validate(&Value::String(
+            t.validate(&Value::Concrete(ConcreteValue::String(
                 "vpc-cidr-assoc-0123456789abcdef0".to_string()
-            ))
+            )))
             .is_ok()
         );
     }
@@ -2236,22 +2253,33 @@ mod tests {
     fn validate_vpc_cidr_block_association_id_invalid() {
         let t = vpc_cidr_block_association_id();
         assert!(
-            t.validate(&Value::String("vpc-12345678".to_string()))
-                .is_err()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "vpc-12345678".to_string()
+            )))
+            .is_err()
         );
-        assert!(t.validate(&Value::String("invalid".to_string())).is_err());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "invalid".to_string()
+            )))
+            .is_err()
+        );
     }
 
     #[test]
     fn validate_tgw_route_table_id_valid() {
         let t = tgw_route_table_id();
         assert!(
-            t.validate(&Value::String("tgw-rtb-12345678".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "tgw-rtb-12345678".to_string()
+            )))
+            .is_ok()
         );
         assert!(
-            t.validate(&Value::String("tgw-rtb-0123456789abcdef0".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "tgw-rtb-0123456789abcdef0".to_string()
+            )))
+            .is_ok()
         );
     }
 
@@ -2260,15 +2288,24 @@ mod tests {
         let t = tgw_route_table_id();
         // Regular route table ID should fail
         assert!(
-            t.validate(&Value::String("rtb-12345678".to_string()))
-                .is_err()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "rtb-12345678".to_string()
+            )))
+            .is_err()
         );
         // Transit gateway ID should fail
         assert!(
-            t.validate(&Value::String("tgw-12345678".to_string()))
-                .is_err()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "tgw-12345678".to_string()
+            )))
+            .is_err()
         );
-        assert!(t.validate(&Value::String("invalid".to_string())).is_err());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "invalid".to_string()
+            )))
+            .is_err()
+        );
     }
 
     // Availability zone tests
@@ -2336,12 +2373,22 @@ mod tests {
     #[test]
     fn validate_availability_zone_id_type_with_value() {
         let t = availability_zone_id();
-        assert!(t.validate(&Value::String("use1-az1".to_string())).is_ok());
         assert!(
-            t.validate(&Value::String("us-east-1a".to_string()))
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "use1-az1".to_string()
+            )))
+            .is_ok()
+        );
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "us-east-1a".to_string()
+            )))
+            .is_err()
+        );
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
                 .is_err()
         );
-        assert!(t.validate(&Value::Int(42)).is_err());
         assert!(
             t.validate(&Value::resource_ref(
                 "subnet".to_string(),
@@ -2581,7 +2628,7 @@ mod tests {
 
     #[test]
     fn validate_iam_policy_document_basic() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -2605,26 +2652,26 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_iam_policy_document(&doc).is_ok());
     }
 
     #[test]
     fn validate_iam_policy_document_invalid_version() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "version".to_string(),
                 Value::String("2020-01-01".to_string()),
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_iam_policy_document(&doc).is_err());
     }
 
     #[test]
     fn validate_iam_policy_document_invalid_effect() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -2635,14 +2682,14 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_iam_policy_document(&doc).is_err());
     }
 
     #[test]
     fn iam_policy_document_type_validates() {
         let t = iam_policy_document();
-        let valid_doc = Value::Map(
+        let valid_doc = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -2663,7 +2710,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(t.validate(&valid_doc).is_ok());
     }
 
@@ -2671,7 +2718,7 @@ mod tests {
     fn iam_policy_document_principal_map_validates() {
         let t = iam_policy_document();
         // principal as a map: { service = "ec2.amazonaws.com" }
-        let doc_with_principal_map = Value::Map(
+        let doc_with_principal_map = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -2705,7 +2752,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(
             t.validate(&doc_with_principal_map).is_ok(),
             "principal as map (struct) should be valid: {:?}",
@@ -2717,7 +2764,7 @@ mod tests {
     fn iam_policy_document_principal_string_validates() {
         let t = iam_policy_document();
         // principal as a string: "*"
-        let doc_with_principal_string = Value::Map(
+        let doc_with_principal_string = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -2741,7 +2788,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(
             t.validate(&doc_with_principal_string).is_ok(),
             "principal as string should be valid: {:?}",
@@ -2841,14 +2888,14 @@ mod tests {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert(
             "tags".to_string(),
-            Value::Map(
+            Value::Concrete(ConcreteValue::Map(
                 [
                     ("key".to_string(), Value::String("Project".to_string())),
                     ("value".to_string(), Value::String("carina".to_string())),
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
         );
         assert!(validate_tags_map(&attrs).is_err());
     }
@@ -2858,14 +2905,14 @@ mod tests {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert(
             "tags".to_string(),
-            Value::Map(
+            Value::Concrete(ConcreteValue::Map(
                 [
                     ("Key".to_string(), Value::String("Project".to_string())),
                     ("Value".to_string(), Value::String("carina".to_string())),
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
         );
         assert!(validate_tags_map(&attrs).is_err());
     }
@@ -2875,14 +2922,14 @@ mod tests {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert(
             "tags".to_string(),
-            Value::Map(
+            Value::Concrete(ConcreteValue::Map(
                 [
                     ("Project".to_string(), Value::String("carina".to_string())),
                     ("ManagedBy".to_string(), Value::String("carina".to_string())),
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
         );
         assert!(validate_tags_map(&attrs).is_ok());
     }
@@ -2962,7 +3009,7 @@ mod tests {
 
     #[test]
     fn validate_condition_operators_accepts_valid() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -2990,13 +3037,13 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_condition_operators(&doc).is_ok());
     }
 
     #[test]
     fn validate_condition_operators_rejects_pascal_case() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -3017,7 +3064,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         let err = validate_condition_operators(&doc).unwrap_err();
         assert!(
             err.contains("StringEquals"),
@@ -3027,7 +3074,7 @@ mod tests {
 
     #[test]
     fn validate_condition_operators_rejects_unknown() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -3045,13 +3092,13 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_condition_operators(&doc).is_err());
     }
 
     #[test]
     fn validate_condition_operators_accepts_if_exists() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -3072,7 +3119,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_condition_operators(&doc).is_ok());
     }
 }

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -820,7 +820,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         code.push_str("use super::validate_tags_map;\n");
     }
     if has_ranged_ints {
-        code.push_str("use carina_core::resource::Value;\n");
+        code.push_str("use carina_core::resource::{ConcreteValue, DeferredValue, Value};\n");
     }
     code.push_str(&format!(
         "use carina_core::schema::{{{}}};\n\n",
@@ -1767,7 +1767,7 @@ fn generate_provider_code(
          use indexmap::IndexMap;\n\
          use std::collections::HashMap;\n\n\
          use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};\n\
-         use carina_core::resource::{Resource, ResourceId, State, Value};\n\
+         use carina_core::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};\n\
          #[allow(unused_imports)]\n\
          use carina_core::utils::extract_enum_value;\n\n\
          use crate::AwsProvider;\n\

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1d5f1a24233aff498fb523f3316148031be56348" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "1d5f1a24233aff498fb523f3316148031be56348" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "1d5f1a24233aff498fb523f3316148031be56348" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -7,8 +7,8 @@
 use std::collections::HashMap;
 
 use carina_core::resource::{
-    Directives as CoreDirectives, Resource as CoreResource, ResourceId as CoreResourceId,
-    State as CoreState, Value as CoreValue,
+    ConcreteValue, DeferredValue, Directives as CoreDirectives, Resource as CoreResource,
+    ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
@@ -41,34 +41,70 @@ pub fn proto_to_core_resource_id(id: &ProtoResourceId) -> CoreResourceId {
 
 pub fn core_to_proto_value(v: &CoreValue) -> ProtoValue {
     match v {
-        CoreValue::String(s) => ProtoValue::String(s.clone()),
-        CoreValue::Int(i) => ProtoValue::Int(*i),
-        CoreValue::Float(f) => ProtoValue::Float(*f),
-        CoreValue::Bool(b) => ProtoValue::Bool(*b),
-        CoreValue::List(l) => ProtoValue::List(l.iter().map(core_to_proto_value).collect()),
-        CoreValue::Map(m) => ProtoValue::Map(
+        CoreValue::Concrete(ConcreteValue::String(s)) => ProtoValue::String(s.clone()),
+        CoreValue::Concrete(ConcreteValue::Int(i)) => ProtoValue::Int(*i),
+        CoreValue::Concrete(ConcreteValue::Float(f)) => ProtoValue::Float(*f),
+        CoreValue::Concrete(ConcreteValue::Bool(b)) => ProtoValue::Bool(*b),
+        // Duration is currently serialised to providers as integer seconds —
+        // the WIT contract has no native Duration variant. Matches the
+        // wire-side type mapping in `core_to_proto_attribute_type`.
+        CoreValue::Concrete(ConcreteValue::Duration(d)) => ProtoValue::Int(d.as_secs() as i64),
+        CoreValue::Concrete(ConcreteValue::List(l)) => {
+            ProtoValue::List(l.iter().map(core_to_proto_value).collect())
+        }
+        CoreValue::Concrete(ConcreteValue::StringList(items)) => ProtoValue::List(
+            items
+                .iter()
+                .map(|s| ProtoValue::String(s.clone()))
+                .collect(),
+        ),
+        CoreValue::Concrete(ConcreteValue::Map(m)) => ProtoValue::Map(
             m.iter()
                 .map(|(k, v)| (k.clone(), core_to_proto_value(v)))
                 .collect(),
         ),
-        // ResourceRef, Interpolation, FunctionCall, Closure, Secret
-        // should be resolved before reaching the provider.
-        _ => ProtoValue::String(format!("{v:?}")),
+        // Deferred-axis values must be resolved before reaching the provider.
+        // Phase 5a of RFC #2972 makes the axis explicit so we can pattern-match
+        // each deferred variant individually. We do NOT fall through to
+        // `format!("{v:?}")` because `Debug` on `Value::Deferred(Secret(inner))`
+        // includes the inner plaintext — a leak. Emit a redacted sentinel
+        // instead so the provider sees a clearly-bogus value rather than
+        // either the plaintext or an inner pointer / panic.
+        CoreValue::Deferred(DeferredValue::Secret(_)) => {
+            ProtoValue::String("<redacted-secret>".to_string())
+        }
+        CoreValue::Deferred(DeferredValue::ResourceRef { path }) => {
+            ProtoValue::String(format!("<unresolved-ref:{}>", path.to_dot_string()))
+        }
+        CoreValue::Deferred(DeferredValue::BindingRef { binding }) => {
+            ProtoValue::String(format!("<unresolved-binding:{binding}>"))
+        }
+        CoreValue::Deferred(DeferredValue::Interpolation(_)) => {
+            ProtoValue::String("<unresolved-interpolation>".to_string())
+        }
+        CoreValue::Deferred(DeferredValue::FunctionCall { name, .. }) => {
+            ProtoValue::String(format!("<unresolved-fn:{name}>"))
+        }
+        CoreValue::Deferred(DeferredValue::Unknown(_)) => {
+            ProtoValue::String("<unknown>".to_string())
+        }
     }
 }
 
 pub fn proto_to_core_value(v: &ProtoValue) -> CoreValue {
     match v {
-        ProtoValue::String(s) => CoreValue::String(s.clone()),
-        ProtoValue::Int(i) => CoreValue::Int(*i),
-        ProtoValue::Float(f) => CoreValue::Float(*f),
-        ProtoValue::Bool(b) => CoreValue::Bool(*b),
-        ProtoValue::List(l) => CoreValue::List(l.iter().map(proto_to_core_value).collect()),
-        ProtoValue::Map(m) => CoreValue::Map(
+        ProtoValue::String(s) => CoreValue::Concrete(ConcreteValue::String(s.clone())),
+        ProtoValue::Int(i) => CoreValue::Concrete(ConcreteValue::Int(*i)),
+        ProtoValue::Float(f) => CoreValue::Concrete(ConcreteValue::Float(*f)),
+        ProtoValue::Bool(b) => CoreValue::Concrete(ConcreteValue::Bool(*b)),
+        ProtoValue::List(l) => CoreValue::Concrete(ConcreteValue::List(
+            l.iter().map(proto_to_core_value).collect(),
+        )),
+        ProtoValue::Map(m) => CoreValue::Concrete(ConcreteValue::Map(
             m.iter()
                 .map(|(k, v)| (k.clone(), proto_to_core_value(v)))
                 .collect(),
-        ),
+        )),
     }
 }
 
@@ -141,6 +177,7 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
         force_delete: r.directives.force_delete,
         create_before_destroy: r.directives.create_before_destroy,
         prevent_destroy: r.directives.prevent_destroy,
+        depends_on: Vec::new(),
     };
     resource
 }
@@ -252,6 +289,8 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
             create_max_retries: c.create_max_retries,
         }),
         exclusive_required: s.exclusive_required.clone(),
+        default_wait_timeout: None,
+        default_wait_interval: None,
     }
 }
 
@@ -275,6 +314,11 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Int => ProtoAttributeType::Int,
         CoreAttributeType::Float => ProtoAttributeType::Float,
         CoreAttributeType::Bool => ProtoAttributeType::Bool,
+        // `Duration` isn't representable on the WIT wire today; map to Int
+        // seconds. Carina-core only emits Duration values from DSL literals
+        // (`75min`, `1h`), and providers receive the resolved int form
+        // through json_to_dsl_value, so the inverse direction is moot.
+        CoreAttributeType::Duration => ProtoAttributeType::Int,
         CoreAttributeType::StringEnum {
             values,
             name,

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
@@ -64,7 +64,7 @@ impl AwsProvider {
         let rule_identifier = if !rule_ids.is_empty() {
             attributes.insert(
                 "security_group_rule_id".to_string(),
-                Value::String(rule_ids.join(",")),
+                Value::Concrete(ConcreteValue::String(rule_ids.join(","))),
             );
             Some(rule_ids.join(","))
         } else {
@@ -73,7 +73,10 @@ impl AwsProvider {
 
         // IPv4 CIDR (CidrIp in schema maps to CidrIpv4 in SDK)
         if let Some(cidr_ip) = first_rule.cidr_ipv4() {
-            attributes.insert("cidr_ip".to_string(), Value::String(cidr_ip.to_string()));
+            attributes.insert(
+                "cidr_ip".to_string(),
+                Value::Concrete(ConcreteValue::String(cidr_ip.to_string())),
+            );
         }
 
         // Referenced security group ID (nested struct, not auto-extracted)
@@ -85,7 +88,10 @@ impl AwsProvider {
             } else {
                 "destination_security_group_id"
             };
-            attributes.insert(attr_name.to_string(), Value::String(group_id.to_string()));
+            attributes.insert(
+                attr_name.to_string(),
+                Value::Concrete(ConcreteValue::String(group_id.to_string())),
+            );
         }
 
         let state = State::existing(id.clone(), attributes);
@@ -103,7 +109,7 @@ impl AwsProvider {
         is_ingress: bool,
     ) -> ProviderResult<State> {
         let sg_id = match resource.get_attr("group_id") {
-            Some(Value::String(s)) => s.clone(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {
                 return Err(ProviderError::invalid_input(
                     "Security Group ID (group_id) is required",
@@ -113,32 +119,32 @@ impl AwsProvider {
         };
 
         let protocol = match resource.get_attr("ip_protocol") {
-            Some(Value::String(s)) => convert_protocol_value(s),
+            Some(Value::Concrete(ConcreteValue::String(s))) => convert_protocol_value(s),
             _ => "-1".to_string(),
         };
 
         let from_port = match resource.get_attr("from_port") {
-            Some(Value::Int(n)) => *n as i32,
+            Some(Value::Concrete(ConcreteValue::Int(n))) => *n as i32,
             _ => 0,
         };
 
         let to_port = match resource.get_attr("to_port") {
-            Some(Value::Int(n)) => *n as i32,
+            Some(Value::Concrete(ConcreteValue::Int(n))) => *n as i32,
             _ => 0,
         };
 
         let cidr_ip = match resource.get_attr("cidr_ip") {
-            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
             _ => None,
         };
 
         let cidr_ipv6 = match resource.get_attr("cidr_ipv6") {
-            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
             _ => None,
         };
 
         let description = match resource.get_attr("description") {
-            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
             _ => None,
         };
 
@@ -148,7 +154,7 @@ impl AwsProvider {
             "destination_prefix_list_id"
         };
         let prefix_list_id = match resource.get_attr(prefix_list_attr) {
-            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
             _ => None,
         };
 
@@ -158,7 +164,7 @@ impl AwsProvider {
             "destination_security_group_id"
         };
         let ref_security_group_id = match resource.get_attr(sg_ref_attr) {
-            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
             _ => None,
         };
 
@@ -440,13 +446,15 @@ mod tests {
         {
             attributes.insert(
                 "source_security_group_id".to_string(),
-                Value::String(group_id.to_string()),
+                Value::Concrete(ConcreteValue::String(group_id.to_string())),
             );
         }
 
         assert_eq!(
             attributes.get("source_security_group_id"),
-            Some(&Value::String("sg-ref-12345678".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "sg-ref-12345678".to_string()
+            )))
         );
     }
 
@@ -464,12 +472,17 @@ mod tests {
         // Replicate logic from read_ec2_security_group_rule
         let mut attributes = HashMap::new();
         if let Some(cidr_ip) = rule.cidr_ipv4() {
-            attributes.insert("cidr_ip".to_string(), Value::String(cidr_ip.to_string()));
+            attributes.insert(
+                "cidr_ip".to_string(),
+                Value::Concrete(ConcreteValue::String(cidr_ip.to_string())),
+            );
         }
 
         assert_eq!(
             attributes.get("cidr_ip"),
-            Some(&Value::String("10.0.0.0/8".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "10.0.0.0/8".to_string()
+            )))
         );
     }
 

--- a/carina-provider-aws/src/ec2_tags.rs
+++ b/carina-provider-aws/src/ec2_tags.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ResourceId, Value};
+use carina_core::resource::{ConcreteValue, ResourceId, Value};
 
 use crate::AwsProvider;
 use crate::helpers::sdk_error_message;
@@ -15,22 +15,25 @@ impl AwsProvider {
         let mut tag_map: IndexMap<String, Value> = IndexMap::new();
         for tag in tags {
             if let (Some(key), Some(value)) = (tag.key(), tag.value()) {
-                tag_map.insert(key.to_string(), Value::String(value.to_string()));
+                tag_map.insert(
+                    key.to_string(),
+                    Value::Concrete(ConcreteValue::String(value.to_string())),
+                );
             }
         }
         if tag_map.is_empty() {
             None
         } else {
-            Some(Value::Map(tag_map))
+            Some(Value::Concrete(ConcreteValue::Map(tag_map)))
         }
     }
 
     /// Build EC2 Tag list from Value::Map
     pub(crate) fn value_to_ec2_tags(value: &Value) -> Vec<aws_sdk_ec2::types::Tag> {
         let mut tags = Vec::new();
-        if let Value::Map(map) = value {
+        if let Value::Concrete(ConcreteValue::Map(map)) = value {
             for (key, val) in map {
-                if let Value::String(v) = val {
+                if let Value::Concrete(ConcreteValue::String(v)) = val {
                     tags.push(aws_sdk_ec2::types::Tag::builder().key(key).value(v).build());
                 }
             }
@@ -51,18 +54,22 @@ impl AwsProvider {
     ) -> ProviderResult<()> {
         // Delete tags that were removed (present in from but not in to)
         if let Some(from_attrs) = from_attributes {
-            let old_keys: std::collections::HashSet<&String> =
-                if let Some(Value::Map(old_map)) = from_attrs.get("tags") {
-                    old_map.keys().collect()
-                } else {
-                    std::collections::HashSet::new()
-                };
-            let new_keys: std::collections::HashSet<&String> =
-                if let Some(Value::Map(new_map)) = attributes.get("tags") {
-                    new_map.keys().collect()
-                } else {
-                    std::collections::HashSet::new()
-                };
+            let old_keys: std::collections::HashSet<&String> = if let Some(Value::Concrete(
+                ConcreteValue::Map(old_map),
+            )) = from_attrs.get("tags")
+            {
+                old_map.keys().collect()
+            } else {
+                std::collections::HashSet::new()
+            };
+            let new_keys: std::collections::HashSet<&String> = if let Some(Value::Concrete(
+                ConcreteValue::Map(new_map),
+            )) = attributes.get("tags")
+            {
+                new_map.keys().collect()
+            } else {
+                std::collections::HashSet::new()
+            };
             let removed_keys: Vec<&String> = old_keys.difference(&new_keys).copied().collect();
             if !removed_keys.is_empty() {
                 let mut req = self.ec2_client.delete_tags().resources(ec2_resource_id);
@@ -117,10 +124,12 @@ mod tests {
         ];
         let result = AwsProvider::ec2_tags_to_value(&tags);
         assert!(result.is_some());
-        if let Some(Value::Map(map)) = result {
+        if let Some(Value::Concrete(ConcreteValue::Map(map))) = result {
             assert_eq!(
                 map.get("Name"),
-                Some(&Value::String("my-resource".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "my-resource".to_string()
+                )))
             );
         } else {
             panic!("Expected Value::Map");
@@ -140,12 +149,17 @@ mod tests {
                 .build(),
         ];
         let result = AwsProvider::ec2_tags_to_value(&tags);
-        if let Some(Value::Map(map)) = result {
+        if let Some(Value::Concrete(ConcreteValue::Map(map))) = result {
             assert_eq!(map.len(), 2);
-            assert_eq!(map.get("Name"), Some(&Value::String("test".to_string())));
+            assert_eq!(
+                map.get("Name"),
+                Some(&Value::Concrete(ConcreteValue::String("test".to_string())))
+            );
             assert_eq!(
                 map.get("Environment"),
-                Some(&Value::String("production".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "production".to_string()
+                )))
             );
         } else {
             panic!("Expected Value::Map with 2 entries");
@@ -163,10 +177,10 @@ mod tests {
 
     #[test]
     fn test_value_to_ec2_tags_from_map() {
-        let value = Value::Map(IndexMap::from([
+        let value = Value::Concrete(ConcreteValue::Map(IndexMap::from([
             ("Name".to_string(), Value::String("test".to_string())),
             ("Env".to_string(), Value::String("prod".to_string())),
-        ]));
+        ])));
         let tags = AwsProvider::value_to_ec2_tags(&value);
         assert_eq!(tags.len(), 2);
         // Check both tags exist (order not guaranteed from HashMap)
@@ -185,17 +199,17 @@ mod tests {
 
     #[test]
     fn test_value_to_ec2_tags_non_map_value() {
-        let value = Value::String("not a map".to_string());
+        let value = Value::Concrete(ConcreteValue::String("not a map".to_string()));
         let tags = AwsProvider::value_to_ec2_tags(&value);
         assert!(tags.is_empty());
     }
 
     #[test]
     fn test_value_to_ec2_tags_non_string_values_skipped() {
-        let value = Value::Map(IndexMap::from([
+        let value = Value::Concrete(ConcreteValue::Map(IndexMap::from([
             ("Name".to_string(), Value::String("test".to_string())),
             ("Count".to_string(), Value::Int(42)),
-        ]));
+        ])));
         let tags = AwsProvider::value_to_ec2_tags(&value);
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].key(), Some("Name"));
@@ -204,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_value_to_ec2_tags_empty_map() {
-        let value = Value::Map(IndexMap::new());
+        let value = Value::Concrete(ConcreteValue::Map(IndexMap::new()));
         let tags = AwsProvider::value_to_ec2_tags(&value);
         assert!(tags.is_empty());
     }

--- a/carina-provider-aws/src/factory.rs
+++ b/carina-provider-aws/src/factory.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use indexmap::IndexMap;
 
 use carina_core::provider::{BoxFuture, ProviderFactory, ProviderNormalizer};
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 
 use crate::AwsProvider;
 use crate::normalizer::AwsNormalizer;
@@ -80,7 +80,7 @@ impl ProviderFactory for AwsProviderFactory {
     }
 
     fn extract_region(&self, attributes: &IndexMap<String, Value>) -> String {
-        if let Some(Value::String(region)) = attributes.get("region") {
+        if let Some(Value::Concrete(ConcreteValue::String(region))) = attributes.get("region") {
             return carina_core::utils::convert_region_value(region);
         }
         "ap-northeast-1".to_string()

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -11,14 +11,14 @@ use aws_smithy_types::error::display::DisplayErrorContext;
 use tokio::time::sleep;
 
 use carina_core::provider::{PatchOpKind, ProviderError, ProviderResult, UpdatePatch};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 /// Extract a required `String` attribute from a resource.
 ///
 /// Returns the string value or a `ProviderError` with `"{attr_name} is required"`.
 pub fn require_string_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
     match resource.get_attr(attr_name) {
-        Some(Value::String(s)) => Ok(s.clone()),
+        Some(Value::Concrete(ConcreteValue::String(s))) => Ok(s.clone()),
         _ => Err(
             ProviderError::invalid_input(format!("{} is required", attr_name))
                 .for_resource(resource.id.clone()),
@@ -44,7 +44,7 @@ pub fn build_tag_specification(
     resource: &Resource,
     resource_type: ResourceType,
 ) -> Option<TagSpecification> {
-    if let Some(Value::Map(tags)) = resource.get_attr("tags") {
+    if let Some(Value::Concrete(ConcreteValue::Map(tags))) = resource.get_attr("tags") {
         Some(build_tag_specification_from_map(tags, resource_type))
     } else {
         None
@@ -58,7 +58,7 @@ fn build_tag_specification_from_map(
 ) -> TagSpecification {
     let mut tag_spec = TagSpecification::builder().resource_type(resource_type);
     for (key, val) in tags {
-        if let Value::String(v) = val {
+        if let Value::Concrete(ConcreteValue::String(v)) = val {
             tag_spec = tag_spec.tags(Tag::builder().key(key).value(v).build());
         }
     }
@@ -226,9 +226,10 @@ mod tests {
     fn make_test_resource(attrs: Vec<(&str, &str)>) -> Resource {
         let mut resource = Resource::new("route53.RecordSet", "test");
         for (k, v) in attrs {
-            resource
-                .attributes
-                .insert(k.to_string(), Value::String(v.to_string()));
+            resource.attributes.insert(
+                k.to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         resource
     }
@@ -241,14 +242,17 @@ mod tests {
         // from-state has two attrs; patch adds one, replaces one, removes one.
         let id = ResourceId::with_provider("aws", "ec2.Vpc", "test");
         let mut from_attrs: HashMap<String, Value> = HashMap::new();
-        from_attrs.insert("cidr_block".into(), Value::String("10.0.0.0/16".into()));
+        from_attrs.insert(
+            "cidr_block".into(),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".into())),
+        );
         from_attrs.insert(
             "tags".into(),
-            Value::Map(
+            Value::Concrete(ConcreteValue::Map(
                 [("Name".to_string(), Value::String("old".into()))]
                     .into_iter()
                     .collect(),
-            ),
+            )),
         );
         let from = State::existing(id, from_attrs);
 
@@ -258,17 +262,17 @@ mod tests {
                 PatchOp {
                     kind: PatchOpKind::Add,
                     key: "instance_tenancy".into(),
-                    value: Some(Value::String("default".into())),
+                    value: Some(Value::Concrete(ConcreteValue::String("default".into()))),
                 },
                 // Replace the existing tags
                 PatchOp {
                     kind: PatchOpKind::Replace,
                     key: "tags".into(),
-                    value: Some(Value::Map(
+                    value: Some(Value::Concrete(ConcreteValue::Map(
                         [("Name".to_string(), Value::String("new".into()))]
                             .into_iter()
                             .collect(),
-                    )),
+                    ))),
                 },
                 // Remove cidr_block
                 PatchOp {
@@ -287,12 +291,15 @@ mod tests {
         );
         assert_eq!(
             to.attributes.get("instance_tenancy"),
-            Some(&Value::String("default".into())),
+            Some(&Value::Concrete(ConcreteValue::String("default".into()))),
             "Add op should insert the new value"
         );
         match to.attributes.get("tags") {
-            Some(Value::Map(m)) => {
-                assert_eq!(m.get("Name"), Some(&Value::String("new".into())));
+            Some(Value::Concrete(ConcreteValue::Map(m))) => {
+                assert_eq!(
+                    m.get("Name"),
+                    Some(&Value::Concrete(ConcreteValue::String("new".into())))
+                );
             }
             other => panic!("expected tags map, got {:?}", other),
         }

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -10,7 +10,7 @@ use carina_core::provider::{
     ProviderNormalizer, ReadRequest as CoreReadRequest, UpdatePatch as CoreUpdatePatch,
     UpdateRequest as CoreUpdateRequest,
 };
-use carina_core::resource::Value as CoreValue;
+use carina_core::resource::{ConcreteValue, Value as CoreValue};
 use carina_core::schema::SchemaRegistry;
 
 use carina_provider_aws::AwsNormalizer;
@@ -153,7 +153,9 @@ impl CarinaProvider for AwsProcessProvider {
     fn initialize(&mut self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
         use carina_provider_aws::services::sts::account_guard::extract_string_list;
         let core_attrs = convert::proto_to_core_value_map(attrs);
-        let region = if let Some(CoreValue::String(region)) = core_attrs.get("region") {
+        let region = if let Some(CoreValue::Concrete(ConcreteValue::String(region))) =
+            core_attrs.get("region")
+        {
             carina_core::utils::convert_region_value(region)
         } else {
             "ap-northeast-1".to_string()
@@ -302,6 +304,7 @@ impl CarinaProvider for AwsProcessProvider {
             force_delete: request.directives.force_delete,
             create_before_destroy: request.directives.create_before_destroy,
             prevent_destroy: request.directives.prevent_destroy,
+            depends_on: Vec::new(),
         };
         let core_request = CoreDeleteRequest {
             directives: core_directives,

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use indexmap::IndexMap;
 
 use carina_core::provider::{self, ProviderNormalizer};
-use carina_core::resource::{Resource, Value};
+use carina_core::resource::{ConcreteValue, Resource, Value};
 use carina_core::schema::SchemaRegistry;
 
 /// Schema extension for the AWS provider.
@@ -102,7 +102,7 @@ pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMa
             // Normalize enum fields within struct (Map) values
             if let carina_core::schema::AttributeType::Struct { fields, .. } =
                 &attr_schema.attr_type
-                && let Value::Map(map_fields) = value
+                && let Value::Concrete(ConcreteValue::Map(map_fields)) = value
             {
                 let mut normalized_map = map_fields.clone();
                 for field in fields {
@@ -118,7 +118,10 @@ pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMa
                     }
                 }
                 if normalized_map != *map_fields {
-                    resolved.insert(key.clone(), Value::Map(normalized_map));
+                    resolved.insert(
+                        key.clone(),
+                        Value::Concrete(ConcreteValue::Map(normalized_map)),
+                    );
                 }
             }
         }
@@ -138,31 +141,36 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test");
         resource.set_attr(
             "status".to_string(),
-            Value::String("aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string(),
+            )),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         assert_eq!(
             resources[0].get_attr("status"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string()
-            ))
+            )))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
         let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test");
-        resource.set_attr("status".to_string(), Value::String("Enabled".to_string()));
+        resource.set_attr(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         // After carina#2832, resolve_enum_value applies dsl_aliases so the
         // namespaced output uses the DSL spelling (snake_case).
         assert_eq!(
             resources[0].get_attr("status"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketVersioning.VersioningStatus.enabled".to_string()
-            ))
+            )))
         );
     }
 
@@ -171,42 +179,52 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "s3.BucketOwnershipControls", "test");
         resource.set_attr(
             "object_ownership".to_string(),
-            Value::String("ObjectOwnership.BucketOwnerEnforced".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "ObjectOwnership.BucketOwnerEnforced".to_string(),
+            )),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         assert_eq!(
             resources[0].get_attr("object_ownership"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced".to_string()
-            ))
+            )))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_plain_string() {
         let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test");
-        resource.set_attr("status".to_string(), Value::String("Enabled".to_string()));
+        resource.set_attr(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         assert_eq!(
             resources[0].get_attr("status"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketVersioning.VersioningStatus.enabled".to_string()
-            ))
+            )))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_aws() {
         let mut resource = Resource::with_provider("awscc", "s3.BucketVersioning", "test");
-        resource.set_attr("status".to_string(), Value::String("Enabled".to_string()));
+        resource.set_attr(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         // Should not be modified since provider is "awscc"
         assert_eq!(
             resources[0].get_attr("status"),
-            Some(&Value::String("Enabled".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Enabled".to_string()
+            )))
         );
     }
 
@@ -214,38 +232,46 @@ mod tests {
     fn test_resolve_enum_identifiers_with_to_dsl() {
         // ip_protocol has to_dsl that maps "-1" → "all"
         let mut resource = Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule");
-        resource.set_attr("ip_protocol".to_string(), Value::String("-1".to_string()));
+        resource.set_attr(
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("-1".to_string())),
+        );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         assert_eq!(
             resources[0].get_attr("ip_protocol"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.SecurityGroupIngress.IpProtocol.all".to_string()
-            ))
+            )))
         );
     }
 
     #[test]
     fn test_normalize_state_enums_with_to_dsl() {
         // Read returns "-1" for ip_protocol, should be normalized to "all" via to_dsl
-        let mut attributes =
-            HashMap::from([("ip_protocol".to_string(), Value::String("-1".to_string()))]);
+        let mut attributes = HashMap::from([(
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("-1".to_string())),
+        )]);
         normalize_state_enums("ec2.SecurityGroupIngress", &mut attributes);
         assert_eq!(
             attributes.get("ip_protocol"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.SecurityGroupIngress.IpProtocol.all".to_string()
-            ))
+            )))
         );
     }
 
     #[test]
     fn test_normalize_state_enums() {
         let mut attributes = HashMap::from([
-            ("bucket".to_string(), Value::String("my-bucket".to_string())),
+            (
+                "bucket".to_string(),
+                Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+            ),
             (
                 "object_ownership".to_string(),
-                Value::String("BucketOwnerEnforced".to_string()),
+                Value::Concrete(ConcreteValue::String("BucketOwnerEnforced".to_string())),
             ),
         ]);
         normalize_state_enums("s3.BucketOwnershipControls", &mut attributes);
@@ -253,29 +279,37 @@ mod tests {
         // and writes back the DSL spelling for diff stability.
         assert_eq!(
             attributes.get("object_ownership"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced".to_string()
-            ))
+            )))
         );
         // Non-enum attributes should not be modified
         assert_eq!(
             attributes.get("bucket"),
-            Some(&Value::String("my-bucket".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "my-bucket".to_string()
+            )))
         );
     }
 
     #[test]
     fn test_normalize_state_enums_bucket_versioning() {
         let mut attributes = HashMap::from([
-            ("bucket".to_string(), Value::String("my-bucket".to_string())),
-            ("status".to_string(), Value::String("Enabled".to_string())),
+            (
+                "bucket".to_string(),
+                Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+            ),
+            (
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+            ),
         ]);
         normalize_state_enums("s3.BucketVersioning", &mut attributes);
         assert_eq!(
             attributes.get("status"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketVersioning.VersioningStatus.enabled".to_string()
-            ))
+            )))
         );
     }
 
@@ -283,15 +317,17 @@ mod tests {
     fn test_normalize_state_enums_already_namespaced() {
         let mut attributes = HashMap::from([(
             "status".to_string(),
-            Value::String("aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string(),
+            )),
         )]);
         normalize_state_enums("s3.BucketVersioning", &mut attributes);
         // Already namespaced values (contain dots) should not be modified
         assert_eq!(
             attributes.get("status"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string()
-            ))
+            )))
         );
     }
 
@@ -300,15 +336,17 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "ec2.Vpc", "test-vpc");
         resource.set_attr(
             "instance_tenancy".to_string(),
-            Value::String("InstanceTenancy.dedicated".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "InstanceTenancy.dedicated".to_string(),
+            )),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         assert_eq!(
             resources[0].get_attr("instance_tenancy"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.Vpc.InstanceTenancy.dedicated".to_string()
-            ))
+            )))
         );
     }
 
@@ -317,15 +355,15 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule");
         resource.set_attr(
             "ip_protocol".to_string(),
-            Value::String("IpProtocol.tcp".to_string()),
+            Value::Concrete(ConcreteValue::String("IpProtocol.tcp".to_string())),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
         assert_eq!(
             resources[0].get_attr("ip_protocol"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.SecurityGroupIngress.IpProtocol.tcp".to_string()
-            ))
+            )))
         );
     }
 
@@ -333,27 +371,29 @@ mod tests {
     fn test_normalize_state_enums_ec2_vpc_tenancy() {
         let mut attributes = HashMap::from([(
             "instance_tenancy".to_string(),
-            Value::String("default".to_string()),
+            Value::Concrete(ConcreteValue::String("default".to_string())),
         )]);
         normalize_state_enums("ec2.Vpc", &mut attributes);
         assert_eq!(
             attributes.get("instance_tenancy"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.Vpc.InstanceTenancy.default".to_string()
-            ))
+            )))
         );
     }
 
     #[test]
     fn test_normalize_state_enums_ec2_security_group_egress() {
-        let mut attributes =
-            HashMap::from([("ip_protocol".to_string(), Value::String("-1".to_string()))]);
+        let mut attributes = HashMap::from([(
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("-1".to_string())),
+        )]);
         normalize_state_enums("ec2.SecurityGroupEgress", &mut attributes);
         assert_eq!(
             attributes.get("ip_protocol"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.SecurityGroupEgress.IpProtocol.all".to_string()
-            ))
+            )))
         );
     }
 
@@ -362,28 +402,30 @@ mod tests {
         let mut inner = IndexMap::new();
         inner.insert(
             "hostname_type".to_string(),
-            Value::String("ip-name".to_string()),
+            Value::Concrete(ConcreteValue::String("ip-name".to_string())),
         );
         inner.insert(
             "enable_resource_name_dns_a_record".to_string(),
-            Value::Bool(true),
+            Value::Concrete(ConcreteValue::Bool(true)),
         );
         let mut attributes = HashMap::from([(
             "private_dns_name_options_on_launch".to_string(),
-            Value::Map(inner),
+            Value::Concrete(ConcreteValue::Map(inner)),
         )]);
         normalize_state_enums("ec2.Subnet", &mut attributes);
-        if let Some(Value::Map(fields)) = attributes.get("private_dns_name_options_on_launch") {
+        if let Some(Value::Concrete(ConcreteValue::Map(fields))) =
+            attributes.get("private_dns_name_options_on_launch")
+        {
             assert_eq!(
                 fields.get("hostname_type"),
-                Some(&Value::String(
+                Some(&Value::Concrete(ConcreteValue::String(
                     "aws.ec2.Subnet.HostnameType.ip_name".to_string()
-                ))
+                )))
             );
             // Non-enum fields should not be modified
             assert_eq!(
                 fields.get("enable_resource_name_dns_a_record"),
-                Some(&Value::Bool(true))
+                Some(&Value::Concrete(ConcreteValue::Bool(true)))
             );
         } else {
             panic!("Expected Value::Map for private_dns_name_options_on_launch");
@@ -392,14 +434,16 @@ mod tests {
 
     #[test]
     fn test_normalize_state_enums_ec2_security_group_egress_tcp() {
-        let mut attributes =
-            HashMap::from([("ip_protocol".to_string(), Value::String("tcp".to_string()))]);
+        let mut attributes = HashMap::from([(
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("tcp".to_string())),
+        )]);
         normalize_state_enums("ec2.SecurityGroupEgress", &mut attributes);
         assert_eq!(
             attributes.get("ip_protocol"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.SecurityGroupEgress.IpProtocol.tcp".to_string()
-            ))
+            )))
         );
     }
 
@@ -407,14 +451,16 @@ mod tests {
     fn test_normalize_state_enums_vpn_gateway_type_with_dot() {
         // "ipsec.1" contains a dot but is a raw enum value, not a namespaced identifier.
         // The normalizer should recognize it as a valid enum value and namespace it.
-        let mut attributes =
-            HashMap::from([("type".to_string(), Value::String("ipsec.1".to_string()))]);
+        let mut attributes = HashMap::from([(
+            "type".to_string(),
+            Value::Concrete(ConcreteValue::String("ipsec.1".to_string())),
+        )]);
         normalize_state_enums("ec2.VpnGateway", &mut attributes);
         assert_eq!(
             attributes.get("type"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.VpnGateway.Type.ipsec.1".to_string()
-            ))
+            )))
         );
     }
 
@@ -423,14 +469,16 @@ mod tests {
         // Already in DSL format — should NOT be double-normalized.
         let mut attributes = HashMap::from([(
             "type".to_string(),
-            Value::String("aws.ec2.VpnGateway.Type.ipsec.1".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "aws.ec2.VpnGateway.Type.ipsec.1".to_string(),
+            )),
         )]);
         normalize_state_enums("ec2.VpnGateway", &mut attributes);
         assert_eq!(
             attributes.get("type"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "aws.ec2.VpnGateway.Type.ipsec.1".to_string()
-            ))
+            )))
         );
     }
 }

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 #[allow(unused_imports)]
 use carina_core::utils::extract_enum_value;
 
@@ -161,16 +161,22 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.cidr_block() {
-            attributes.insert("cidr_block".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "cidr_block".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.instance_tenancy() {
             attributes.insert(
                 "instance_tenancy".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.vpc_id() {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.vpc_id().map(String::from)
     }
@@ -183,72 +189,93 @@ impl AwsProvider {
         if let Some(v) = obj.assign_ipv6_address_on_creation() {
             attributes.insert(
                 "assign_ipv6_address_on_creation".to_string(),
-                Value::Bool(v),
+                Value::Concrete(ConcreteValue::Bool(v)),
             );
         }
         if let Some(v) = obj.availability_zone() {
             attributes.insert(
                 "availability_zone".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.availability_zone_id() {
             attributes.insert(
                 "availability_zone_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.cidr_block() {
-            attributes.insert("cidr_block".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "cidr_block".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.enable_dns64() {
-            attributes.insert("enable_dns64".to_string(), Value::Bool(v));
+            attributes.insert(
+                "enable_dns64".to_string(),
+                Value::Concrete(ConcreteValue::Bool(v)),
+            );
         }
         if let Some(v) = obj.enable_lni_at_device_index() {
             attributes.insert(
                 "enable_lni_at_device_index".to_string(),
-                Value::Int(v as i64),
+                Value::Concrete(ConcreteValue::Int(v as i64)),
             );
         }
         if let Some(v) = obj.ipv6_native() {
-            attributes.insert("ipv6_native".to_string(), Value::Bool(v));
+            attributes.insert(
+                "ipv6_native".to_string(),
+                Value::Concrete(ConcreteValue::Bool(v)),
+            );
         }
         if let Some(v) = obj.map_public_ip_on_launch() {
-            attributes.insert("map_public_ip_on_launch".to_string(), Value::Bool(v));
+            attributes.insert(
+                "map_public_ip_on_launch".to_string(),
+                Value::Concrete(ConcreteValue::Bool(v)),
+            );
         }
         if let Some(v) = obj.outpost_arn() {
-            attributes.insert("outpost_arn".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "outpost_arn".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.subnet_id() {
-            attributes.insert("subnet_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "subnet_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.vpc_id() {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(dns_opts) = obj.private_dns_name_options_on_launch() {
             let mut fields = IndexMap::new();
             if let Some(v) = dns_opts.hostname_type() {
                 fields.insert(
                     "hostname_type".to_string(),
-                    Value::String(v.as_str().to_string()),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
                 );
             }
             if let Some(v) = dns_opts.enable_resource_name_dns_a_record() {
                 fields.insert(
                     "enable_resource_name_dns_a_record".to_string(),
-                    Value::Bool(v),
+                    Value::Concrete(ConcreteValue::Bool(v)),
                 );
             }
             if let Some(v) = dns_opts.enable_resource_name_dns_aaaa_record() {
                 fields.insert(
                     "enable_resource_name_dns_aaaa_record".to_string(),
-                    Value::Bool(v),
+                    Value::Concrete(ConcreteValue::Bool(v)),
                 );
             }
             if !fields.is_empty() {
                 attributes.insert(
                     "private_dns_name_options_on_launch".to_string(),
-                    Value::Map(fields),
+                    Value::Concrete(ConcreteValue::Map(fields)),
                 );
             }
         }
@@ -263,7 +290,7 @@ impl AwsProvider {
         if let Some(v) = obj.internet_gateway_id() {
             attributes.insert(
                 "internet_gateway_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         obj.internet_gateway_id().map(String::from)
@@ -275,10 +302,16 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.route_table_id() {
-            attributes.insert("route_table_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "route_table_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.vpc_id() {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.route_table_id().map(String::from)
     }
@@ -291,14 +324,20 @@ impl AwsProvider {
         if let Some(v) = obj.destination_cidr_block() {
             attributes.insert(
                 "destination_cidr_block".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.gateway_id() {
-            attributes.insert("gateway_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "gateway_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.nat_gateway_id() {
-            attributes.insert("nat_gateway_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "nat_gateway_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         None
     }
@@ -309,16 +348,28 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.description() {
-            attributes.insert("description".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "description".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.group_id() {
-            attributes.insert("group_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "group_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.group_name() {
-            attributes.insert("group_name".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "group_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.vpc_id() {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.group_id().map(String::from)
     }
@@ -329,34 +380,52 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.cidr_ipv6() {
-            attributes.insert("cidr_ipv6".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "cidr_ipv6".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.description() {
-            attributes.insert("description".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "description".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.from_port() {
-            attributes.insert("from_port".to_string(), Value::Int(v as i64));
+            attributes.insert(
+                "from_port".to_string(),
+                Value::Concrete(ConcreteValue::Int(v as i64)),
+            );
         }
         if let Some(v) = obj.group_id() {
-            attributes.insert("group_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "group_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.ip_protocol() {
-            attributes.insert("ip_protocol".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "ip_protocol".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.security_group_rule_id() {
             attributes.insert(
                 "security_group_rule_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.prefix_list_id() {
             attributes.insert(
                 "source_prefix_list_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.to_port() {
-            attributes.insert("to_port".to_string(), Value::Int(v as i64));
+            attributes.insert(
+                "to_port".to_string(),
+                Value::Concrete(ConcreteValue::Int(v as i64)),
+            );
         }
         obj.security_group_rule_id().map(String::from)
     }
@@ -367,34 +436,52 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.cidr_ipv6() {
-            attributes.insert("cidr_ipv6".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "cidr_ipv6".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.description() {
-            attributes.insert("description".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "description".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.prefix_list_id() {
             attributes.insert(
                 "destination_prefix_list_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.from_port() {
-            attributes.insert("from_port".to_string(), Value::Int(v as i64));
+            attributes.insert(
+                "from_port".to_string(),
+                Value::Concrete(ConcreteValue::Int(v as i64)),
+            );
         }
         if let Some(v) = obj.group_id() {
-            attributes.insert("group_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "group_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.ip_protocol() {
-            attributes.insert("ip_protocol".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "ip_protocol".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.security_group_rule_id() {
             attributes.insert(
                 "security_group_rule_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.to_port() {
-            attributes.insert("to_port".to_string(), Value::Int(v as i64));
+            attributes.insert(
+                "to_port".to_string(),
+                Value::Concrete(ConcreteValue::Int(v as i64)),
+            );
         }
         obj.security_group_rule_id().map(String::from)
     }
@@ -407,13 +494,16 @@ impl AwsProvider {
         if let Some(v) = obj.egress_only_internet_gateway_id() {
             attributes.insert(
                 "egress_only_internet_gateway_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(addr) = obj.attachments().first()
             && let Some(v) = addr.vpc_id()
         {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.egress_only_internet_gateway_id().map(String::from)
     }
@@ -424,16 +514,28 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.allocation_id() {
-            attributes.insert("allocation_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "allocation_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.domain() {
-            attributes.insert("domain".to_string(), Value::String(v.as_str().to_string()));
+            attributes.insert(
+                "domain".to_string(),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+            );
         }
         if let Some(v) = obj.public_ip() {
-            attributes.insert("public_ip".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "public_ip".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.public_ipv4_pool() {
-            attributes.insert("public_ipv4_pool".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "public_ipv4_pool".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.allocation_id().map(String::from)
     }
@@ -446,28 +548,40 @@ impl AwsProvider {
         if let Some(v) = obj.availability_mode() {
             attributes.insert(
                 "availability_mode".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.connectivity_type() {
             attributes.insert(
                 "connectivity_type".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.nat_gateway_id() {
-            attributes.insert("nat_gateway_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "nat_gateway_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.subnet_id() {
-            attributes.insert("subnet_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "subnet_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.vpc_id() {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(addr) = obj.nat_gateway_addresses().first()
             && let Some(v) = addr.allocation_id()
         {
-            attributes.insert("allocation_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "allocation_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.nat_gateway_id().map(String::from)
     }
@@ -478,13 +592,22 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.public_ipv4_pool() {
-            attributes.insert("public_ipv4_pool".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "public_ipv4_pool".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.route_table_id() {
-            attributes.insert("route_table_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "route_table_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.subnet_id() {
-            attributes.insert("subnet_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "subnet_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         None
     }
@@ -495,25 +618,31 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.description() {
-            attributes.insert("description".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "description".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.transit_gateway_id() {
             attributes.insert(
                 "transit_gateway_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(opts) = obj.options()
             && let Some(v) = opts.amazon_side_asn()
         {
-            attributes.insert("amazon_side_asn".to_string(), Value::Int(v));
+            attributes.insert(
+                "amazon_side_asn".to_string(),
+                Value::Concrete(ConcreteValue::Int(v)),
+            );
         }
         if let Some(opts) = obj.options()
             && let Some(v) = opts.auto_accept_shared_attachments()
         {
             attributes.insert(
                 "auto_accept_shared_attachments".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(opts) = obj.options()
@@ -521,7 +650,7 @@ impl AwsProvider {
         {
             attributes.insert(
                 "default_route_table_association".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(opts) = obj.options()
@@ -529,7 +658,7 @@ impl AwsProvider {
         {
             attributes.insert(
                 "default_route_table_propagation".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(opts) = obj.options()
@@ -537,7 +666,7 @@ impl AwsProvider {
         {
             attributes.insert(
                 "dns_support".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(opts) = obj.options()
@@ -545,7 +674,7 @@ impl AwsProvider {
         {
             attributes.insert(
                 "vpn_ecmp_support".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         obj.transit_gateway_id().map(String::from)
@@ -559,24 +688,33 @@ impl AwsProvider {
         {
             let ids = obj.subnet_ids();
             if !ids.is_empty() {
-                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
-                attributes.insert("subnet_ids".to_string(), Value::List(list));
+                let list: Vec<Value> = ids
+                    .iter()
+                    .map(|s| Value::Concrete(ConcreteValue::String(s.to_string())))
+                    .collect();
+                attributes.insert(
+                    "subnet_ids".to_string(),
+                    Value::Concrete(ConcreteValue::List(list)),
+                );
             }
         }
         if let Some(v) = obj.transit_gateway_attachment_id() {
             attributes.insert(
                 "transit_gateway_attachment_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.transit_gateway_id() {
             attributes.insert(
                 "transit_gateway_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.vpc_id() {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.transit_gateway_attachment_id().map(String::from)
     }
@@ -589,28 +727,40 @@ impl AwsProvider {
         if let Some(v) = obj.vpc_peering_connection_id() {
             attributes.insert(
                 "vpc_peering_connection_id".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(opts) = obj.requester_vpc_info()
             && let Some(v) = opts.vpc_id()
         {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(opts) = obj.accepter_vpc_info()
             && let Some(v) = opts.vpc_id()
         {
-            attributes.insert("peer_vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "peer_vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(opts) = obj.accepter_vpc_info()
             && let Some(v) = opts.owner_id()
         {
-            attributes.insert("peer_owner_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "peer_owner_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(opts) = obj.accepter_vpc_info()
             && let Some(v) = opts.region()
         {
-            attributes.insert("peer_region".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "peer_region".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.vpc_peering_connection_id().map(String::from)
     }
@@ -621,19 +771,28 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.amazon_side_asn() {
-            attributes.insert("amazon_side_asn".to_string(), Value::Int(v));
+            attributes.insert(
+                "amazon_side_asn".to_string(),
+                Value::Concrete(ConcreteValue::Int(v)),
+            );
         }
         if let Some(v) = obj.availability_zone() {
             attributes.insert(
                 "availability_zone".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.r#type() {
-            attributes.insert("type".to_string(), Value::String(v.as_str().to_string()));
+            attributes.insert(
+                "type".to_string(),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+            );
         }
         if let Some(v) = obj.vpn_gateway_id() {
-            attributes.insert("vpn_gateway_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpn_gateway_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         obj.vpn_gateway_id().map(String::from)
     }
@@ -645,7 +804,10 @@ impl AwsProvider {
     ) -> Option<String> {
         let v = obj.name();
         if !v.is_empty() {
-            attributes.insert("name".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         Some(obj.name().to_string())
     }
@@ -656,22 +818,34 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.deletion_protection_enabled() {
-            attributes.insert("deletion_protection_enabled".to_string(), Value::Bool(v));
+            attributes.insert(
+                "deletion_protection_enabled".to_string(),
+                Value::Concrete(ConcreteValue::Bool(v)),
+            );
         }
         if let Some(v) = obj.kms_key_id() {
-            attributes.insert("kms_key_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "kms_key_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.log_group_class() {
             attributes.insert(
                 "log_group_class".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.log_group_name() {
-            attributes.insert("log_group_name".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "log_group_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.retention_in_days() {
-            attributes.insert("retention_in_days".to_string(), Value::Int(v as i64));
+            attributes.insert(
+                "retention_in_days".to_string(),
+                Value::Concrete(ConcreteValue::Int(v as i64)),
+            );
         }
         None
     }
@@ -682,35 +856,53 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.certificate_arn() {
-            attributes.insert("certificate_arn".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "certificate_arn".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.domain_name() {
-            attributes.insert("domain_name".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "domain_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.key_algorithm() {
             attributes.insert(
                 "key_algorithm".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.renewal_eligibility() {
             attributes.insert(
                 "renewal_eligibility".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.status() {
-            attributes.insert("status".to_string(), Value::String(v.as_str().to_string()));
+            attributes.insert(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+            );
         }
         {
             let ids = obj.subject_alternative_names();
             if !ids.is_empty() {
-                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
-                attributes.insert("subject_alternative_names".to_string(), Value::List(list));
+                let list: Vec<Value> = ids
+                    .iter()
+                    .map(|s| Value::Concrete(ConcreteValue::String(s.to_string())))
+                    .collect();
+                attributes.insert(
+                    "subject_alternative_names".to_string(),
+                    Value::Concrete(ConcreteValue::List(list)),
+                );
             }
         }
         if let Some(v) = obj.r#type() {
-            attributes.insert("type".to_string(), Value::String(v.as_str().to_string()));
+            attributes.insert(
+                "type".to_string(),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+            );
         }
         obj.certificate_arn().map(String::from)
     }

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
@@ -13,7 +13,7 @@ use carina_core::schema::{
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all", "_1"];
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {
@@ -25,7 +25,7 @@ fn validate_from_port_range(value: &Value) -> Result<(), String> {
 }
 
 fn validate_to_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
@@ -13,7 +13,7 @@ use carina_core::schema::{
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all", "_1"];
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {
@@ -25,7 +25,7 @@ fn validate_from_port_range(value: &Value) -> Result<(), String> {
 }
 
 fn validate_to_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator, types,
 };
@@ -15,7 +15,7 @@ use carina_core::schema::{
 const VALID_HOSTNAME_TYPE: &[&str] = &["ip-name", "resource-name", "ip_name", "resource_name"];
 
 fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 || *n > 32 {
             Err(format!("Value {} is out of range 0..=32", n))
         } else {
@@ -27,7 +27,7 @@ fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
 }
 
 fn validate_ipv6_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 || *n > 128 {
             Err(format!("Value {} is out of range 0..=128", n))
         } else {

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
@@ -15,7 +15,7 @@ use carina_core::schema::{
 const VALID_INSTANCE_TENANCY: &[&str] = &["dedicated", "default", "host"];
 
 fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 || *n > 32 {
             Err(format!("Value {} is out of range 0..=32", n))
         } else {

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -7,11 +7,11 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
 fn validate_max_session_duration_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 3600 || *n > 43200 {
             Err(format!("Value {} is out of range 3600..=43200", n))
         } else {

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
 };
@@ -17,7 +17,7 @@ const VALID_TYPE: &[&str] = &[
 ];
 
 fn validate_ttl_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 || *n > 2147483647 {
             Err(format!("Value {} is out of range 0..=2147483647", n))
         } else {

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -7,7 +7,7 @@ pub use carina_aws_types::*;
 
 use std::collections::HashMap;
 
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeType, ResourceSchema, legacy_validator};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 
@@ -37,7 +37,7 @@ pub fn aws_region() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_enum_namespace(s, "Region", "aws")
                     .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
                 // Normalize the input to AWS format (hyphens)
@@ -72,7 +72,7 @@ pub fn availability_zone() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_enum_namespace(s, "AvailabilityZone", "aws")
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 let extracted = extract_enum_value(s);
@@ -103,7 +103,7 @@ pub fn s3_grantee() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 if s.is_empty() {
                     return Err("Grantee specification must not be empty".to_string());
                 }
@@ -219,7 +219,9 @@ mod tests {
         let region_type = aws_region();
         assert!(
             region_type
-                .validate(&Value::String("ap-northeast-1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "ap-northeast-1".to_string()
+                )))
                 .is_ok()
         );
     }
@@ -229,7 +231,9 @@ mod tests {
         let region_type = aws_region();
         assert!(
             region_type
-                .validate(&Value::String("aws.Region.ap_northeast_1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "aws.Region.ap_northeast_1".to_string()
+                )))
                 .is_ok()
         );
     }
@@ -239,7 +243,9 @@ mod tests {
         let region_type = aws_region();
         assert!(
             region_type
-                .validate(&Value::String("Region.ap_northeast_1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "Region.ap_northeast_1".to_string()
+                )))
                 .is_ok()
         );
     }
@@ -247,7 +253,9 @@ mod tests {
     #[test]
     fn region_rejects_invalid_region() {
         let region_type = aws_region();
-        let result = region_type.validate(&Value::String("invalid-region".to_string()));
+        let result = region_type.validate(&Value::Concrete(ConcreteValue::String(
+            "invalid-region".to_string(),
+        )));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Invalid region"));
@@ -260,7 +268,9 @@ mod tests {
         // ap-northeast-1a is an AZ, not a region
         assert!(
             region_type
-                .validate(&Value::String("ap-northeast-1a".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "ap-northeast-1a".to_string()
+                )))
                 .is_err()
         );
     }
@@ -271,7 +281,7 @@ mod tests {
         for (region, _) in REGIONS {
             assert!(
                 region_type
-                    .validate(&Value::String(region.to_string()))
+                    .validate(&Value::Concrete(ConcreteValue::String(region.to_string())))
                     .is_ok(),
                 "Region {} should be valid",
                 region
@@ -286,7 +296,9 @@ mod tests {
         let az_type = availability_zone();
         assert!(
             az_type
-                .validate(&Value::String("us-east-1a".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "us-east-1a".to_string()
+                )))
                 .is_ok()
         );
     }
@@ -296,9 +308,9 @@ mod tests {
         let az_type = availability_zone();
         assert!(
             az_type
-                .validate(&Value::String(
+                .validate(&Value::Concrete(ConcreteValue::String(
                     "aws.AvailabilityZone.us_east_1a".to_string()
-                ))
+                )))
                 .is_ok()
         );
     }
@@ -308,7 +320,9 @@ mod tests {
         let az_type = availability_zone();
         assert!(
             az_type
-                .validate(&Value::String("us_east_1a".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "us_east_1a".to_string()
+                )))
                 .is_ok()
         );
     }
@@ -318,7 +332,9 @@ mod tests {
         let az_type = availability_zone();
         assert!(
             az_type
-                .validate(&Value::String("invalid-zone".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "invalid-zone".to_string()
+                )))
                 .is_err()
         );
     }
@@ -328,9 +344,9 @@ mod tests {
         let az_type = availability_zone();
         assert!(
             az_type
-                .validate(&Value::String(
+                .validate(&Value::Concrete(ConcreteValue::String(
                     "gcp.AvailabilityZone.us_east_1a".to_string()
-                ))
+                )))
                 .is_err()
         );
     }
@@ -363,10 +379,10 @@ mod tests {
     fn grantee_accepts_id_format() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::String(
+            t.validate(&Value::Concrete(ConcreteValue::String(
                 "id=\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\""
                     .to_string()
-            ))
+            )))
             .is_ok()
         );
     }
@@ -375,9 +391,9 @@ mod tests {
     fn grantee_accepts_email_format() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::String(
+            t.validate(&Value::Concrete(ConcreteValue::String(
                 "emailAddress=\"user@example.com\"".to_string()
-            ))
+            )))
             .is_ok()
         );
     }
@@ -386,9 +402,9 @@ mod tests {
     fn grantee_accepts_uri_format() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::String(
+            t.validate(&Value::Concrete(ConcreteValue::String(
                 "uri=\"http://acs.amazonaws.com/groups/global/AllUsers\"".to_string()
-            ))
+            )))
             .is_ok()
         );
     }
@@ -397,9 +413,9 @@ mod tests {
     fn grantee_accepts_multiple_specs() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::String(
+            t.validate(&Value::Concrete(ConcreteValue::String(
                 "id=\"abc123\", emailAddress=\"user@example.com\"".to_string()
-            ))
+            )))
             .is_ok()
         );
     }
@@ -407,13 +423,18 @@ mod tests {
     #[test]
     fn grantee_rejects_empty_string() {
         let t = s3_grantee();
-        assert!(t.validate(&Value::String("".to_string())).is_err());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String("".to_string())))
+                .is_err()
+        );
     }
 
     #[test]
     fn grantee_rejects_invalid_prefix() {
         let t = s3_grantee();
-        let result = t.validate(&Value::String("foo=\"bar\"".to_string()));
+        let result = t.validate(&Value::Concrete(ConcreteValue::String(
+            "foo=\"bar\"".to_string(),
+        )));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("must start with id=, emailAddress=, or uri="));
@@ -424,22 +445,30 @@ mod tests {
         let region_type = aws_region();
         assert!(
             region_type
-                .validate(&Value::String("gcp.Region.ap_northeast_1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "gcp.Region.ap_northeast_1".to_string()
+                )))
                 .is_err()
         );
         assert!(
             region_type
-                .validate(&Value::String("aws.Location.ap_northeast_1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "aws.Location.ap_northeast_1".to_string()
+                )))
                 .is_err()
         );
         assert!(
             region_type
-                .validate(&Value::String("foo.bar.baz.ap_northeast_1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "foo.bar.baz.ap_northeast_1".to_string()
+                )))
                 .is_err()
         );
         assert!(
             region_type
-                .validate(&Value::String("Location.ap_northeast_1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "Location.ap_northeast_1".to_string()
+                )))
                 .is_err()
         );
     }

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -16,13 +16,13 @@ use aws_sdk_acm::types::{DomainValidationOption, ValidationMethod};
 use indexmap::IndexMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
 
 fn extract_string(value: &Value) -> Option<&str> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         Some(s.as_str())
     } else {
         None
@@ -30,18 +30,18 @@ fn extract_string(value: &Value) -> Option<&str> {
 }
 
 fn extract_string_list(value: &Value) -> Vec<String> {
-    if let Value::List(items) = value {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
         items
             .iter()
             .filter_map(|v| {
-                if let Value::String(s) = v {
+                if let Value::Concrete(ConcreteValue::String(s)) = v {
                     Some(s.clone())
                 } else {
                     None
                 }
             })
             .collect()
-    } else if let Value::StringList(items) = value {
+    } else if let Value::Concrete(ConcreteValue::StringList(items)) = value {
         items.clone()
     } else {
         Vec::new()
@@ -92,9 +92,11 @@ impl AwsProvider {
         }
         // `domain_validation_options` (per-SAN validation domain
         // override) is parsed from a list of structs.
-        if let Some(Value::List(opts)) = resource.get_attr("domain_validation_options") {
+        if let Some(Value::Concrete(ConcreteValue::List(opts))) =
+            resource.get_attr("domain_validation_options")
+        {
             for entry in opts {
-                if let Value::Map(map) = entry {
+                if let Value::Concrete(ConcreteValue::Map(map)) = entry {
                     let domain = map.get("domain_name").and_then(extract_string);
                     let validation_domain = map.get("validation_domain").and_then(extract_string);
                     if let (Some(d), Some(vd)) = (domain, validation_domain) {
@@ -155,34 +157,48 @@ impl AwsProvider {
 
         let mut attributes: HashMap<String, Value> = HashMap::new();
         if let Some(v) = cert.domain_name() {
-            attributes.insert("domain_name".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "domain_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = cert.certificate_arn() {
-            attributes.insert("arn".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "arn".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = cert.status() {
-            attributes.insert("status".to_string(), Value::String(v.as_str().to_string()));
+            attributes.insert(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+            );
         }
         if let Some(v) = cert.r#type() {
-            attributes.insert("type".to_string(), Value::String(v.as_str().to_string()));
+            attributes.insert(
+                "type".to_string(),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+            );
         }
         if let Some(v) = cert.key_algorithm() {
             attributes.insert(
                 "key_algorithm".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = cert.renewal_eligibility() {
             attributes.insert(
                 "renewal_eligibility".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         let sans = cert.subject_alternative_names();
         if !sans.is_empty() {
             attributes.insert(
                 "subject_alternative_names".to_string(),
-                Value::List(sans.iter().map(|s| Value::String(s.clone())).collect()),
+                Value::Concrete(ConcreteValue::List(
+                    sans.iter().map(|s| Value::String(s.clone())).collect(),
+                )),
             );
         }
         // domain_validation_options carries the DNS records the user
@@ -195,37 +211,40 @@ impl AwsProvider {
                 let mut m: IndexMap<String, Value> = IndexMap::new();
                 m.insert(
                     "domain_name".to_string(),
-                    Value::String(dv.domain_name().to_string()),
+                    Value::Concrete(ConcreteValue::String(dv.domain_name().to_string())),
                 );
                 if let Some(rr) = dv.resource_record() {
                     m.insert(
                         "resource_record_name".to_string(),
-                        Value::String(rr.name().to_string()),
+                        Value::Concrete(ConcreteValue::String(rr.name().to_string())),
                     );
                     m.insert(
                         "resource_record_type".to_string(),
-                        Value::String(rr.r#type().as_str().to_string()),
+                        Value::Concrete(ConcreteValue::String(rr.r#type().as_str().to_string())),
                     );
                     m.insert(
                         "resource_record_value".to_string(),
-                        Value::String(rr.value().to_string()),
+                        Value::Concrete(ConcreteValue::String(rr.value().to_string())),
                     );
                 }
                 if let Some(status) = dv.validation_status() {
                     m.insert(
                         "validation_status".to_string(),
-                        Value::String(status.as_str().to_string()),
+                        Value::Concrete(ConcreteValue::String(status.as_str().to_string())),
                     );
                 }
                 if let Some(method) = dv.validation_method() {
                     m.insert(
                         "validation_method".to_string(),
-                        Value::String(method.as_str().to_string()),
+                        Value::Concrete(ConcreteValue::String(method.as_str().to_string())),
                     );
                 }
-                list.push(Value::Map(m));
+                list.push(Value::Concrete(ConcreteValue::Map(m)));
             }
-            attributes.insert("domain_validation_options".to_string(), Value::List(list));
+            attributes.insert(
+                "domain_validation_options".to_string(),
+                Value::Concrete(ConcreteValue::List(list)),
+            );
         }
         // The user-supplied validation_method is preserved from the
         // request side (DescribeCertificate doesn't echo the top-level
@@ -237,7 +256,7 @@ impl AwsProvider {
         {
             attributes.insert(
                 "validation_method".to_string(),
-                Value::String(method.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(method.as_str().to_string())),
             );
         }
 
@@ -258,10 +277,13 @@ impl AwsProvider {
             for tag in tags {
                 if let Some(k) = Some(tag.key()) {
                     let v = tag.value().unwrap_or("").to_string();
-                    tag_map.insert(k.to_string(), Value::String(v));
+                    tag_map.insert(k.to_string(), Value::Concrete(ConcreteValue::String(v)));
                 }
             }
-            attributes.insert("tags".to_string(), Value::Map(tag_map));
+            attributes.insert(
+                "tags".to_string(),
+                Value::Concrete(ConcreteValue::Map(tag_map)),
+            );
         }
 
         Ok(State::existing(id.clone(), attributes).with_identifier(arn))

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -62,7 +62,7 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_eip(&self, resource: Resource) -> ProviderResult<State> {
         let mut req = self.ec2_client.allocate_address();
 
-        if let Some(Value::String(domain)) = resource.get_attr("domain") {
+        if let Some(Value::Concrete(ConcreteValue::String(domain))) = resource.get_attr("domain") {
             use aws_sdk_ec2::types::DomainType;
             let domain_type = DomainType::from(extract_enum_value(domain));
             req = req.domain(domain_type);

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -46,10 +46,12 @@ impl AwsProvider {
             // describe response exposes one resource_id per FlowLog entity. The
             // generated extractor inserts the singular key, so replace it here
             // with a one-element list matching the schema.
-            if let Some(Value::String(rid)) = attributes.remove("resource_id") {
+            if let Some(Value::Concrete(ConcreteValue::String(rid))) =
+                attributes.remove("resource_id")
+            {
                 attributes.insert(
                     "resource_ids".to_string(),
-                    Value::List(vec![Value::String(rid)]),
+                    Value::Concrete(ConcreteValue::List(vec![Value::String(rid)])),
                 );
             }
 
@@ -72,10 +74,10 @@ impl AwsProvider {
     /// Create an EC2 Flow Log
     pub(crate) async fn create_ec2_flow_log(&self, resource: Resource) -> ProviderResult<State> {
         let resource_ids_val: Vec<String> = match resource.get_attr("resource_ids") {
-            Some(Value::List(items)) => items
+            Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
                 .filter_map(|v| {
-                    if let Value::String(s) = v {
+                    if let Value::Concrete(ConcreteValue::String(s)) = v {
                         Some(s.clone())
                     } else {
                         None
@@ -92,7 +94,7 @@ impl AwsProvider {
         }
 
         let resource_type_val = match resource.get_attr("resource_type") {
-            Some(Value::String(s)) => extract_enum_value(s).to_string(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => extract_enum_value(s).to_string(),
             _ => {
                 return Err(ProviderError::invalid_input("resource_type is required")
                     .for_resource(resource.id.clone()));
@@ -107,13 +109,17 @@ impl AwsProvider {
                 resource_type_val.as_str(),
             ));
 
-        if let Some(Value::String(traffic_type)) = resource.get_attr("traffic_type") {
+        if let Some(Value::Concrete(ConcreteValue::String(traffic_type))) =
+            resource.get_attr("traffic_type")
+        {
             use aws_sdk_ec2::types::TrafficType;
             let tt = TrafficType::from(extract_enum_value(traffic_type));
             req = req.traffic_type(tt);
         }
 
-        if let Some(Value::String(log_dest_type)) = resource.get_attr("log_destination_type") {
+        if let Some(Value::Concrete(ConcreteValue::String(log_dest_type))) =
+            resource.get_attr("log_destination_type")
+        {
             use aws_sdk_ec2::types::LogDestinationType;
             let raw = extract_enum_value(log_dest_type);
             // Map DSL snake_case enum values back to API hyphenated format
@@ -126,23 +132,33 @@ impl AwsProvider {
             req = req.log_destination_type(ldt);
         }
 
-        if let Some(Value::String(log_dest)) = resource.get_attr("log_destination") {
+        if let Some(Value::Concrete(ConcreteValue::String(log_dest))) =
+            resource.get_attr("log_destination")
+        {
             req = req.log_destination(log_dest);
         }
 
-        if let Some(Value::String(log_group)) = resource.get_attr("log_group_name") {
+        if let Some(Value::Concrete(ConcreteValue::String(log_group))) =
+            resource.get_attr("log_group_name")
+        {
             req = req.log_group_name(log_group);
         }
 
-        if let Some(Value::String(perm_arn)) = resource.get_attr("deliver_logs_permission_arn") {
+        if let Some(Value::Concrete(ConcreteValue::String(perm_arn))) =
+            resource.get_attr("deliver_logs_permission_arn")
+        {
             req = req.deliver_logs_permission_arn(perm_arn);
         }
 
-        if let Some(Value::String(log_format)) = resource.get_attr("log_format") {
+        if let Some(Value::Concrete(ConcreteValue::String(log_format))) =
+            resource.get_attr("log_format")
+        {
             req = req.log_format(log_format);
         }
 
-        if let Some(Value::Int(interval)) = resource.get_attr("max_aggregation_interval") {
+        if let Some(Value::Concrete(ConcreteValue::Int(interval))) =
+            resource.get_attr("max_aggregation_interval")
+        {
             req = req.max_aggregation_interval(*interval as i32);
         }
 
@@ -290,40 +306,58 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.flow_log_id() {
-            attributes.insert("flow_log_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "flow_log_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.resource_id() {
-            attributes.insert("resource_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "resource_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.traffic_type() {
             attributes.insert(
                 "traffic_type".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.log_destination_type() {
             attributes.insert(
                 "log_destination_type".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.log_destination() {
-            attributes.insert("log_destination".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "log_destination".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.log_group_name() {
-            attributes.insert("log_group_name".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "log_group_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.deliver_logs_permission_arn() {
             attributes.insert(
                 "deliver_logs_permission_arn".to_string(),
-                Value::String(v.to_string()),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
         if let Some(v) = obj.log_format() {
-            attributes.insert("log_format".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "log_format".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.max_aggregation_interval() {
-            attributes.insert("max_aggregation_interval".to_string(), Value::Int(v as i64));
+            attributes.insert(
+                "max_aggregation_interval".to_string(),
+                Value::Concrete(ConcreteValue::Int(v as i64)),
+            );
         }
         if let Some(v) = obj.flow_log_status()
             && v == "ACTIVE"
@@ -344,7 +378,7 @@ impl AwsProvider {
                 if !resource_type_str.is_empty() {
                     attributes.insert(
                         "resource_type".to_string(),
-                        Value::String(resource_type_str.to_string()),
+                        Value::Concrete(ConcreteValue::String(resource_type_str.to_string())),
                     );
                 }
             }

--- a/carina-provider-aws/src/services/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/internet_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::sdk_error_message;
@@ -49,7 +49,10 @@ impl AwsProvider {
             if let Some(attachment) = igw.attachments().first()
                 && let Some(vpc_id) = attachment.vpc_id()
             {
-                attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
+                attributes.insert(
+                    "vpc_id".to_string(),
+                    Value::Concrete(ConcreteValue::String(vpc_id.to_string())),
+                );
             }
 
             // Extract user-defined tags
@@ -97,7 +100,7 @@ impl AwsProvider {
             .await?;
 
         // Attach to VPC if specified
-        if let Some(Value::String(vpc_id)) = resource.get_attr("vpc_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(vpc_id))) = resource.get_attr("vpc_id") {
             self.ec2_client
                 .attach_internet_gateway()
                 .internet_gateway_id(igw_id)

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use aws_sdk_ec2::types::NatGatewayState;
@@ -73,11 +73,15 @@ impl AwsProvider {
 
         let mut req = self.ec2_client.create_nat_gateway().subnet_id(&subnet_id);
 
-        if let Some(Value::String(alloc_id)) = resource.get_attr("allocation_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(alloc_id))) =
+            resource.get_attr("allocation_id")
+        {
             req = req.allocation_id(alloc_id);
         }
 
-        if let Some(Value::String(conn_type)) = resource.get_attr("connectivity_type") {
+        if let Some(Value::Concrete(ConcreteValue::String(conn_type))) =
+            resource.get_attr("connectivity_type")
+        {
             use aws_sdk_ec2::types::ConnectivityType;
             let ct = ConnectivityType::from(extract_enum_value(conn_type));
             req = req.connectivity_type(ct);

--- a/carina-provider-aws/src/services/ec2/route.rs
+++ b/carina-provider-aws/src/services/ec2/route.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
@@ -46,7 +46,7 @@ impl AwsProvider {
                     // route_table_id is not in the Route struct, add from parameter
                     attributes.insert(
                         "route_table_id".to_string(),
-                        Value::String(route_table_id.to_string()),
+                        Value::Concrete(ConcreteValue::String(route_table_id.to_string())),
                     );
 
                     // Route identifier is route_table_id|destination_cidr_block
@@ -71,12 +71,15 @@ impl AwsProvider {
             .destination_cidr_block(&destination_cidr);
 
         // Add gateway_id if specified
-        if let Some(Value::String(gw_id)) = resource.get_attr("gateway_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(gw_id))) = resource.get_attr("gateway_id")
+        {
             req = req.gateway_id(gw_id);
         }
 
         // Add nat_gateway_id if specified
-        if let Some(Value::String(nat_gw_id)) = resource.get_attr("nat_gateway_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(nat_gw_id))) =
+            resource.get_attr("nat_gateway_id")
+        {
             req = req.nat_gateway_id(nat_gw_id);
         }
 
@@ -101,7 +104,7 @@ impl AwsProvider {
         to: Resource,
     ) -> ProviderResult<State> {
         let route_table_id = match to.get_attr("route_table_id") {
-            Some(Value::String(s)) => s.clone(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {
                 return Err(ProviderError::invalid_input("route_table_id is required")
                     .for_resource(id.clone()));
@@ -109,7 +112,7 @@ impl AwsProvider {
         };
 
         let destination_cidr = match to.get_attr("destination_cidr_block") {
-            Some(Value::String(s)) => s.clone(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {
                 return Err(
                     ProviderError::invalid_input("destination_cidr_block is required")
@@ -125,12 +128,14 @@ impl AwsProvider {
             .destination_cidr_block(&destination_cidr);
 
         // Add gateway_id if specified
-        if let Some(Value::String(gw_id)) = to.get_attr("gateway_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(gw_id))) = to.get_attr("gateway_id") {
             req = req.gateway_id(gw_id);
         }
 
         // Add nat_gateway_id if specified
-        if let Some(Value::String(nat_gw_id)) = to.get_attr("nat_gateway_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(nat_gw_id))) =
+            to.get_attr("nat_gateway_id")
+        {
             req = req.nat_gateway_id(nat_gw_id);
         }
 

--- a/carina-provider-aws/src/services/ec2/route_table.rs
+++ b/carina-provider-aws/src/services/ec2/route_table.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
@@ -47,17 +47,26 @@ impl AwsProvider {
             for route in rt.routes() {
                 let mut route_map: IndexMap<String, Value> = IndexMap::new();
                 if let Some(dest) = route.destination_cidr_block() {
-                    route_map.insert("destination".to_string(), Value::String(dest.to_string()));
+                    route_map.insert(
+                        "destination".to_string(),
+                        Value::Concrete(ConcreteValue::String(dest.to_string())),
+                    );
                 }
                 if let Some(gw) = route.gateway_id() {
-                    route_map.insert("gateway_id".to_string(), Value::String(gw.to_string()));
+                    route_map.insert(
+                        "gateway_id".to_string(),
+                        Value::Concrete(ConcreteValue::String(gw.to_string())),
+                    );
                 }
                 if !route_map.is_empty() {
-                    routes_list.push(Value::Map(route_map));
+                    routes_list.push(Value::Concrete(ConcreteValue::Map(route_map)));
                 }
             }
             if !routes_list.is_empty() {
-                attributes.insert("routes".to_string(), Value::List(routes_list));
+                attributes.insert(
+                    "routes".to_string(),
+                    Value::Concrete(ConcreteValue::List(routes_list)),
+                );
             }
 
             // Extract user-defined tags
@@ -105,18 +114,18 @@ impl AwsProvider {
             .await?;
 
         // Add routes
-        if let Some(Value::List(routes)) = resource.get_attr("routes") {
+        if let Some(Value::Concrete(ConcreteValue::List(routes))) = resource.get_attr("routes") {
             for route in routes {
-                if let Value::Map(route_map) = route {
+                if let Value::Concrete(ConcreteValue::Map(route_map)) = route {
                     let destination = route_map.get("destination").and_then(|v| {
-                        if let Value::String(s) = v {
+                        if let Value::Concrete(ConcreteValue::String(s)) = v {
                             Some(s)
                         } else {
                             None
                         }
                     });
                     let gateway_id = route_map.get("gateway_id").and_then(|v| {
-                        if let Value::String(s) = v {
+                        if let Value::Concrete(ConcreteValue::String(s)) = v {
                             Some(s)
                         } else {
                             None

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
@@ -68,13 +68,13 @@ impl AwsProvider {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
 
         let description = match resource.get_attr("description") {
-            Some(Value::String(s)) => s.clone(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => String::new(),
         };
 
         // group_name is required for CreateSecurityGroup API
         let group_name = match resource.get_attr("group_name") {
-            Some(Value::String(s)) => s.clone(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => resource.id.name.to_string(),
         };
 

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
@@ -46,7 +46,10 @@ impl AwsProvider {
             // Override availability_zone with DSL format
             if let Some(az) = subnet.availability_zone() {
                 let az_dsl = format!("aws.AvailabilityZone.{}", az.replace('-', "_"));
-                attributes.insert("availability_zone".to_string(), Value::String(az_dsl));
+                attributes.insert(
+                    "availability_zone".to_string(),
+                    Value::Concrete(ConcreteValue::String(az_dsl)),
+                );
             }
 
             // Extract user-defined tags
@@ -76,7 +79,9 @@ impl AwsProvider {
             .vpc_id(&vpc_id)
             .cidr_block(&cidr_block);
 
-        if let Some(Value::String(az)) = resource.get_attr("availability_zone") {
+        if let Some(Value::Concrete(ConcreteValue::String(az))) =
+            resource.get_attr("availability_zone")
+        {
             req = req.availability_zone(convert_enum_value(az).replace('_', "-"));
         }
 
@@ -131,7 +136,9 @@ impl AwsProvider {
         subnet_id: &str,
         attributes: &HashMap<String, Value>,
     ) -> ProviderResult<()> {
-        if let Some(Value::Bool(enabled)) = attributes.get("map_public_ip_on_launch") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
+            attributes.get("map_public_ip_on_launch")
+        {
             self.ec2_client
                 .modify_subnet_attribute()
                 .subnet_id(subnet_id)
@@ -147,7 +154,9 @@ impl AwsProvider {
                 })?;
         }
 
-        if let Some(Value::Bool(enabled)) = attributes.get("assign_ipv6_address_on_creation") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
+            attributes.get("assign_ipv6_address_on_creation")
+        {
             self.ec2_client
                 .modify_subnet_attribute()
                 .subnet_id(subnet_id)
@@ -165,7 +174,8 @@ impl AwsProvider {
                 })?;
         }
 
-        if let Some(Value::Bool(enabled)) = attributes.get("enable_dns64") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) = attributes.get("enable_dns64")
+        {
             self.ec2_client
                 .modify_subnet_attribute()
                 .subnet_id(subnet_id)
@@ -180,8 +190,10 @@ impl AwsProvider {
 
         // The ModifySubnetAttribute API only allows modifying one attribute at a time.
         // Each private_dns_name_options_on_launch field must be a separate API call.
-        if let Some(Value::Map(fields)) = attributes.get("private_dns_name_options_on_launch") {
-            if let Some(Value::String(ht)) = fields.get("hostname_type") {
+        if let Some(Value::Concrete(ConcreteValue::Map(fields))) =
+            attributes.get("private_dns_name_options_on_launch")
+        {
+            if let Some(Value::Concrete(ConcreteValue::String(ht))) = fields.get("hostname_type") {
                 let hostname_val = convert_enum_value(ht).replace('_', "-");
                 self.ec2_client
                     .modify_subnet_attribute()
@@ -197,7 +209,9 @@ impl AwsProvider {
                         .for_resource(id.clone())
                     })?;
             }
-            if let Some(Value::Bool(v)) = fields.get("enable_resource_name_dns_a_record") {
+            if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+                fields.get("enable_resource_name_dns_a_record")
+            {
                 self.ec2_client
                     .modify_subnet_attribute()
                     .subnet_id(subnet_id)
@@ -214,7 +228,9 @@ impl AwsProvider {
                         .for_resource(id.clone())
                     })?;
             }
-            if let Some(Value::Bool(v)) = fields.get("enable_resource_name_dns_aaaa_record") {
+            if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+                fields.get("enable_resource_name_dns_aaaa_record")
+            {
                 self.ec2_client
                     .modify_subnet_attribute()
                     .subnet_id(subnet_id)

--- a/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
@@ -49,18 +49,21 @@ impl AwsProvider {
 
                     attributes.insert(
                         "association_id".to_string(),
-                        Value::String(association_id.to_string()),
+                        Value::Concrete(ConcreteValue::String(association_id.to_string())),
                     );
 
                     if let Some(rt_id) = assoc.route_table_id() {
                         attributes.insert(
                             "route_table_id".to_string(),
-                            Value::String(rt_id.to_string()),
+                            Value::Concrete(ConcreteValue::String(rt_id.to_string())),
                         );
                     }
 
                     if let Some(sid) = assoc.subnet_id() {
-                        attributes.insert("subnet_id".to_string(), Value::String(sid.to_string()));
+                        attributes.insert(
+                            "subnet_id".to_string(),
+                            Value::Concrete(ConcreteValue::String(sid.to_string())),
+                        );
                     }
 
                     let composite = format!("{}|{}", association_id, subnet_id);
@@ -122,7 +125,7 @@ impl AwsProvider {
         };
 
         let route_table_id = match to.get_attr("route_table_id") {
-            Some(Value::String(s)) => s.clone(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {
                 return Err(ProviderError::invalid_input("route_table_id is required")
                     .for_resource(id.clone()));

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -66,7 +66,8 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let mut req = self.ec2_client.create_transit_gateway();
 
-        if let Some(Value::String(desc)) = resource.get_attr("description") {
+        if let Some(Value::Concrete(ConcreteValue::String(desc))) = resource.get_attr("description")
+        {
             req = req.description(desc);
         }
 
@@ -74,12 +75,15 @@ impl AwsProvider {
         let mut options = aws_sdk_ec2::types::TransitGatewayRequestOptions::builder();
         let mut has_options = false;
 
-        if let Some(Value::Int(asn)) = resource.get_attr("amazon_side_asn") {
+        if let Some(Value::Concrete(ConcreteValue::Int(asn))) = resource.get_attr("amazon_side_asn")
+        {
             options = options.amazon_side_asn(*asn);
             has_options = true;
         }
 
-        if let Some(Value::String(v)) = resource.get_attr("auto_accept_shared_attachments") {
+        if let Some(Value::Concrete(ConcreteValue::String(v))) =
+            resource.get_attr("auto_accept_shared_attachments")
+        {
             use aws_sdk_ec2::types::AutoAcceptSharedAttachmentsValue;
             options = options.auto_accept_shared_attachments(
                 AutoAcceptSharedAttachmentsValue::from(extract_enum_value(v)),
@@ -87,7 +91,9 @@ impl AwsProvider {
             has_options = true;
         }
 
-        if let Some(Value::String(v)) = resource.get_attr("default_route_table_association") {
+        if let Some(Value::Concrete(ConcreteValue::String(v))) =
+            resource.get_attr("default_route_table_association")
+        {
             use aws_sdk_ec2::types::DefaultRouteTableAssociationValue;
             options = options.default_route_table_association(
                 DefaultRouteTableAssociationValue::from(extract_enum_value(v)),
@@ -95,7 +101,9 @@ impl AwsProvider {
             has_options = true;
         }
 
-        if let Some(Value::String(v)) = resource.get_attr("default_route_table_propagation") {
+        if let Some(Value::Concrete(ConcreteValue::String(v))) =
+            resource.get_attr("default_route_table_propagation")
+        {
             use aws_sdk_ec2::types::DefaultRouteTablePropagationValue;
             options = options.default_route_table_propagation(
                 DefaultRouteTablePropagationValue::from(extract_enum_value(v)),
@@ -103,13 +111,15 @@ impl AwsProvider {
             has_options = true;
         }
 
-        if let Some(Value::String(v)) = resource.get_attr("dns_support") {
+        if let Some(Value::Concrete(ConcreteValue::String(v))) = resource.get_attr("dns_support") {
             use aws_sdk_ec2::types::DnsSupportValue;
             options = options.dns_support(DnsSupportValue::from(extract_enum_value(v)));
             has_options = true;
         }
 
-        if let Some(Value::String(v)) = resource.get_attr("vpn_ecmp_support") {
+        if let Some(Value::Concrete(ConcreteValue::String(v))) =
+            resource.get_attr("vpn_ecmp_support")
+        {
             use aws_sdk_ec2::types::VpnEcmpSupportValue;
             options = options.vpn_ecmp_support(VpnEcmpSupportValue::from(extract_enum_value(v)));
             has_options = true;

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{
@@ -69,10 +69,10 @@ impl AwsProvider {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
 
         let subnet_ids = match resource.get_attr("subnet_ids") {
-            Some(Value::List(ids)) => {
+            Some(Value::Concrete(ConcreteValue::List(ids))) => {
                 let mut result = Vec::new();
                 for id_val in ids {
-                    if let Value::String(s) = id_val {
+                    if let Value::Concrete(ConcreteValue::String(s)) = id_val {
                         result.push(s.clone());
                     }
                 }

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -57,7 +57,7 @@ impl AwsProvider {
                 {
                     attributes.insert(
                         "enable_dns_support".to_string(),
-                        Value::Bool(attr.value.unwrap_or(false)),
+                        Value::Concrete(ConcreteValue::Bool(attr.value.unwrap_or(false))),
                     );
                 }
 
@@ -72,7 +72,7 @@ impl AwsProvider {
                 {
                     attributes.insert(
                         "enable_dns_hostnames".to_string(),
-                        Value::Bool(attr.value.unwrap_or(false)),
+                        Value::Concrete(ConcreteValue::Bool(attr.value.unwrap_or(false))),
                     );
                 }
             }
@@ -96,7 +96,9 @@ impl AwsProvider {
         let mut create_vpc_builder = self.ec2_client.create_vpc().cidr_block(&cidr_block);
 
         // Handle instance_tenancy if specified
-        if let Some(Value::String(tenancy)) = resource.get_attr("instance_tenancy") {
+        if let Some(Value::Concrete(ConcreteValue::String(tenancy))) =
+            resource.get_attr("instance_tenancy")
+        {
             // Convert DSL format (aws.vpc.InstanceTenancy.dedicated) to API value (dedicated)
             let tenancy_value = extract_enum_value(tenancy);
 
@@ -131,7 +133,9 @@ impl AwsProvider {
             .await?;
 
         // Configure DNS support
-        if let Some(Value::Bool(enabled)) = resource.get_attr("enable_dns_support") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
+            resource.get_attr("enable_dns_support")
+        {
             self.ec2_client
                 .modify_vpc_attribute()
                 .vpc_id(vpc_id)
@@ -149,7 +153,9 @@ impl AwsProvider {
         }
 
         // Configure DNS hostnames
-        if let Some(Value::Bool(enabled)) = resource.get_attr("enable_dns_hostnames") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
+            resource.get_attr("enable_dns_hostnames")
+        {
             self.ec2_client
                 .modify_vpc_attribute()
                 .vpc_id(vpc_id)
@@ -182,7 +188,9 @@ impl AwsProvider {
         let vpc_id = identifier.to_string();
 
         // Update DNS support
-        if let Some(Value::Bool(enabled)) = to.get_attr("enable_dns_support") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
+            to.get_attr("enable_dns_support")
+        {
             self.ec2_client
                 .modify_vpc_attribute()
                 .vpc_id(&vpc_id)
@@ -200,7 +208,9 @@ impl AwsProvider {
         }
 
         // Update DNS hostnames
-        if let Some(Value::Bool(enabled)) = to.get_attr("enable_dns_hostnames") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
+            to.get_attr("enable_dns_hostnames")
+        {
             self.ec2_client
                 .modify_vpc_attribute()
                 .vpc_id(&vpc_id)

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -70,53 +70,63 @@ impl AwsProvider {
             .vpc_id(&vpc_id)
             .service_name(&service_name);
 
-        if let Some(Value::String(ep_type)) = resource.get_attr("vpc_endpoint_type") {
+        if let Some(Value::Concrete(ConcreteValue::String(ep_type))) =
+            resource.get_attr("vpc_endpoint_type")
+        {
             use aws_sdk_ec2::types::VpcEndpointType;
             let et = VpcEndpointType::from(extract_enum_value(ep_type));
             req = req.vpc_endpoint_type(et);
         }
 
-        if let Some(Value::List(ids)) = resource.get_attr("route_table_ids") {
+        if let Some(Value::Concrete(ConcreteValue::List(ids))) =
+            resource.get_attr("route_table_ids")
+        {
             for id_val in ids {
-                if let Value::String(s) = id_val {
+                if let Value::Concrete(ConcreteValue::String(s)) = id_val {
                     req = req.route_table_ids(s);
                 }
             }
         }
 
-        if let Some(Value::List(ids)) = resource.get_attr("subnet_ids") {
+        if let Some(Value::Concrete(ConcreteValue::List(ids))) = resource.get_attr("subnet_ids") {
             for id_val in ids {
-                if let Value::String(s) = id_val {
+                if let Value::Concrete(ConcreteValue::String(s)) = id_val {
                     req = req.subnet_ids(s);
                 }
             }
         }
 
-        if let Some(Value::List(ids)) = resource.get_attr("security_group_ids") {
+        if let Some(Value::Concrete(ConcreteValue::List(ids))) =
+            resource.get_attr("security_group_ids")
+        {
             for id_val in ids {
-                if let Value::String(s) = id_val {
+                if let Value::Concrete(ConcreteValue::String(s)) = id_val {
                     req = req.security_group_ids(s);
                 }
             }
         }
 
-        if let Some(Value::Bool(v)) = resource.get_attr("private_dns_enabled") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+            resource.get_attr("private_dns_enabled")
+        {
             req = req.private_dns_enabled(*v);
         }
 
-        if let Some(Value::String(policy)) = resource.get_attr("policy_document") {
+        if let Some(Value::Concrete(ConcreteValue::String(policy))) =
+            resource.get_attr("policy_document")
+        {
             req = req.policy_document(policy);
-        } else if let Some(Value::Map(map)) = resource.get_attr("policy_document") {
+        } else if let Some(Value::Concrete(ConcreteValue::Map(map))) =
+            resource.get_attr("policy_document")
+        {
             // Convert Value::Map to JSON string for the API
-            let json_str =
-                crate::services::iam::role::value_to_iam_policy_json(&Value::Map(map.clone()))
-                    .map_err(|e| {
-                        ProviderError::internal(format!(
-                            "Failed to serialize policy_document: {}",
-                            e
-                        ))
-                        .for_resource(resource.id.clone())
-                    })?;
+            let json_str = crate::services::iam::role::value_to_iam_policy_json(&Value::Concrete(
+                ConcreteValue::Map(map.clone()),
+            ))
+            .map_err(|e| {
+                ProviderError::internal(format!("Failed to serialize policy_document: {}", e))
+                    .for_resource(resource.id.clone())
+            })?;
             req = req.policy_document(&json_str);
         }
 
@@ -171,25 +181,27 @@ impl AwsProvider {
         let mut has_modifications = false;
 
         // Update route_table_ids
-        if let Some(Value::List(new_ids)) = to.get_attr("route_table_ids") {
-            let old_ids: Vec<String> =
-                if let Some(Value::List(old)) = from.attributes.get("route_table_ids") {
-                    old.iter()
-                        .filter_map(|v| {
-                            if let Value::String(s) = v {
-                                Some(s.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect()
-                } else {
-                    vec![]
-                };
+        if let Some(Value::Concrete(ConcreteValue::List(new_ids))) = to.get_attr("route_table_ids")
+        {
+            let old_ids: Vec<String> = if let Some(Value::Concrete(ConcreteValue::List(old))) =
+                from.attributes.get("route_table_ids")
+            {
+                old.iter()
+                    .filter_map(|v| {
+                        if let Value::Concrete(ConcreteValue::String(s)) = v {
+                            Some(s.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            } else {
+                vec![]
+            };
             let new_id_strs: Vec<String> = new_ids
                 .iter()
                 .filter_map(|v| {
-                    if let Value::String(s) = v {
+                    if let Value::Concrete(ConcreteValue::String(s)) = v {
                         Some(s.clone())
                     } else {
                         None
@@ -212,25 +224,26 @@ impl AwsProvider {
         }
 
         // Update subnet_ids
-        if let Some(Value::List(new_ids)) = to.get_attr("subnet_ids") {
-            let old_ids: Vec<String> =
-                if let Some(Value::List(old)) = from.attributes.get("subnet_ids") {
-                    old.iter()
-                        .filter_map(|v| {
-                            if let Value::String(s) = v {
-                                Some(s.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect()
-                } else {
-                    vec![]
-                };
+        if let Some(Value::Concrete(ConcreteValue::List(new_ids))) = to.get_attr("subnet_ids") {
+            let old_ids: Vec<String> = if let Some(Value::Concrete(ConcreteValue::List(old))) =
+                from.attributes.get("subnet_ids")
+            {
+                old.iter()
+                    .filter_map(|v| {
+                        if let Value::Concrete(ConcreteValue::String(s)) = v {
+                            Some(s.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            } else {
+                vec![]
+            };
             let new_id_strs: Vec<String> = new_ids
                 .iter()
                 .filter_map(|v| {
-                    if let Value::String(s) = v {
+                    if let Value::Concrete(ConcreteValue::String(s)) = v {
                         Some(s.clone())
                     } else {
                         None
@@ -253,25 +266,28 @@ impl AwsProvider {
         }
 
         // Update security_group_ids
-        if let Some(Value::List(new_ids)) = to.get_attr("security_group_ids") {
-            let old_ids: Vec<String> =
-                if let Some(Value::List(old)) = from.attributes.get("security_group_ids") {
-                    old.iter()
-                        .filter_map(|v| {
-                            if let Value::String(s) = v {
-                                Some(s.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect()
-                } else {
-                    vec![]
-                };
+        if let Some(Value::Concrete(ConcreteValue::List(new_ids))) =
+            to.get_attr("security_group_ids")
+        {
+            let old_ids: Vec<String> = if let Some(Value::Concrete(ConcreteValue::List(old))) =
+                from.attributes.get("security_group_ids")
+            {
+                old.iter()
+                    .filter_map(|v| {
+                        if let Value::Concrete(ConcreteValue::String(s)) = v {
+                            Some(s.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            } else {
+                vec![]
+            };
             let new_id_strs: Vec<String> = new_ids
                 .iter()
                 .filter_map(|v| {
-                    if let Value::String(s) = v {
+                    if let Value::Concrete(ConcreteValue::String(s)) = v {
                         Some(s.clone())
                     } else {
                         None
@@ -294,25 +310,26 @@ impl AwsProvider {
         }
 
         // Update private_dns_enabled
-        if let Some(Value::Bool(v)) = to.get_attr("private_dns_enabled") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(v))) = to.get_attr("private_dns_enabled") {
             req = req.private_dns_enabled(*v);
             has_modifications = true;
         }
 
         // Update policy_document
-        if let Some(Value::String(policy)) = to.get_attr("policy_document") {
+        if let Some(Value::Concrete(ConcreteValue::String(policy))) = to.get_attr("policy_document")
+        {
             req = req.policy_document(policy);
             has_modifications = true;
-        } else if let Some(Value::Map(map)) = to.get_attr("policy_document") {
-            let json_str =
-                crate::services::iam::role::value_to_iam_policy_json(&Value::Map(map.clone()))
-                    .map_err(|e| {
-                        ProviderError::internal(format!(
-                            "Failed to serialize policy_document: {}",
-                            e
-                        ))
-                        .for_resource(id.clone())
-                    })?;
+        } else if let Some(Value::Concrete(ConcreteValue::Map(map))) =
+            to.get_attr("policy_document")
+        {
+            let json_str = crate::services::iam::role::value_to_iam_policy_json(&Value::Concrete(
+                ConcreteValue::Map(map.clone()),
+            ))
+            .map_err(|e| {
+                ProviderError::internal(format!("Failed to serialize policy_document: {}", e))
+                    .for_resource(id.clone())
+            })?;
             req = req.policy_document(&json_str);
             has_modifications = true;
         }
@@ -385,41 +402,65 @@ impl AwsProvider {
         attributes: &mut HashMap<String, Value>,
     ) -> Option<String> {
         if let Some(v) = obj.vpc_endpoint_id() {
-            attributes.insert("vpc_endpoint_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_endpoint_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.vpc_endpoint_type() {
             attributes.insert(
                 "vpc_endpoint_type".to_string(),
-                Value::String(v.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
             );
         }
         if let Some(v) = obj.vpc_id() {
-            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.service_name() {
-            attributes.insert("service_name".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "service_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.private_dns_enabled() {
-            attributes.insert("private_dns_enabled".to_string(), Value::Bool(v));
+            attributes.insert(
+                "private_dns_enabled".to_string(),
+                Value::Concrete(ConcreteValue::Bool(v)),
+            );
         }
         if let Some(v) = obj.policy_document() {
             // Try to parse the policy document JSON into a Value::Map.
             let policy_value = crate::services::iam::role::iam_policy_json_to_value(v)
-                .unwrap_or_else(|_| Value::String(v.to_string()));
+                .unwrap_or_else(|_| Value::Concrete(ConcreteValue::String(v.to_string())));
             attributes.insert("policy_document".to_string(), policy_value);
         }
         {
             let ids = obj.route_table_ids();
             if !ids.is_empty() {
-                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
-                attributes.insert("route_table_ids".to_string(), Value::List(list));
+                let list: Vec<Value> = ids
+                    .iter()
+                    .map(|s| Value::Concrete(ConcreteValue::String(s.to_string())))
+                    .collect();
+                attributes.insert(
+                    "route_table_ids".to_string(),
+                    Value::Concrete(ConcreteValue::List(list)),
+                );
             }
         }
         {
             let ids = obj.subnet_ids();
             if !ids.is_empty() {
-                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
-                attributes.insert("subnet_ids".to_string(), Value::List(list));
+                let list: Vec<Value> = ids
+                    .iter()
+                    .map(|s| Value::Concrete(ConcreteValue::String(s.to_string())))
+                    .collect();
+                attributes.insert(
+                    "subnet_ids".to_string(),
+                    Value::Concrete(ConcreteValue::List(list)),
+                );
             }
         }
         // Extract security group IDs from Groups[*].group_id.
@@ -428,10 +469,16 @@ impl AwsProvider {
             if !groups.is_empty() {
                 let list: Vec<Value> = groups
                     .iter()
-                    .filter_map(|g| g.group_id().map(|id| Value::String(id.to_string())))
+                    .filter_map(|g| {
+                        g.group_id()
+                            .map(|id| Value::Concrete(ConcreteValue::String(id.to_string())))
+                    })
                     .collect();
                 if !list.is_empty() {
-                    attributes.insert("security_group_ids".to_string(), Value::List(list));
+                    attributes.insert(
+                        "security_group_ids".to_string(),
+                        Value::Concrete(ConcreteValue::List(list)),
+                    );
                 }
             }
         }

--- a/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
@@ -70,10 +70,13 @@ impl AwsProvider {
             for attachment in igw.attachments() {
                 if attachment.vpc_id() == Some(vpc_id) {
                     let mut attributes = HashMap::new();
-                    attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
+                    attributes.insert(
+                        "vpc_id".to_string(),
+                        Value::Concrete(ConcreteValue::String(vpc_id.to_string())),
+                    );
                     attributes.insert(
                         "internet_gateway_id".to_string(),
-                        Value::String(igw_id.to_string()),
+                        Value::Concrete(ConcreteValue::String(igw_id.to_string())),
                     );
 
                     return Ok(State::existing(id.clone(), attributes)
@@ -116,10 +119,13 @@ impl AwsProvider {
                     let state_str = attachment.state().map(|s| s.as_str());
                     if state_str == Some("attached") {
                         let mut attributes = HashMap::new();
-                        attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
+                        attributes.insert(
+                            "vpc_id".to_string(),
+                            Value::Concrete(ConcreteValue::String(vpc_id.to_string())),
+                        );
                         attributes.insert(
                             "vpn_gateway_id".to_string(),
-                            Value::String(vgw_id.to_string()),
+                            Value::Concrete(ConcreteValue::String(vgw_id.to_string())),
                         );
 
                         return Ok(State::existing(id.clone(), attributes)
@@ -139,7 +145,9 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
 
-        if let Some(Value::String(igw_id)) = resource.get_attr("internet_gateway_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(igw_id))) =
+            resource.get_attr("internet_gateway_id")
+        {
             // Attach Internet Gateway
             self.ec2_client
                 .attach_internet_gateway()
@@ -158,7 +166,9 @@ impl AwsProvider {
             let composite = format!("{}|{}", vpc_id, igw_id);
             self.read_ec2_vpc_gateway_attachment(&resource.id, Some(&composite))
                 .await
-        } else if let Some(Value::String(vgw_id)) = resource.get_attr("vpn_gateway_id") {
+        } else if let Some(Value::Concrete(ConcreteValue::String(vgw_id))) =
+            resource.get_attr("vpn_gateway_id")
+        {
             // Attach VPN Gateway
             self.ec2_client
                 .attach_vpn_gateway()

--- a/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{build_tag_specification, require_string_attr, sdk_error_message};
@@ -79,11 +79,15 @@ impl AwsProvider {
             .vpc_id(&vpc_id)
             .peer_vpc_id(&peer_vpc_id);
 
-        if let Some(Value::String(owner_id)) = resource.get_attr("peer_owner_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(owner_id))) =
+            resource.get_attr("peer_owner_id")
+        {
             req = req.peer_owner_id(owner_id);
         }
 
-        if let Some(Value::String(region)) = resource.get_attr("peer_region") {
+        if let Some(Value::Concrete(ConcreteValue::String(region))) =
+            resource.get_attr("peer_region")
+        {
             req = req.peer_region(region);
         }
 

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value_with_values;
 
 use crate::AwsProvider;
@@ -65,7 +65,9 @@ impl AwsProvider {
     /// Create an EC2 VPN Gateway
     pub(crate) async fn create_ec2_vpn_gateway(&self, resource: Resource) -> ProviderResult<State> {
         let gw_type = match resource.get_attr("type") {
-            Some(Value::String(s)) => extract_enum_value_with_values(s, &["ipsec.1"]).to_string(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => {
+                extract_enum_value_with_values(s, &["ipsec.1"]).to_string()
+            }
             _ => {
                 return Err(ProviderError::invalid_input("type is required")
                     .for_resource(resource.id.clone()));
@@ -77,7 +79,8 @@ impl AwsProvider {
             .create_vpn_gateway()
             .r#type(aws_sdk_ec2::types::GatewayType::from(gw_type.as_str()));
 
-        if let Some(Value::Int(asn)) = resource.get_attr("amazon_side_asn") {
+        if let Some(Value::Concrete(ConcreteValue::Int(asn))) = resource.get_attr("amazon_side_asn")
+        {
             req = req.amazon_side_asn(*asn);
         }
 

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
@@ -39,10 +39,16 @@ impl AwsProvider {
                         for tag in tags {
                             let key = tag.key();
                             let val = tag.value();
-                            tag_map.insert(key.to_string(), Value::String(val.to_string()));
+                            tag_map.insert(
+                                key.to_string(),
+                                Value::Concrete(ConcreteValue::String(val.to_string())),
+                            );
                         }
                         if !tag_map.is_empty() {
-                            attributes.insert("tags".to_string(), Value::Map(tag_map));
+                            attributes.insert(
+                                "tags".to_string(),
+                                Value::Concrete(ConcreteValue::Map(tag_map)),
+                            );
                         }
                     }
 
@@ -84,22 +90,25 @@ impl AwsProvider {
             .role_name(&role_name)
             .assume_role_policy_document(&assume_role_policy_document);
 
-        if let Some(Value::String(desc)) = resource.get_attr("description") {
+        if let Some(Value::Concrete(ConcreteValue::String(desc))) = resource.get_attr("description")
+        {
             req = req.description(desc);
         }
 
-        if let Some(Value::String(path)) = resource.get_attr("path") {
+        if let Some(Value::Concrete(ConcreteValue::String(path))) = resource.get_attr("path") {
             req = req.path(path);
         }
 
-        if let Some(Value::Int(duration)) = resource.get_attr("max_session_duration") {
+        if let Some(Value::Concrete(ConcreteValue::Int(duration))) =
+            resource.get_attr("max_session_duration")
+        {
             req = req.max_session_duration(*duration as i32);
         }
 
         // Apply tags at creation time
-        if let Some(Value::Map(tag_map)) = resource.get_attr("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(tag_map))) = resource.get_attr("tags") {
             for (key, value) in tag_map {
-                if let Value::String(val) = value {
+                if let Value::Concrete(ConcreteValue::String(val)) = value {
                     let tag = aws_sdk_iam::types::Tag::builder()
                         .key(key)
                         .value(val)
@@ -151,12 +160,14 @@ impl AwsProvider {
         let mut needs_update = false;
         let mut req = self.iam_client.update_role().role_name(identifier);
 
-        if let Some(Value::String(desc)) = to.get_attr("description") {
+        if let Some(Value::Concrete(ConcreteValue::String(desc))) = to.get_attr("description") {
             req = req.description(desc);
             needs_update = true;
         }
 
-        if let Some(Value::Int(duration)) = to.get_attr("max_session_duration") {
+        if let Some(Value::Concrete(ConcreteValue::Int(duration))) =
+            to.get_attr("max_session_duration")
+        {
             req = req.max_session_duration(*duration as i32);
             needs_update = true;
         }
@@ -207,11 +218,11 @@ impl AwsProvider {
         current: Option<&HashMap<String, Value>>,
     ) -> ProviderResult<()> {
         let desired_tags = match desired.get("tags") {
-            Some(Value::Map(m)) => m.clone(),
+            Some(Value::Concrete(ConcreteValue::Map(m))) => m.clone(),
             _ => IndexMap::new(),
         };
         let current_tags = match current.and_then(|c| c.get("tags")) {
-            Some(Value::Map(m)) => m.clone(),
+            Some(Value::Concrete(ConcreteValue::Map(m))) => m.clone(),
             _ => IndexMap::new(),
         };
 
@@ -236,9 +247,9 @@ impl AwsProvider {
         // Tags to add/update
         let mut tags_to_add = Vec::new();
         for (key, value) in &desired_tags {
-            if let Value::String(val) = value {
+            if let Value::Concrete(ConcreteValue::String(val)) = value {
                 let should_add = match current_tags.get(key) {
-                    Some(Value::String(current_val)) => current_val != val,
+                    Some(Value::Concrete(ConcreteValue::String(current_val))) => current_val != val,
                     _ => true,
                 };
                 if should_add {
@@ -286,7 +297,10 @@ impl AwsProvider {
         // sometimes uses when the field is absent on the wire.
         let arn = obj.arn();
         if !arn.is_empty() {
-            attributes.insert("arn".to_string(), Value::String(arn.to_string()));
+            attributes.insert(
+                "arn".to_string(),
+                Value::Concrete(ConcreteValue::String(arn.to_string())),
+            );
         }
         if let Some(v) = obj.assume_role_policy_document() {
             // The SDK URL-encodes the policy document.
@@ -295,28 +309,40 @@ impl AwsProvider {
             // struct comparison; fall back to the raw string if the
             // policy is malformed.
             let policy_value = iam_policy_json_to_value(&decoded)
-                .unwrap_or_else(|_| Value::String(decoded.into_owned()));
+                .unwrap_or_else(|_| Value::Concrete(ConcreteValue::String(decoded.into_owned())));
             attributes.insert("assume_role_policy_document".to_string(), policy_value);
         }
         if let Some(v) = obj.description() {
-            attributes.insert("description".to_string(), Value::String(v.to_string()));
+            attributes.insert(
+                "description".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = obj.max_session_duration() {
-            attributes.insert("max_session_duration".to_string(), Value::Int(v as i64));
+            attributes.insert(
+                "max_session_duration".to_string(),
+                Value::Concrete(ConcreteValue::Int(v as i64)),
+            );
         }
         let path = obj.path();
         if !path.is_empty() {
-            attributes.insert("path".to_string(), Value::String(path.to_string()));
+            attributes.insert(
+                "path".to_string(),
+                Value::Concrete(ConcreteValue::String(path.to_string())),
+            );
         }
         let role_id = obj.role_id();
         if !role_id.is_empty() {
-            attributes.insert("role_id".to_string(), Value::String(role_id.to_string()));
+            attributes.insert(
+                "role_id".to_string(),
+                Value::Concrete(ConcreteValue::String(role_id.to_string())),
+            );
         }
         let role_name = obj.role_name();
         if !role_name.is_empty() {
             attributes.insert(
                 "role_name".to_string(),
-                Value::String(role_name.to_string()),
+                Value::Concrete(ConcreteValue::String(role_name.to_string())),
             );
             Some(role_name.to_string())
         } else {
@@ -349,11 +375,12 @@ pub fn value_to_iam_policy_json(value: &Value) -> Result<String, String> {
 /// unsupported type.
 pub fn resolve_iam_policy_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
     match resource.get_attr(attr_name) {
-        Some(Value::String(s)) => Ok(s.clone()),
-        Some(value @ Value::Map(_)) => value_to_iam_policy_json(value).map_err(|e| {
-            ProviderError::invalid_input(format!("Failed to convert {}: {}", attr_name, e))
-                .for_resource(resource.id.clone())
-        }),
+        Some(Value::Concrete(ConcreteValue::String(s))) => Ok(s.clone()),
+        Some(value @ Value::Concrete(ConcreteValue::Map(_))) => value_to_iam_policy_json(value)
+            .map_err(|e| {
+                ProviderError::invalid_input(format!("Failed to convert {}: {}", attr_name, e))
+                    .for_resource(resource.id.clone())
+            }),
         _ => Err(ProviderError::invalid_input(format!(
             "{} is required (must be a JSON string or block)",
             attr_name
@@ -408,7 +435,7 @@ fn lookup_snake(
 /// case-mapped via `POLICY_TOP_FIELDS`; the value of `Statement` is
 /// further converted by `policy_statement_to_json`.
 fn policy_doc_to_json(value: &Value) -> serde_json::Value {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return scalar_to_json(value);
     };
     let mut obj = serde_json::Map::new();
@@ -416,10 +443,10 @@ fn policy_doc_to_json(value: &Value) -> serde_json::Value {
         let pascal_key = lookup_pascal(POLICY_TOP_FIELDS, k).unwrap_or(k.as_str());
         let json_value = if k == "statement" {
             match v {
-                Value::List(items) => {
+                Value::Concrete(ConcreteValue::List(items)) => {
                     serde_json::Value::Array(items.iter().map(policy_statement_to_json).collect())
                 }
-                Value::Map(_) => policy_statement_to_json(v),
+                Value::Concrete(ConcreteValue::Map(_)) => policy_statement_to_json(v),
                 _ => scalar_to_json(v),
             }
         } else {
@@ -431,7 +458,7 @@ fn policy_doc_to_json(value: &Value) -> serde_json::Value {
 }
 
 fn policy_statement_to_json(value: &Value) -> serde_json::Value {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return scalar_to_json(value);
     };
     let mut obj = serde_json::Map::new();
@@ -449,7 +476,7 @@ fn policy_statement_to_json(value: &Value) -> serde_json::Value {
 
 fn principal_to_json(value: &Value) -> serde_json::Value {
     match value {
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut obj = serde_json::Map::new();
             for (k, v) in map {
                 let key = lookup_pascal(PRINCIPAL_FIELDS, k).unwrap_or(k.as_str());
@@ -462,7 +489,7 @@ fn principal_to_json(value: &Value) -> serde_json::Value {
 }
 
 fn condition_to_json(value: &Value) -> serde_json::Value {
-    let Value::Map(operators) = value else {
+    let Value::Concrete(ConcreteValue::Map(operators)) = value else {
         return scalar_to_json(value);
     };
     let mut obj = serde_json::Map::new();
@@ -472,7 +499,7 @@ fn condition_to_json(value: &Value) -> serde_json::Value {
         let kv_json = match kv_value {
             // Inner map keys are condition variables (e.g. "aws:SecureTransport")
             // and must pass through verbatim — no case conversion.
-            Value::Map(inner) => {
+            Value::Concrete(ConcreteValue::Map(inner)) => {
                 let mut m = serde_json::Map::new();
                 for (var, val) in inner {
                     m.insert(var.clone(), scalar_or_passthrough_to_json(val));
@@ -490,10 +517,10 @@ fn condition_to_json(value: &Value) -> serde_json::Value {
 /// Sid / Effect / condition variable values. No key conversion.
 fn scalar_or_passthrough_to_json(value: &Value) -> serde_json::Value {
     match value {
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             serde_json::Value::Array(items.iter().map(scalar_or_passthrough_to_json).collect())
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             // Generic map (e.g. nested condition value map): keys verbatim.
             let mut obj = serde_json::Map::new();
             for (k, v) in map {
@@ -507,11 +534,13 @@ fn scalar_or_passthrough_to_json(value: &Value) -> serde_json::Value {
 
 fn scalar_to_json(value: &Value) -> serde_json::Value {
     match value {
-        Value::String(s) => serde_json::Value::String(s.clone()),
-        Value::Int(n) => serde_json::Value::Number((*n).into()),
-        Value::Float(f) => serde_json::json!(*f),
-        Value::Bool(b) => serde_json::Value::Bool(*b),
-        Value::List(_) | Value::Map(_) => scalar_or_passthrough_to_json(value),
+        Value::Concrete(ConcreteValue::String(s)) => serde_json::Value::String(s.clone()),
+        Value::Concrete(ConcreteValue::Int(n)) => serde_json::Value::Number((*n).into()),
+        Value::Concrete(ConcreteValue::Float(f)) => serde_json::json!(*f),
+        Value::Concrete(ConcreteValue::Bool(b)) => serde_json::Value::Bool(*b),
+        Value::Concrete(ConcreteValue::List(_)) | Value::Concrete(ConcreteValue::Map(_)) => {
+            scalar_or_passthrough_to_json(value)
+        }
         _ => serde_json::Value::Null,
     }
 }
@@ -540,9 +569,9 @@ fn json_to_policy_doc(json: &serde_json::Value) -> Value {
         let snake_key = lookup_snake(POLICY_TOP_FIELDS, k).unwrap_or(k.as_str());
         let value = if snake_key == "statement" {
             match v {
-                serde_json::Value::Array(items) => {
-                    Value::List(items.iter().map(json_to_policy_statement).collect())
-                }
+                serde_json::Value::Array(items) => Value::Concrete(ConcreteValue::List(
+                    items.iter().map(json_to_policy_statement).collect(),
+                )),
                 serde_json::Value::Object(_) => json_to_policy_statement(v),
                 _ => json_scalar_to_value(v),
             }
@@ -551,7 +580,7 @@ fn json_to_policy_doc(json: &serde_json::Value) -> Value {
         };
         map.insert(snake_key.to_string(), value);
     }
-    Value::Map(map)
+    Value::Concrete(ConcreteValue::Map(map))
 }
 
 fn json_to_policy_statement(json: &serde_json::Value) -> Value {
@@ -571,7 +600,7 @@ fn json_to_policy_statement(json: &serde_json::Value) -> Value {
         };
         map.insert(snake_key.to_string(), value);
     }
-    Value::Map(map)
+    Value::Concrete(ConcreteValue::Map(map))
 }
 
 fn json_to_principal(json: &serde_json::Value) -> Value {
@@ -585,7 +614,7 @@ fn json_to_principal(json: &serde_json::Value) -> Value {
                 let key = lookup_snake(PRINCIPAL_FIELDS, k).unwrap_or(k.as_str());
                 map.insert(key.to_string(), json_scalar_or_passthrough_to_value(v));
             }
-            Value::Map(map)
+            Value::Concrete(ConcreteValue::Map(map))
         }
         _ => json_scalar_to_value(json),
     }
@@ -612,29 +641,29 @@ fn json_to_condition(json: &serde_json::Value) -> Value {
                     }
                     m.insert(var.clone(), json_scalar_or_passthrough_to_value(val));
                 }
-                Value::Map(m)
+                Value::Concrete(ConcreteValue::Map(m))
             }
             _ => json_scalar_to_value(kv_value),
         };
         map.insert(op_snake, kv);
     }
-    Value::Map(map)
+    Value::Concrete(ConcreteValue::Map(map))
 }
 
 fn json_scalar_or_passthrough_to_value(json: &serde_json::Value) -> Value {
     match json {
-        serde_json::Value::Array(items) => Value::List(
+        serde_json::Value::Array(items) => Value::Concrete(ConcreteValue::List(
             items
                 .iter()
                 .map(json_scalar_or_passthrough_to_value)
                 .collect(),
-        ),
+        )),
         serde_json::Value::Object(obj) => {
             let mut map = IndexMap::new();
             for (k, v) in obj {
                 map.insert(k.clone(), json_scalar_or_passthrough_to_value(v));
             }
-            Value::Map(map)
+            Value::Concrete(ConcreteValue::Map(map))
         }
         _ => json_scalar_to_value(json),
     }
@@ -642,22 +671,22 @@ fn json_scalar_or_passthrough_to_value(json: &serde_json::Value) -> Value {
 
 fn json_scalar_to_value(json: &serde_json::Value) -> Value {
     match json {
-        serde_json::Value::String(s) => Value::String(s.clone()),
+        serde_json::Value::String(s) => Value::Concrete(ConcreteValue::String(s.clone())),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Value::Int(i)
+                Value::Concrete(ConcreteValue::Int(i))
             } else if let Some(f) = n.as_f64() {
-                Value::Float(f)
+                Value::Concrete(ConcreteValue::Float(f))
             } else {
-                Value::String(n.to_string())
+                Value::Concrete(ConcreteValue::String(n.to_string()))
             }
         }
-        serde_json::Value::Bool(b) => Value::Bool(*b),
+        serde_json::Value::Bool(b) => Value::Concrete(ConcreteValue::Bool(*b)),
         // JSON null in policy documents is uncommon and has no faithful
         // Carina counterpart (Value has no Null variant). Map to empty
         // string only as a last resort; callers should normally treat
         // null fields as absent.
-        serde_json::Value::Null => Value::String(String::new()),
+        serde_json::Value::Null => Value::Concrete(ConcreteValue::String(String::new())),
         serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
             json_scalar_or_passthrough_to_value(json)
         }
@@ -680,7 +709,9 @@ mod tests {
     #[test]
     fn resolve_iam_policy_attr_accepts_json_string_passthrough() {
         let json = r#"{"Version":"2012-10-17","Statement":[]}"#;
-        let r = make_resource(Some(Value::String(json.to_string())));
+        let r = make_resource(Some(Value::Concrete(ConcreteValue::String(
+            json.to_string(),
+        ))));
         let resolved = resolve_iam_policy_attr(&r, "policy").expect("string passthrough");
         assert_eq!(resolved, json);
     }
@@ -690,17 +721,23 @@ mod tests {
         let mut policy = IndexMap::new();
         policy.insert(
             "version".to_string(),
-            Value::String("2012-10-17".to_string()),
+            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
         );
         let mut stmt = IndexMap::new();
-        stmt.insert("effect".to_string(), Value::String("Allow".to_string()));
+        stmt.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
         stmt.insert(
             "action".to_string(),
-            Value::String("s3:GetObject".to_string()),
+            Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
         );
-        policy.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
+        policy.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Map(stmt)])),
+        );
 
-        let r = make_resource(Some(Value::Map(policy)));
+        let r = make_resource(Some(Value::Concrete(ConcreteValue::Map(policy))));
         let resolved = resolve_iam_policy_attr(&r, "policy").expect("map → JSON");
 
         assert!(resolved.contains("\"Version\""));
@@ -719,7 +756,7 @@ mod tests {
 
     #[test]
     fn resolve_iam_policy_attr_errors_on_non_string_non_map() {
-        let r = make_resource(Some(Value::Bool(true)));
+        let r = make_resource(Some(Value::Concrete(ConcreteValue::Bool(true))));
         let err = resolve_iam_policy_attr(&r, "policy").expect_err("invalid type");
         assert!(format!("{}", err).contains("policy is required"));
     }
@@ -729,40 +766,61 @@ mod tests {
     /// `bool` condition with the `aws:SecureTransport` value key.
     fn full_deny_policy_value() -> Value {
         let mut principal = IndexMap::new();
-        principal.insert("aws".to_string(), Value::String("*".to_string()));
+        principal.insert(
+            "aws".to_string(),
+            Value::Concrete(ConcreteValue::String("*".to_string())),
+        );
 
         let mut bool_inner = IndexMap::new();
         bool_inner.insert(
             "aws:SecureTransport".to_string(),
-            Value::String("false".to_string()),
+            Value::Concrete(ConcreteValue::String("false".to_string())),
         );
         let mut condition = IndexMap::new();
-        condition.insert("bool".to_string(), Value::Map(bool_inner));
+        condition.insert(
+            "bool".to_string(),
+            Value::Concrete(ConcreteValue::Map(bool_inner)),
+        );
 
         let mut stmt = IndexMap::new();
         stmt.insert(
             "sid".to_string(),
-            Value::String("DenyInsecureTransport".to_string()),
+            Value::Concrete(ConcreteValue::String("DenyInsecureTransport".to_string())),
         );
-        stmt.insert("effect".to_string(), Value::String("Deny".to_string()));
-        stmt.insert("principal".to_string(), Value::Map(principal));
-        stmt.insert("action".to_string(), Value::String("s3:*".to_string()));
+        stmt.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Deny".to_string())),
+        );
+        stmt.insert(
+            "principal".to_string(),
+            Value::Concrete(ConcreteValue::Map(principal)),
+        );
+        stmt.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::String("s3:*".to_string())),
+        );
         stmt.insert(
             "resource".to_string(),
-            Value::List(vec![
+            Value::Concrete(ConcreteValue::List(vec![
                 Value::String("arn:aws:s3:::my-bucket".to_string()),
                 Value::String("arn:aws:s3:::my-bucket/*".to_string()),
-            ]),
+            ])),
         );
-        stmt.insert("condition".to_string(), Value::Map(condition));
+        stmt.insert(
+            "condition".to_string(),
+            Value::Concrete(ConcreteValue::Map(condition)),
+        );
 
         let mut doc = IndexMap::new();
         doc.insert(
             "version".to_string(),
-            Value::String("2012-10-17".to_string()),
+            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
         );
-        doc.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
-        Value::Map(doc)
+        doc.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Map(stmt)])),
+        );
+        Value::Concrete(ConcreteValue::Map(doc))
     }
 
     #[test]
@@ -825,7 +883,7 @@ mod tests {
             }]
         }"#;
         let value = iam_policy_json_to_value(aws_json).expect("ok");
-        let Value::Map(doc) = &value else {
+        let Value::Concrete(ConcreteValue::Map(doc)) = &value else {
             panic!("expected map");
         };
         // Top-level snake_case.
@@ -833,16 +891,16 @@ mod tests {
         assert!(doc.contains_key("statement"));
 
         // Drill into statement[0].condition.bool.
-        let Value::List(stmts) = doc.get("statement").unwrap() else {
+        let Value::Concrete(ConcreteValue::List(stmts)) = doc.get("statement").unwrap() else {
             panic!();
         };
-        let Value::Map(stmt) = &stmts[0] else {
+        let Value::Concrete(ConcreteValue::Map(stmt)) = &stmts[0] else {
             panic!()
         };
-        let Value::Map(cond) = stmt.get("condition").unwrap() else {
+        let Value::Concrete(ConcreteValue::Map(cond)) = stmt.get("condition").unwrap() else {
             panic!()
         };
-        let Value::Map(bool_inner) = cond.get("bool").unwrap() else {
+        let Value::Concrete(ConcreteValue::Map(bool_inner)) = cond.get("bool").unwrap() else {
             panic!()
         };
         // CRITICAL: condition variable key preserved verbatim.
@@ -850,13 +908,13 @@ mod tests {
         assert!(!bool_inner.contains_key("aws:secure_transport"));
 
         // Principal {"AWS"} → snake "aws".
-        let Value::Map(principal) = stmt.get("principal").unwrap() else {
+        let Value::Concrete(ConcreteValue::Map(principal)) = stmt.get("principal").unwrap() else {
             panic!()
         };
         assert!(principal.contains_key("aws"));
         assert_eq!(
             principal.get("aws"),
-            Some(&Value::String("*".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String("*".to_string()))),
             "principal value should round-trip verbatim"
         );
     }
@@ -866,12 +924,18 @@ mod tests {
         let mut doc = IndexMap::new();
         doc.insert(
             "version".to_string(),
-            Value::String("2012-10-17".to_string()),
+            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
         );
-        doc.insert("id".to_string(), Value::String("MyPolicyId".to_string()));
-        doc.insert("statement".to_string(), Value::List(vec![]));
+        doc.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String("MyPolicyId".to_string())),
+        );
+        doc.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![])),
+        );
 
-        let original = Value::Map(doc);
+        let original = Value::Concrete(ConcreteValue::Map(doc));
         let json = value_to_iam_policy_json(&original).expect("ok");
         assert!(json.contains("\"Id\""));
         assert!(json.contains("\"MyPolicyId\""));
@@ -892,13 +956,15 @@ mod tests {
             }
         }"#;
         let value = iam_policy_json_to_value(aws_json).expect("ok");
-        let Value::Map(doc) = &value else { panic!() };
-        let Value::Map(stmt) = doc.get("statement").unwrap() else {
+        let Value::Concrete(ConcreteValue::Map(doc)) = &value else {
+            panic!()
+        };
+        let Value::Concrete(ConcreteValue::Map(stmt)) = doc.get("statement").unwrap() else {
             panic!("statement should be a Map for single-object form")
         };
         assert_eq!(
             stmt.get("effect"),
-            Some(&Value::String("Allow".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("Allow".to_string())))
         );
     }
 
@@ -915,16 +981,18 @@ mod tests {
             }]
         }"#;
         let value = iam_policy_json_to_value(aws_json).expect("ok");
-        let Value::Map(doc) = &value else { panic!() };
-        let Value::List(stmts) = doc.get("statement").unwrap() else {
+        let Value::Concrete(ConcreteValue::Map(doc)) = &value else {
             panic!()
         };
-        let Value::Map(stmt) = &stmts[0] else {
+        let Value::Concrete(ConcreteValue::List(stmts)) = doc.get("statement").unwrap() else {
+            panic!()
+        };
+        let Value::Concrete(ConcreteValue::Map(stmt)) = &stmts[0] else {
             panic!()
         };
         assert_eq!(
             stmt.get("principal"),
-            Some(&Value::String("*".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String("*".to_string()))),
             "principal string form should pass through verbatim"
         );
     }
@@ -937,25 +1005,39 @@ mod tests {
         let mut inner = IndexMap::new();
         inner.insert(
             "aws:TagKeys".to_string(),
-            Value::List(vec![Value::String("Environment".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::String(
+                "Environment".to_string(),
+            )])),
         );
         let mut condition = IndexMap::new();
         condition.insert(
             "for_all_values_string_equals_if_exists".to_string(),
-            Value::Map(inner),
+            Value::Concrete(ConcreteValue::Map(inner)),
         );
         let mut stmt = IndexMap::new();
-        stmt.insert("effect".to_string(), Value::String("Allow".to_string()));
-        stmt.insert("action".to_string(), Value::String("s3:*".to_string()));
-        stmt.insert("condition".to_string(), Value::Map(condition));
+        stmt.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
+        stmt.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::String("s3:*".to_string())),
+        );
+        stmt.insert(
+            "condition".to_string(),
+            Value::Concrete(ConcreteValue::Map(condition)),
+        );
         let mut doc = IndexMap::new();
         doc.insert(
             "version".to_string(),
-            Value::String("2012-10-17".to_string()),
+            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
         );
-        doc.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
+        doc.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Map(stmt)])),
+        );
 
-        let original = Value::Map(doc);
+        let original = Value::Concrete(ConcreteValue::Map(doc));
         let json = value_to_iam_policy_json(&original).expect("ok");
         assert!(
             json.contains("\"ForAllValues:StringEqualsIfExists\""),
@@ -974,25 +1056,37 @@ mod tests {
         let mut inner = IndexMap::new();
         inner.insert(
             "aws:PrincipalOrgID".to_string(),
-            Value::String("o-1234567890".to_string()),
+            Value::Concrete(ConcreteValue::String("o-1234567890".to_string())),
         );
         let mut condition = IndexMap::new();
-        condition.insert("string_equals".to_string(), Value::Map(inner));
+        condition.insert(
+            "string_equals".to_string(),
+            Value::Concrete(ConcreteValue::Map(inner)),
+        );
         let mut stmt = IndexMap::new();
-        stmt.insert("effect".to_string(), Value::String("Allow".to_string()));
+        stmt.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
         stmt.insert(
             "action".to_string(),
-            Value::String("s3:GetObject".to_string()),
+            Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
         );
-        stmt.insert("condition".to_string(), Value::Map(condition));
+        stmt.insert(
+            "condition".to_string(),
+            Value::Concrete(ConcreteValue::Map(condition)),
+        );
         let mut doc = IndexMap::new();
         doc.insert(
             "version".to_string(),
-            Value::String("2012-10-17".to_string()),
+            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
         );
-        doc.insert("statement".to_string(), Value::List(vec![Value::Map(stmt)]));
+        doc.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Map(stmt)])),
+        );
 
-        let original = Value::Map(doc);
+        let original = Value::Concrete(ConcreteValue::Map(doc));
         let json = value_to_iam_policy_json(&original).expect("ok");
         assert!(json.contains("\"StringEquals\""));
         assert!(json.contains("\"aws:PrincipalOrgID\""));

--- a/carina-provider-aws/src/services/identitystore/user.rs
+++ b/carina-provider-aws/src/services/identitystore/user.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use aws_sdk_identitystore::types::{AlternateIdentifier, UniqueAttribute};
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
-use carina_core::resource::{Resource, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::sdk_error_message;
@@ -120,64 +120,89 @@ pub(crate) fn extract_identitystore_user(
 
     attributes.insert(
         "user_id".to_string(),
-        Value::String(resp.user_id().to_string()),
+        Value::Concrete(ConcreteValue::String(resp.user_id().to_string())),
     );
     attributes.insert(
         "identity_store_id".to_string(),
-        Value::String(resp.identity_store_id().to_string()),
+        Value::Concrete(ConcreteValue::String(resp.identity_store_id().to_string())),
     );
     if let Some(user_name) = resp.user_name() {
         attributes.insert(
             "user_name".to_string(),
-            Value::String(user_name.to_string()),
+            Value::Concrete(ConcreteValue::String(user_name.to_string())),
         );
     }
     if let Some(display_name) = resp.display_name() {
         attributes.insert(
             "display_name".to_string(),
-            Value::String(display_name.to_string()),
+            Value::Concrete(ConcreteValue::String(display_name.to_string())),
         );
     }
     if let Some(name) = resp.name() {
         let mut name_fields: IndexMap<String, Value> = IndexMap::new();
         if let Some(v) = name.formatted() {
-            name_fields.insert("formatted".to_string(), Value::String(v.to_string()));
+            name_fields.insert(
+                "formatted".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = name.family_name() {
-            name_fields.insert("family_name".to_string(), Value::String(v.to_string()));
+            name_fields.insert(
+                "family_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = name.given_name() {
-            name_fields.insert("given_name".to_string(), Value::String(v.to_string()));
+            name_fields.insert(
+                "given_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = name.middle_name() {
-            name_fields.insert("middle_name".to_string(), Value::String(v.to_string()));
+            name_fields.insert(
+                "middle_name".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = name.honorific_prefix() {
-            name_fields.insert("honorific_prefix".to_string(), Value::String(v.to_string()));
+            name_fields.insert(
+                "honorific_prefix".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if let Some(v) = name.honorific_suffix() {
-            name_fields.insert("honorific_suffix".to_string(), Value::String(v.to_string()));
+            name_fields.insert(
+                "honorific_suffix".to_string(),
+                Value::Concrete(ConcreteValue::String(v.to_string())),
+            );
         }
         if !name_fields.is_empty() {
-            attributes.insert("name".to_string(), Value::Map(name_fields));
+            attributes.insert(
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::Map(name_fields)),
+            );
         }
     }
     let email_values: Vec<Value> = resp
         .emails()
         .iter()
         .filter_map(|e: &aws_sdk_identitystore::types::Email| {
-            e.value().map(|v| Value::String(v.to_string()))
+            e.value()
+                .map(|v| Value::Concrete(ConcreteValue::String(v.to_string())))
         })
         .collect();
     if !email_values.is_empty() {
-        attributes.insert("emails".to_string(), Value::List(email_values));
+        attributes.insert(
+            "emails".to_string(),
+            Value::Concrete(ConcreteValue::List(email_values)),
+        );
     }
 
     attributes
 }
 
 fn value_as_str(v: &Value) -> Option<&str> {
-    if let Value::String(s) = v {
+    if let Value::Concrete(ConcreteValue::String(s)) = v {
         Some(s.as_str())
     } else {
         None
@@ -221,21 +246,27 @@ mod tests {
 
         assert_eq!(
             attrs.get("user_id"),
-            Some(&Value::String(
+            Some(&Value::Concrete(ConcreteValue::String(
                 "37846ac8-4021-705b-1bf2-26861723348f".to_string()
-            ))
+            )))
         );
         assert_eq!(
             attrs.get("identity_store_id"),
-            Some(&Value::String("d-9567916d09".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "d-9567916d09".to_string()
+            )))
         );
         assert_eq!(
             attrs.get("user_name"),
-            Some(&Value::String("gosukenator@gmail.com".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "gosukenator@gmail.com".to_string()
+            )))
         );
         assert_eq!(
             attrs.get("display_name"),
-            Some(&Value::String("Gosuke Miyashita".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Gosuke Miyashita".to_string()
+            )))
         );
     }
 
@@ -244,20 +275,26 @@ mod tests {
         let resp = describe_user_full();
         let attrs = extract_identitystore_user(&resp);
 
-        let Some(Value::Map(name)) = attrs.get("name") else {
+        let Some(Value::Concrete(ConcreteValue::Map(name))) = attrs.get("name") else {
             panic!("expected name map, got {:?}", attrs.get("name"));
         };
         assert_eq!(
             name.get("formatted"),
-            Some(&Value::String("Gosuke Miyashita".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Gosuke Miyashita".to_string()
+            )))
         );
         assert_eq!(
             name.get("family_name"),
-            Some(&Value::String("Miyashita".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Miyashita".to_string()
+            )))
         );
         assert_eq!(
             name.get("given_name"),
-            Some(&Value::String("Gosuke".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Gosuke".to_string()
+            )))
         );
         // Unset optional fields must not appear in the map.
         assert!(!name.contains_key("middle_name"));
@@ -269,13 +306,13 @@ mod tests {
         let resp = describe_user_full();
         let attrs = extract_identitystore_user(&resp);
 
-        let Some(Value::List(emails)) = attrs.get("emails") else {
+        let Some(Value::Concrete(ConcreteValue::List(emails))) = attrs.get("emails") else {
             panic!("expected emails list, got {:?}", attrs.get("emails"));
         };
         assert_eq!(emails.len(), 1);
         assert_eq!(
             emails[0],
-            Value::String("gosukenator@gmail.com".to_string())
+            Value::Concrete(ConcreteValue::String("gosukenator@gmail.com".to_string()))
         );
     }
 
@@ -291,11 +328,13 @@ mod tests {
 
         assert_eq!(
             attrs.get("user_id"),
-            Some(&Value::String("uid-min".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "uid-min".to_string()
+            )))
         );
         assert_eq!(
             attrs.get("identity_store_id"),
-            Some(&Value::String("d-min".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("d-min".to_string())))
         );
         assert!(!attrs.contains_key("user_name"));
         assert!(!attrs.contains_key("display_name"));
@@ -315,13 +354,15 @@ mod tests {
             .unwrap();
         let attrs = extract_identitystore_user(&resp);
 
-        let Some(Value::Map(name)) = attrs.get("name") else {
+        let Some(Value::Concrete(ConcreteValue::Map(name))) = attrs.get("name") else {
             panic!("expected name map, got {:?}", attrs.get("name"));
         };
         assert_eq!(name.len(), 1);
         assert_eq!(
             name.get("given_name"),
-            Some(&Value::String("Gosuke".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Gosuke".to_string()
+            )))
         );
         assert!(!name.contains_key("formatted"));
         assert!(!name.contains_key("family_name"));

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -41,26 +41,35 @@ impl AwsProvider {
             if let Some(name) = lg.log_group_name() {
                 attributes.insert(
                     "log_group_name".to_string(),
-                    Value::String(name.to_string()),
+                    Value::Concrete(ConcreteValue::String(name.to_string())),
                 );
             }
 
             if let Some(arn) = lg.arn() {
-                attributes.insert("arn".to_string(), Value::String(arn.to_string()));
+                attributes.insert(
+                    "arn".to_string(),
+                    Value::Concrete(ConcreteValue::String(arn.to_string())),
+                );
             }
 
             if let Some(days) = lg.retention_in_days() {
-                attributes.insert("retention_in_days".to_string(), Value::Int(days as i64));
+                attributes.insert(
+                    "retention_in_days".to_string(),
+                    Value::Concrete(ConcreteValue::Int(days as i64)),
+                );
             }
 
             if let Some(kms_key) = lg.kms_key_id() {
-                attributes.insert("kms_key_id".to_string(), Value::String(kms_key.to_string()));
+                attributes.insert(
+                    "kms_key_id".to_string(),
+                    Value::Concrete(ConcreteValue::String(kms_key.to_string())),
+                );
             }
 
             if let Some(class) = lg.log_group_class() {
                 attributes.insert(
                     "log_group_class".to_string(),
-                    Value::String(class.as_str().to_string()),
+                    Value::Concrete(ConcreteValue::String(class.as_str().to_string())),
                 );
             }
 
@@ -79,9 +88,15 @@ impl AwsProvider {
                     {
                         let mut tag_map = IndexMap::new();
                         for (key, val) in tags {
-                            tag_map.insert(key.to_string(), Value::String(val.to_string()));
+                            tag_map.insert(
+                                key.to_string(),
+                                Value::Concrete(ConcreteValue::String(val.to_string())),
+                            );
                         }
-                        attributes.insert("tags".to_string(), Value::Map(tag_map));
+                        attributes.insert(
+                            "tags".to_string(),
+                            Value::Concrete(ConcreteValue::Map(tag_map)),
+                        );
                     }
                 }
                 Err(_) => {
@@ -105,20 +120,24 @@ impl AwsProvider {
             .create_log_group()
             .log_group_name(&log_group_name);
 
-        if let Some(Value::String(kms_key)) = resource.get_attr("kms_key_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(kms_key))) =
+            resource.get_attr("kms_key_id")
+        {
             req = req.kms_key_id(kms_key);
         }
 
-        if let Some(Value::String(class)) = resource.get_attr("log_group_class") {
+        if let Some(Value::Concrete(ConcreteValue::String(class))) =
+            resource.get_attr("log_group_class")
+        {
             use aws_sdk_cloudwatchlogs::types::LogGroupClass;
             let class_value = extract_enum_value(class);
             req = req.log_group_class(LogGroupClass::from(class_value));
         }
 
-        if let Some(Value::Map(tag_map)) = resource.get_attr("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(tag_map))) = resource.get_attr("tags") {
             let mut tags = HashMap::new();
             for (key, value) in tag_map {
-                if let Value::String(val) = value {
+                if let Value::Concrete(ConcreteValue::String(val)) = value {
                     tags.insert(key.clone(), val.clone());
                 }
             }
@@ -131,7 +150,9 @@ impl AwsProvider {
         })?;
 
         // Set retention if specified
-        if let Some(Value::Int(days)) = resource.get_attr("retention_in_days") {
+        if let Some(Value::Concrete(ConcreteValue::Int(days))) =
+            resource.get_attr("retention_in_days")
+        {
             self.logs_client
                 .put_retention_policy()
                 .log_group_name(&log_group_name)
@@ -161,7 +182,7 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         // Update retention
         match to.get_attr("retention_in_days") {
-            Some(Value::Int(days)) => {
+            Some(Value::Concrete(ConcreteValue::Int(days))) => {
                 self.logs_client
                     .put_retention_policy()
                     .log_group_name(identifier)
@@ -195,7 +216,7 @@ impl AwsProvider {
         }
 
         // Update KMS key
-        if let Some(Value::String(kms_key)) = to.get_attr("kms_key_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(kms_key))) = to.get_attr("kms_key_id") {
             self.logs_client
                 .associate_kms_key()
                 .log_group_name(identifier)
@@ -260,11 +281,11 @@ impl AwsProvider {
         current: Option<&HashMap<String, Value>>,
     ) -> ProviderResult<()> {
         let desired_tags = match desired.get("tags") {
-            Some(Value::Map(m)) => m.clone(),
+            Some(Value::Concrete(ConcreteValue::Map(m))) => m.clone(),
             _ => IndexMap::new(),
         };
         let current_tags = match current.and_then(|c| c.get("tags")) {
-            Some(Value::Map(m)) => m.clone(),
+            Some(Value::Concrete(ConcreteValue::Map(m))) => m.clone(),
             _ => IndexMap::new(),
         };
 
@@ -293,9 +314,9 @@ impl AwsProvider {
         // Tags to add/update
         let mut tags_to_add = HashMap::new();
         for (key, value) in &desired_tags {
-            if let Value::String(val) = value {
+            if let Value::Concrete(ConcreteValue::String(val)) = value {
                 let should_add = match current_tags.get(key) {
-                    Some(Value::String(current_val)) => current_val != val,
+                    Some(Value::Concrete(ConcreteValue::String(current_val))) => current_val != val,
                     _ => true,
                 };
                 if should_add {

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -19,33 +19,45 @@ impl AwsProvider {
         if let Some(id) = account.id() {
             let id_string = id.to_string();
             identifier = Some(id_string.clone());
-            attributes.insert("id".to_string(), Value::String(id_string));
+            attributes.insert(
+                "id".to_string(),
+                Value::Concrete(ConcreteValue::String(id_string)),
+            );
         }
         if let Some(arn) = account.arn() {
-            attributes.insert("arn".to_string(), Value::String(arn.to_string()));
+            attributes.insert(
+                "arn".to_string(),
+                Value::Concrete(ConcreteValue::String(arn.to_string())),
+            );
         }
         if let Some(name) = account.name() {
-            attributes.insert("name".to_string(), Value::String(name.to_string()));
+            attributes.insert(
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String(name.to_string())),
+            );
         }
         if let Some(email) = account.email() {
-            attributes.insert("email".to_string(), Value::String(email.to_string()));
+            attributes.insert(
+                "email".to_string(),
+                Value::Concrete(ConcreteValue::String(email.to_string())),
+            );
         }
         if let Some(status) = account.status() {
             attributes.insert(
                 "status".to_string(),
-                Value::String(status.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(status.as_str().to_string())),
             );
         }
         if let Some(joined_method) = account.joined_method() {
             attributes.insert(
                 "joined_method".to_string(),
-                Value::String(joined_method.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(joined_method.as_str().to_string())),
             );
         }
         if let Some(joined_timestamp) = account.joined_timestamp() {
             attributes.insert(
                 "joined_timestamp".to_string(),
-                Value::String(joined_timestamp.to_string()),
+                Value::Concrete(ConcreteValue::String(joined_timestamp.to_string())),
             );
         }
 
@@ -89,7 +101,7 @@ impl AwsProvider {
                     {
                         attributes.insert(
                             "parent_id".to_string(),
-                            Value::String(parent_id.to_string()),
+                            Value::Concrete(ConcreteValue::String(parent_id.to_string())),
                         );
                     }
 
@@ -107,11 +119,14 @@ impl AwsProvider {
                             for tag in tags {
                                 tag_map.insert(
                                     tag.key().to_string(),
-                                    Value::String(tag.value().to_string()),
+                                    Value::Concrete(ConcreteValue::String(tag.value().to_string())),
                                 );
                             }
                             if !tag_map.is_empty() {
-                                attributes.insert("tags".to_string(), Value::Map(tag_map));
+                                attributes.insert(
+                                    "tags".to_string(),
+                                    Value::Concrete(ConcreteValue::Map(tag_map)),
+                                );
                             }
                         }
                     }
@@ -154,20 +169,24 @@ impl AwsProvider {
             .account_name(&name)
             .email(&email);
 
-        if let Some(Value::String(iam_billing)) = resource.get_attr("iam_user_access_to_billing") {
+        if let Some(Value::Concrete(ConcreteValue::String(iam_billing))) =
+            resource.get_attr("iam_user_access_to_billing")
+        {
             let val = aws_sdk_organizations::types::IamUserAccessToBilling::from(
                 extract_enum_value(iam_billing),
             );
             req = req.iam_user_access_to_billing(val);
         }
 
-        if let Some(Value::String(role_name)) = resource.get_attr("role_name") {
+        if let Some(Value::Concrete(ConcreteValue::String(role_name))) =
+            resource.get_attr("role_name")
+        {
             req = req.role_name(role_name);
         }
 
-        if let Some(Value::Map(tag_map)) = resource.get_attr("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(tag_map))) = resource.get_attr("tags") {
             for (key, value) in tag_map {
-                if let Value::String(val) = value {
+                if let Value::Concrete(ConcreteValue::String(val)) = value {
                     let tag = aws_sdk_organizations::types::Tag::builder()
                         .key(key)
                         .value(val)
@@ -259,7 +278,9 @@ impl AwsProvider {
             })?;
 
         // Move to parent OU if specified
-        if let Some(Value::String(parent_id)) = resource.get_attr("parent_id") {
+        if let Some(Value::Concrete(ConcreteValue::String(parent_id))) =
+            resource.get_attr("parent_id")
+        {
             // Get current parent (root)
             let parents_response = self
                 .organizations_client
@@ -310,11 +331,11 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         // Handle parent_id change via MoveAccount
         let desired_parent = to.get_attr("parent_id").and_then(|v| match v {
-            Value::String(s) => Some(s.as_str()),
+            Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
             _ => None,
         });
         let current_parent = from.attributes.get("parent_id").and_then(|v| match v {
-            Value::String(s) => Some(s.as_str()),
+            Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
             _ => None,
         });
 
@@ -373,11 +394,11 @@ impl AwsProvider {
         current: Option<&HashMap<String, Value>>,
     ) -> ProviderResult<()> {
         let desired_tags = match desired.get("tags") {
-            Some(Value::Map(m)) => m.clone(),
+            Some(Value::Concrete(ConcreteValue::Map(m))) => m.clone(),
             _ => IndexMap::new(),
         };
         let current_tags = match current.and_then(|c| c.get("tags")) {
-            Some(Value::Map(m)) => m.clone(),
+            Some(Value::Concrete(ConcreteValue::Map(m))) => m.clone(),
             _ => IndexMap::new(),
         };
 
@@ -404,9 +425,9 @@ impl AwsProvider {
         // Tags to add/update
         let mut tags_to_add = Vec::new();
         for (key, value) in &desired_tags {
-            if let Value::String(val) = value {
+            if let Value::Concrete(ConcreteValue::String(val)) = value {
                 let should_add = match current_tags.get(key) {
-                    Some(Value::String(current_val)) => current_val != val,
+                    Some(Value::Concrete(ConcreteValue::String(current_val))) => current_val != val,
                     _ => true,
                 };
                 if should_add {

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -18,33 +18,39 @@ impl AwsProvider {
         if let Some(id) = org.id() {
             let id_string = id.to_string();
             identifier = Some(id_string.clone());
-            attributes.insert("id".to_string(), Value::String(id_string));
+            attributes.insert(
+                "id".to_string(),
+                Value::Concrete(ConcreteValue::String(id_string)),
+            );
         }
         if let Some(arn) = org.arn() {
-            attributes.insert("arn".to_string(), Value::String(arn.to_string()));
+            attributes.insert(
+                "arn".to_string(),
+                Value::Concrete(ConcreteValue::String(arn.to_string())),
+            );
         }
         if let Some(feature_set) = org.feature_set() {
             attributes.insert(
                 "feature_set".to_string(),
-                Value::String(feature_set.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(feature_set.as_str().to_string())),
             );
         }
         if let Some(master_account_id) = org.master_account_id() {
             attributes.insert(
                 "master_account_id".to_string(),
-                Value::String(master_account_id.to_string()),
+                Value::Concrete(ConcreteValue::String(master_account_id.to_string())),
             );
         }
         if let Some(master_account_arn) = org.master_account_arn() {
             attributes.insert(
                 "master_account_arn".to_string(),
-                Value::String(master_account_arn.to_string()),
+                Value::Concrete(ConcreteValue::String(master_account_arn.to_string())),
             );
         }
         if let Some(master_account_email) = org.master_account_email() {
             attributes.insert(
                 "master_account_email".to_string(),
-                Value::String(master_account_email.to_string()),
+                Value::Concrete(ConcreteValue::String(master_account_email.to_string())),
             );
         }
 
@@ -104,7 +110,9 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let mut req = self.organizations_client.create_organization();
 
-        if let Some(Value::String(feature_set)) = resource.get_attr("feature_set") {
+        if let Some(Value::Concrete(ConcreteValue::String(feature_set))) =
+            resource.get_attr("feature_set")
+        {
             let fs = aws_sdk_organizations::types::OrganizationFeatureSet::from(
                 extract_enum_value(feature_set),
             );

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -11,7 +11,7 @@ use aws_sdk_route53::types::{
 };
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_enum_attr, require_string_attr, sdk_error_message};
@@ -44,7 +44,7 @@ fn strip_trailing_dot(name: &str) -> String {
 }
 
 fn extract_string(value: &Value) -> Option<&str> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         Some(s.as_str())
     } else {
         None
@@ -55,7 +55,7 @@ fn build_resource_records(records: &[Value]) -> Vec<ResourceRecord> {
     records
         .iter()
         .filter_map(|v| {
-            if let Value::String(s) = v {
+            if let Value::Concrete(ConcreteValue::String(s)) = v {
                 ResourceRecord::builder().value(s.clone()).build().ok()
             } else {
                 None
@@ -79,7 +79,7 @@ fn build_alias_target_from_map(
     let evaluate = alias
         .get("evaluate_target_health")
         .and_then(|v| {
-            if let Value::Bool(b) = v {
+            if let Value::Concrete(ConcreteValue::Bool(b)) = v {
                 Some(*b)
             } else {
                 None
@@ -107,15 +107,17 @@ fn build_record_set(resource: &Resource) -> ProviderResult<ResourceRecordSet> {
         .name(normalize_dns_name(&name))
         .r#type(RrType::from(record_type.as_str()));
 
-    if let Some(Value::Int(ttl)) = resource.get_attr("ttl") {
+    if let Some(Value::Concrete(ConcreteValue::Int(ttl))) = resource.get_attr("ttl") {
         builder = builder.ttl(*ttl);
     }
 
-    if let Some(Value::List(records)) = resource.get_attr("resource_records") {
+    if let Some(Value::Concrete(ConcreteValue::List(records))) =
+        resource.get_attr("resource_records")
+    {
         builder = builder.set_resource_records(Some(build_resource_records(records)));
     }
 
-    if let Some(Value::Map(alias)) = resource.get_attr("alias_target") {
+    if let Some(Value::Concrete(ConcreteValue::Map(alias))) = resource.get_attr("alias_target") {
         builder = builder.alias_target(build_alias_target_from_map(alias, &resource.id)?);
     }
 
@@ -170,47 +172,53 @@ fn extract_attributes(hosted_zone_id: &str, rrs: &ResourceRecordSet) -> HashMap<
 
     attrs.insert(
         "hosted_zone_id".to_string(),
-        Value::String(hosted_zone_id.to_string()),
+        Value::Concrete(ConcreteValue::String(hosted_zone_id.to_string())),
     );
 
     attrs.insert(
         "name".to_string(),
-        Value::String(strip_trailing_dot(rrs.name())),
+        Value::Concrete(ConcreteValue::String(strip_trailing_dot(rrs.name()))),
     );
 
     attrs.insert(
         "type".to_string(),
-        Value::String(rrs.r#type().as_str().to_string()),
+        Value::Concrete(ConcreteValue::String(rrs.r#type().as_str().to_string())),
     );
 
     if let Some(ttl) = rrs.ttl() {
-        attrs.insert("ttl".to_string(), Value::Int(ttl));
+        attrs.insert("ttl".to_string(), Value::Concrete(ConcreteValue::Int(ttl)));
     }
 
     let records: Vec<Value> = rrs
         .resource_records()
         .iter()
-        .map(|r| Value::String(r.value().to_string()))
+        .map(|r| Value::Concrete(ConcreteValue::String(r.value().to_string())))
         .collect();
     if !records.is_empty() {
-        attrs.insert("resource_records".to_string(), Value::List(records));
+        attrs.insert(
+            "resource_records".to_string(),
+            Value::Concrete(ConcreteValue::List(records)),
+        );
     }
 
     if let Some(alias) = rrs.alias_target() {
         let mut alias_map: IndexMap<String, Value> = IndexMap::new();
         alias_map.insert(
             "dns_name".to_string(),
-            Value::String(strip_trailing_dot(alias.dns_name())),
+            Value::Concrete(ConcreteValue::String(strip_trailing_dot(alias.dns_name()))),
         );
         alias_map.insert(
             "hosted_zone_id".to_string(),
-            Value::String(alias.hosted_zone_id().to_string()),
+            Value::Concrete(ConcreteValue::String(alias.hosted_zone_id().to_string())),
         );
         alias_map.insert(
             "evaluate_target_health".to_string(),
-            Value::Bool(alias.evaluate_target_health()),
+            Value::Concrete(ConcreteValue::Bool(alias.evaluate_target_health())),
         );
-        attrs.insert("alias_target".to_string(), Value::Map(alias_map));
+        attrs.insert(
+            "alias_target".to_string(),
+            Value::Concrete(ConcreteValue::Map(alias_map)),
+        );
     }
 
     attrs
@@ -332,15 +340,19 @@ impl AwsProvider {
             .name(&normalized_name)
             .r#type(RrType::from(record_type));
 
-        if let Some(Value::Int(ttl)) = current.attributes.get("ttl") {
+        if let Some(Value::Concrete(ConcreteValue::Int(ttl))) = current.attributes.get("ttl") {
             builder = builder.ttl(*ttl);
         }
 
-        if let Some(Value::List(records)) = current.attributes.get("resource_records") {
+        if let Some(Value::Concrete(ConcreteValue::List(records))) =
+            current.attributes.get("resource_records")
+        {
             builder = builder.set_resource_records(Some(build_resource_records(records)));
         }
 
-        if let Some(Value::Map(alias)) = current.attributes.get("alias_target") {
+        if let Some(Value::Concrete(ConcreteValue::Map(alias))) =
+            current.attributes.get("alias_target")
+        {
             builder = builder.alias_target(build_alias_target_from_map(alias, &id)?);
         }
 

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
-use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
@@ -22,7 +22,10 @@ impl AwsProvider {
         match self.s3_client.head_bucket().bucket(name).send().await {
             Ok(_) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(name.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(name.to_string())),
+                );
 
                 // Get tags
                 self.read_s3_bucket_tags(id, name, &mut attributes).await?;
@@ -63,7 +66,7 @@ impl AwsProvider {
     /// Create an S3 bucket
     pub(crate) async fn create_s3_bucket(&self, resource: Resource) -> ProviderResult<State> {
         let bucket_name = match resource.get_attr("bucket") {
-            Some(Value::String(s)) => s.clone(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {
                 return Err(ProviderError::invalid_input("Bucket name is required")
                     .for_resource(resource.id.clone()));
@@ -72,7 +75,7 @@ impl AwsProvider {
 
         // Get region (use Provider's region if not specified)
         let region = match resource.get_attr("region") {
-            Some(Value::String(s)) => {
+            Some(Value::Concrete(ConcreteValue::String(s))) => {
                 // Convert from aws.Region.ap_northeast_1 format to ap-northeast-1 format
                 convert_enum_value(s).to_string()
             }
@@ -290,11 +293,14 @@ impl AwsProvider {
                 for tag in output.tag_set() {
                     tag_map.insert(
                         tag.key().to_string(),
-                        Value::String(tag.value().to_string()),
+                        Value::Concrete(ConcreteValue::String(tag.value().to_string())),
                     );
                 }
                 if !tag_map.is_empty() {
-                    attributes.insert("tags".to_string(), Value::Map(tag_map));
+                    attributes.insert(
+                        "tags".to_string(),
+                        Value::Concrete(ConcreteValue::Map(tag_map)),
+                    );
                 }
             }
             Err(err) => {
@@ -317,12 +323,12 @@ impl AwsProvider {
         identifier: &str,
         attributes: &HashMap<String, Value>,
     ) -> ProviderResult<()> {
-        if let Some(Value::Map(tag_map)) = attributes.get("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(tag_map))) = attributes.get("tags") {
             use aws_sdk_s3::types::{Tag, Tagging};
             let tags: Vec<Tag> = tag_map
                 .iter()
                 .filter_map(|(k, v)| {
-                    if let Value::String(val) = v {
+                    if let Value::Concrete(ConcreteValue::String(val)) = v {
                         Some(Tag::builder().key(k).value(val).build().ok()?)
                     } else {
                         None
@@ -368,7 +374,7 @@ impl AwsProvider {
         let resource = resource.clone();
         Box::pin(async move {
             let bucket = match resource.get_attr("bucket") {
-                Some(Value::String(s)) => s.clone(),
+                Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
                 _ => {
                     return Err(ProviderError::invalid_input("`bucket` is required")
                         .for_resource(resource.id.clone()));
@@ -438,20 +444,26 @@ impl AwsProvider {
                 .map_err(|m| ProviderError::internal(m).for_resource(resource.id.clone()))?;
 
             let mut attrs = HashMap::new();
-            attrs.insert("bucket".into(), Value::String(bucket.clone()));
-            attrs.insert("arn".into(), Value::String(arn));
-            attrs.insert("region".into(), Value::String(region));
+            attrs.insert(
+                "bucket".into(),
+                Value::Concrete(ConcreteValue::String(bucket.clone())),
+            );
+            attrs.insert("arn".into(), Value::Concrete(ConcreteValue::String(arn)));
+            attrs.insert(
+                "region".into(),
+                Value::Concrete(ConcreteValue::String(region)),
+            );
             attrs.insert(
                 "bucket_domain_name".into(),
-                Value::String(bucket_domain_name),
+                Value::Concrete(ConcreteValue::String(bucket_domain_name)),
             );
             attrs.insert(
                 "bucket_regional_domain_name".into(),
-                Value::String(bucket_regional_domain_name),
+                Value::Concrete(ConcreteValue::String(bucket_regional_domain_name)),
             );
             attrs.insert(
                 "hosted_zone_id".into(),
-                Value::String(hosted_zone_id.to_string()),
+                Value::Concrete(ConcreteValue::String(hosted_zone_id.to_string())),
             );
 
             Ok(State::existing(resource.id.clone(), attrs).with_identifier(&bucket))

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::BucketCannedAcl;
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
@@ -31,7 +31,10 @@ impl AwsProvider {
         match result {
             Ok(_) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
             }
             Err(e) => {
@@ -72,7 +75,7 @@ impl AwsProvider {
             // convert_enum_value normalizes namespaced/typed identifiers
             // (`aws.s3.BucketAcl.Acl.public_read`) and snake-cased aliases
             // (`public_read` ⇄ `public-read`) back to AWS canonical form.
-            Some(Value::String(s)) => convert_enum_value(s).to_string(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => convert_enum_value(s).to_string(),
             _ => {
                 return Err(
                     ProviderError::invalid_input("acl is required").for_resource(id.clone())

--- a/carina-provider-aws/src/services/s3/bucket_cors.rs
+++ b/carina-provider-aws/src/services/s3/bucket_cors.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::{CorsConfiguration, CorsRule};
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -24,9 +24,15 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 let rules: Vec<Value> = output.cors_rules().iter().map(rule_to_value).collect();
-                attributes.insert("cors_rules".to_string(), Value::List(rules));
+                attributes.insert(
+                    "cors_rules".to_string(),
+                    Value::Concrete(ConcreteValue::List(rules)),
+                );
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
             }
             Err(e) => {
@@ -70,7 +76,7 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let rules = match resource.get_attr("cors_rules") {
-            Some(Value::List(items)) => items,
+            Some(Value::Concrete(ConcreteValue::List(items))) => items,
             _ => {
                 return Err(ProviderError::invalid_input(
                     "cors_rules is required and must be a list",
@@ -137,7 +143,7 @@ impl AwsProvider {
 }
 
 fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<CorsRule> {
-    let Value::Map(map) = rule_value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = rule_value else {
         return Err(
             ProviderError::invalid_input("each cors rule must be a map").for_resource(id.clone())
         );
@@ -150,17 +156,17 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<CorsRule> {
         .set_allowed_methods(Some(allowed_methods))
         .set_allowed_origins(Some(allowed_origins));
 
-    if let Some(Value::String(s)) = map.get("id") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("id") {
         builder = builder.id(s);
     }
-    if let Some(Value::List(items)) = map.get("allowed_headers") {
+    if let Some(Value::Concrete(ConcreteValue::List(items))) = map.get("allowed_headers") {
         builder =
             builder.set_allowed_headers(Some(strings_from_list(id, items, "allowed_headers")?));
     }
-    if let Some(Value::List(items)) = map.get("expose_headers") {
+    if let Some(Value::Concrete(ConcreteValue::List(items))) = map.get("expose_headers") {
         builder = builder.set_expose_headers(Some(strings_from_list(id, items, "expose_headers")?));
     }
-    if let Some(Value::Int(n)) = map.get("max_age_seconds") {
+    if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("max_age_seconds") {
         builder = builder.max_age_seconds(*n as i32);
     }
 
@@ -176,7 +182,7 @@ fn require_string_list(
     field: &str,
 ) -> ProviderResult<Vec<String>> {
     match map.get(field) {
-        Some(Value::List(items)) => strings_from_list(id, items, field),
+        Some(Value::Concrete(ConcreteValue::List(items))) => strings_from_list(id, items, field),
         _ => Err(
             ProviderError::invalid_input(format!("cors_rule.{field} is required"))
                 .for_resource(id.clone()),
@@ -188,7 +194,7 @@ fn strings_from_list(id: &ResourceId, items: &[Value], field: &str) -> ProviderR
     items
         .iter()
         .map(|v| match v {
-            Value::String(s) => Ok(s.clone()),
+            Value::Concrete(ConcreteValue::String(s)) => Ok(s.clone()),
             _ => Err(ProviderError::invalid_input(format!(
                 "cors_rule.{field} must be a list of strings"
             ))
@@ -202,38 +208,56 @@ fn rule_to_value(rule: &CorsRule) -> Value {
     if let Some(s) = rule.id()
         && !s.is_empty()
     {
-        m.insert("id".to_string(), Value::String(s.to_string()));
+        m.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String(s.to_string())),
+        );
     }
     let methods: Vec<Value> = rule
         .allowed_methods()
         .iter()
-        .map(|s| Value::String(s.clone()))
+        .map(|s| Value::Concrete(ConcreteValue::String(s.clone())))
         .collect();
-    m.insert("allowed_methods".to_string(), Value::List(methods));
+    m.insert(
+        "allowed_methods".to_string(),
+        Value::Concrete(ConcreteValue::List(methods)),
+    );
     let origins: Vec<Value> = rule
         .allowed_origins()
         .iter()
-        .map(|s| Value::String(s.clone()))
+        .map(|s| Value::Concrete(ConcreteValue::String(s.clone())))
         .collect();
-    m.insert("allowed_origins".to_string(), Value::List(origins));
+    m.insert(
+        "allowed_origins".to_string(),
+        Value::Concrete(ConcreteValue::List(origins)),
+    );
     let headers: Vec<Value> = rule
         .allowed_headers()
         .iter()
-        .map(|s| Value::String(s.clone()))
+        .map(|s| Value::Concrete(ConcreteValue::String(s.clone())))
         .collect();
     if !headers.is_empty() {
-        m.insert("allowed_headers".to_string(), Value::List(headers));
+        m.insert(
+            "allowed_headers".to_string(),
+            Value::Concrete(ConcreteValue::List(headers)),
+        );
     }
     let expose: Vec<Value> = rule
         .expose_headers()
         .iter()
-        .map(|s| Value::String(s.clone()))
+        .map(|s| Value::Concrete(ConcreteValue::String(s.clone())))
         .collect();
     if !expose.is_empty() {
-        m.insert("expose_headers".to_string(), Value::List(expose));
+        m.insert(
+            "expose_headers".to_string(),
+            Value::Concrete(ConcreteValue::List(expose)),
+        );
     }
     if let Some(n) = rule.max_age_seconds() {
-        m.insert("max_age_seconds".to_string(), Value::Int(n as i64));
+        m.insert(
+            "max_age_seconds".to_string(),
+            Value::Concrete(ConcreteValue::Int(n as i64)),
+        );
     }
-    Value::Map(m)
+    Value::Concrete(ConcreteValue::Map(m))
 }

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -5,7 +5,7 @@ use aws_sdk_s3::types::{
     ServerSideEncryptionRule,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 use indexmap::IndexMap;
 
@@ -33,11 +33,17 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 if let Some(config) = output.server_side_encryption_configuration() {
                     let rules: Vec<Value> = config.rules().iter().map(rule_to_value).collect();
                     if !rules.is_empty() {
-                        attributes.insert("rules".to_string(), Value::List(rules));
+                        attributes.insert(
+                            "rules".to_string(),
+                            Value::Concrete(ConcreteValue::List(rules)),
+                        );
                     }
                 }
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
@@ -83,7 +89,7 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let rules = match resource.get_attr("rules") {
-            Some(Value::List(items)) => items,
+            Some(Value::Concrete(ConcreteValue::List(items))) => items,
             _ => {
                 return Err(
                     ProviderError::invalid_input("rules is required and must be a list")
@@ -155,7 +161,7 @@ impl AwsProvider {
 }
 
 fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ServerSideEncryptionRule> {
-    let Value::Map(rule_map) = rule_value else {
+    let Value::Concrete(ConcreteValue::Map(rule_map)) = rule_value else {
         return Err(
             ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
         );
@@ -167,7 +173,7 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ServerSideE
         builder =
             builder.apply_server_side_encryption_by_default(build_by_default(id, by_default)?);
     }
-    if let Some(Value::Bool(b)) = rule_map.get("bucket_key_enabled") {
+    if let Some(Value::Concrete(ConcreteValue::Bool(b))) = rule_map.get("bucket_key_enabled") {
         builder = builder.bucket_key_enabled(*b);
     }
 
@@ -178,14 +184,14 @@ fn build_by_default(
     id: &ResourceId,
     value: &Value,
 ) -> ProviderResult<ServerSideEncryptionByDefault> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(ProviderError::invalid_input(
             "apply_server_side_encryption_by_default must be a map",
         )
         .for_resource(id.clone()));
     };
     let algorithm_str = match map.get("sse_algorithm") {
-        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => extract_enum_value(s).to_string(),
         _ => {
             return Err(
                 ProviderError::invalid_input("sse_algorithm is required").for_resource(id.clone())
@@ -194,7 +200,7 @@ fn build_by_default(
     };
     let mut builder = ServerSideEncryptionByDefault::builder()
         .sse_algorithm(ServerSideEncryption::from(algorithm_str.as_str()));
-    if let Some(Value::String(k)) = map.get("kms_master_key_id") {
+    if let Some(Value::Concrete(ConcreteValue::String(k))) = map.get("kms_master_key_id") {
         builder = builder.kms_master_key_id(k);
     }
     builder.build().map_err(|e| {
@@ -212,21 +218,26 @@ fn rule_to_value(rule: &ServerSideEncryptionRule) -> Value {
         let mut inner = IndexMap::new();
         inner.insert(
             "sse_algorithm".to_string(),
-            Value::String(by_default.sse_algorithm().as_str().to_string()),
+            Value::Concrete(ConcreteValue::String(
+                by_default.sse_algorithm().as_str().to_string(),
+            )),
         );
         if let Some(k) = by_default.kms_master_key_id() {
             inner.insert(
                 "kms_master_key_id".to_string(),
-                Value::String(k.to_string()),
+                Value::Concrete(ConcreteValue::String(k.to_string())),
             );
         }
         map.insert(
             "apply_server_side_encryption_by_default".to_string(),
-            Value::Map(inner),
+            Value::Concrete(ConcreteValue::Map(inner)),
         );
     }
     if let Some(b) = rule.bucket_key_enabled() {
-        map.insert("bucket_key_enabled".to_string(), Value::Bool(b));
+        map.insert(
+            "bucket_key_enabled".to_string(),
+            Value::Concrete(ConcreteValue::Bool(b)),
+        );
     }
-    Value::Map(map)
+    Value::Concrete(ConcreteValue::Map(map))
 }

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -6,7 +6,7 @@ use aws_sdk_s3::types::{
     Transition, TransitionStorageClass,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 use indexmap::IndexMap;
 
@@ -34,10 +34,16 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 let rules: Vec<Value> = output.rules().iter().map(rule_to_value).collect();
                 if !rules.is_empty() {
-                    attributes.insert("rules".to_string(), Value::List(rules));
+                    attributes.insert(
+                        "rules".to_string(),
+                        Value::Concrete(ConcreteValue::List(rules)),
+                    );
                 }
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
             }
@@ -82,7 +88,7 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let rules = match resource.get_attr("rules") {
-            Some(Value::List(items)) => items,
+            Some(Value::Concrete(ConcreteValue::List(items))) => items,
             _ => {
                 return Err(
                     ProviderError::invalid_input("rules is required and must be a list")
@@ -155,14 +161,14 @@ impl AwsProvider {
 }
 
 fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRule> {
-    let Value::Map(map) = rule_value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = rule_value else {
         return Err(
             ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
         );
     };
 
     let status_str = match map.get("status") {
-        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => extract_enum_value(s).to_string(),
         _ => {
             return Err(
                 ProviderError::invalid_input("rule.status is required").for_resource(id.clone())
@@ -172,17 +178,17 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRu
 
     let mut builder = LifecycleRule::builder().status(ExpirationStatus::from(status_str.as_str()));
 
-    if let Some(Value::String(s)) = map.get("id") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("id") {
         builder = builder.id(s);
     }
     #[allow(deprecated)]
-    if let Some(Value::String(s)) = map.get("prefix") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("prefix") {
         builder = builder.prefix(s);
     }
     if let Some(v) = map.get("expiration") {
         builder = builder.expiration(build_expiration(id, v)?);
     }
-    if let Some(Value::List(items)) = map.get("transitions") {
+    if let Some(Value::Concrete(ConcreteValue::List(items))) = map.get("transitions") {
         let transitions: Vec<Transition> = items
             .iter()
             .map(|v| build_transition(id, v))
@@ -192,7 +198,9 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRu
     if let Some(v) = map.get("noncurrent_version_expiration") {
         builder = builder.noncurrent_version_expiration(build_ncv_expiration(id, v)?);
     }
-    if let Some(Value::List(items)) = map.get("noncurrent_version_transitions") {
+    if let Some(Value::Concrete(ConcreteValue::List(items))) =
+        map.get("noncurrent_version_transitions")
+    {
         let transitions: Vec<NoncurrentVersionTransition> = items
             .iter()
             .map(|v| build_ncv_transition(id, v))
@@ -210,29 +218,29 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRu
 }
 
 fn build_expiration(id: &ResourceId, value: &Value) -> ProviderResult<LifecycleExpiration> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("expiration must be a map").for_resource(id.clone())
         );
     };
     let mut builder = LifecycleExpiration::builder();
-    if let Some(Value::Int(d)) = map.get("days") {
+    if let Some(Value::Concrete(ConcreteValue::Int(d))) = map.get("days") {
         builder = builder.days(*d as i32);
     }
-    if let Some(Value::Bool(b)) = map.get("expired_object_delete_marker") {
+    if let Some(Value::Concrete(ConcreteValue::Bool(b))) = map.get("expired_object_delete_marker") {
         builder = builder.expired_object_delete_marker(*b);
     }
     Ok(builder.build())
 }
 
 fn build_transition(id: &ResourceId, value: &Value) -> ProviderResult<Transition> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("transition must be a map").for_resource(id.clone())
         );
     };
     let storage_class_str = match map.get("storage_class") {
-        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => extract_enum_value(s).to_string(),
         _ => {
             return Err(
                 ProviderError::invalid_input("transition.storage_class is required")
@@ -242,7 +250,7 @@ fn build_transition(id: &ResourceId, value: &Value) -> ProviderResult<Transition
     };
     let mut builder = Transition::builder()
         .storage_class(TransitionStorageClass::from(storage_class_str.as_str()));
-    if let Some(Value::Int(d)) = map.get("days") {
+    if let Some(Value::Concrete(ConcreteValue::Int(d))) = map.get("days") {
         builder = builder.days(*d as i32);
     }
     Ok(builder.build())
@@ -252,17 +260,17 @@ fn build_ncv_expiration(
     id: &ResourceId,
     value: &Value,
 ) -> ProviderResult<NoncurrentVersionExpiration> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("noncurrent_version_expiration must be a map")
                 .for_resource(id.clone()),
         );
     };
     let mut builder = NoncurrentVersionExpiration::builder();
-    if let Some(Value::Int(d)) = map.get("noncurrent_days") {
+    if let Some(Value::Concrete(ConcreteValue::Int(d))) = map.get("noncurrent_days") {
         builder = builder.noncurrent_days(*d as i32);
     }
-    if let Some(Value::Int(n)) = map.get("newer_noncurrent_versions") {
+    if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("newer_noncurrent_versions") {
         builder = builder.newer_noncurrent_versions(*n as i32);
     }
     Ok(builder.build())
@@ -272,14 +280,14 @@ fn build_ncv_transition(
     id: &ResourceId,
     value: &Value,
 ) -> ProviderResult<NoncurrentVersionTransition> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("noncurrent_version_transition must be a map")
                 .for_resource(id.clone()),
         );
     };
     let storage_class_str = match map.get("storage_class") {
-        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => extract_enum_value(s).to_string(),
         _ => {
             return Err(ProviderError::invalid_input(
                 "noncurrent_version_transition.storage_class is required",
@@ -289,10 +297,10 @@ fn build_ncv_transition(
     };
     let mut builder = NoncurrentVersionTransition::builder()
         .storage_class(TransitionStorageClass::from(storage_class_str.as_str()));
-    if let Some(Value::Int(d)) = map.get("noncurrent_days") {
+    if let Some(Value::Concrete(ConcreteValue::Int(d))) = map.get("noncurrent_days") {
         builder = builder.noncurrent_days(*d as i32);
     }
-    if let Some(Value::Int(n)) = map.get("newer_noncurrent_versions") {
+    if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("newer_noncurrent_versions") {
         builder = builder.newer_noncurrent_versions(*n as i32);
     }
     Ok(builder.build())
@@ -302,14 +310,14 @@ fn build_abort_multipart(
     id: &ResourceId,
     value: &Value,
 ) -> ProviderResult<AbortIncompleteMultipartUpload> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(ProviderError::invalid_input(
             "abort_incomplete_multipart_upload must be a map",
         )
         .for_resource(id.clone()));
     };
     let mut builder = AbortIncompleteMultipartUpload::builder();
-    if let Some(Value::Int(d)) = map.get("days_after_initiation") {
+    if let Some(Value::Concrete(ConcreteValue::Int(d))) = map.get("days_after_initiation") {
         builder = builder.days_after_initiation(*d as i32);
     }
     Ok(builder.build())
@@ -320,47 +328,71 @@ fn rule_to_value(rule: &LifecycleRule) -> Value {
     if let Some(s) = rule.id()
         && !s.is_empty()
     {
-        map.insert("id".to_string(), Value::String(s.to_string()));
+        map.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String(s.to_string())),
+        );
     }
     map.insert(
         "status".to_string(),
-        Value::String(rule.status().as_str().to_string()),
+        Value::Concrete(ConcreteValue::String(rule.status().as_str().to_string())),
     );
     #[allow(deprecated)]
     if let Some(s) = rule.prefix()
         && !s.is_empty()
     {
-        map.insert("prefix".to_string(), Value::String(s.to_string()));
+        map.insert(
+            "prefix".to_string(),
+            Value::Concrete(ConcreteValue::String(s.to_string())),
+        );
     }
     if let Some(exp) = rule.expiration() {
         let mut e = IndexMap::new();
         if let Some(d) = exp.days() {
-            e.insert("days".to_string(), Value::Int(d as i64));
+            e.insert(
+                "days".to_string(),
+                Value::Concrete(ConcreteValue::Int(d as i64)),
+            );
         }
         if let Some(b) = exp.expired_object_delete_marker() {
-            e.insert("expired_object_delete_marker".to_string(), Value::Bool(b));
+            e.insert(
+                "expired_object_delete_marker".to_string(),
+                Value::Concrete(ConcreteValue::Bool(b)),
+            );
         }
         if !e.is_empty() {
-            map.insert("expiration".to_string(), Value::Map(e));
+            map.insert(
+                "expiration".to_string(),
+                Value::Concrete(ConcreteValue::Map(e)),
+            );
         }
     }
     let transitions: Vec<Value> = rule.transitions().iter().map(transition_to_value).collect();
     if !transitions.is_empty() {
-        map.insert("transitions".to_string(), Value::List(transitions));
+        map.insert(
+            "transitions".to_string(),
+            Value::Concrete(ConcreteValue::List(transitions)),
+        );
     }
     if let Some(ncv) = rule.noncurrent_version_expiration() {
         let mut e = IndexMap::new();
         if let Some(d) = ncv.noncurrent_days() {
-            e.insert("noncurrent_days".to_string(), Value::Int(d as i64));
+            e.insert(
+                "noncurrent_days".to_string(),
+                Value::Concrete(ConcreteValue::Int(d as i64)),
+            );
         }
         if let Some(n) = ncv.newer_noncurrent_versions() {
             e.insert(
                 "newer_noncurrent_versions".to_string(),
-                Value::Int(n as i64),
+                Value::Concrete(ConcreteValue::Int(n as i64)),
             );
         }
         if !e.is_empty() {
-            map.insert("noncurrent_version_expiration".to_string(), Value::Map(e));
+            map.insert(
+                "noncurrent_version_expiration".to_string(),
+                Value::Concrete(ConcreteValue::Map(e)),
+            );
         }
     }
     let ncv_transitions: Vec<Value> = rule
@@ -371,54 +403,63 @@ fn rule_to_value(rule: &LifecycleRule) -> Value {
     if !ncv_transitions.is_empty() {
         map.insert(
             "noncurrent_version_transitions".to_string(),
-            Value::List(ncv_transitions),
+            Value::Concrete(ConcreteValue::List(ncv_transitions)),
         );
     }
     if let Some(abort) = rule.abort_incomplete_multipart_upload() {
         let mut a = IndexMap::new();
         if let Some(d) = abort.days_after_initiation() {
-            a.insert("days_after_initiation".to_string(), Value::Int(d as i64));
+            a.insert(
+                "days_after_initiation".to_string(),
+                Value::Concrete(ConcreteValue::Int(d as i64)),
+            );
         }
         if !a.is_empty() {
             map.insert(
                 "abort_incomplete_multipart_upload".to_string(),
-                Value::Map(a),
+                Value::Concrete(ConcreteValue::Map(a)),
             );
         }
     }
-    Value::Map(map)
+    Value::Concrete(ConcreteValue::Map(map))
 }
 
 fn transition_to_value(t: &Transition) -> Value {
     let mut m = IndexMap::new();
     if let Some(d) = t.days() {
-        m.insert("days".to_string(), Value::Int(d as i64));
+        m.insert(
+            "days".to_string(),
+            Value::Concrete(ConcreteValue::Int(d as i64)),
+        );
     }
     if let Some(sc) = t.storage_class() {
         m.insert(
             "storage_class".to_string(),
-            Value::String(sc.as_str().to_string()),
+            Value::Concrete(ConcreteValue::String(sc.as_str().to_string())),
         );
     }
-    Value::Map(m)
+    Value::Concrete(ConcreteValue::Map(m))
 }
 
 fn ncv_transition_to_value(t: &NoncurrentVersionTransition) -> Value {
     let mut m = IndexMap::new();
     if let Some(d) = t.noncurrent_days() {
-        m.insert("noncurrent_days".to_string(), Value::Int(d as i64));
+        m.insert(
+            "noncurrent_days".to_string(),
+            Value::Concrete(ConcreteValue::Int(d as i64)),
+        );
     }
     if let Some(n) = t.newer_noncurrent_versions() {
         m.insert(
             "newer_noncurrent_versions".to_string(),
-            Value::Int(n as i64),
+            Value::Concrete(ConcreteValue::Int(n as i64)),
         );
     }
     if let Some(sc) = t.storage_class() {
         m.insert(
             "storage_class".to_string(),
-            Value::String(sc.as_str().to_string()),
+            Value::Concrete(ConcreteValue::String(sc.as_str().to_string())),
         );
     }
-    Value::Map(m)
+    Value::Concrete(ConcreteValue::Map(m))
 }

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -5,7 +5,7 @@ use aws_sdk_s3::types::{
     TargetObjectKeyFormat,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 use indexmap::IndexMap;
 
@@ -33,15 +33,18 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 if let Some(le) = output.logging_enabled() {
                     attributes.insert(
                         "target_bucket".to_string(),
-                        Value::String(le.target_bucket().to_string()),
+                        Value::Concrete(ConcreteValue::String(le.target_bucket().to_string())),
                     );
                     attributes.insert(
                         "target_prefix".to_string(),
-                        Value::String(le.target_prefix().to_string()),
+                        Value::Concrete(ConcreteValue::String(le.target_prefix().to_string())),
                     );
                     if let Some(fmt) = le.target_object_key_format() {
                         attributes.insert(
@@ -91,7 +94,7 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let target_bucket = require_string_attr(resource, "target_bucket")?;
         let target_prefix = match resource.get_attr("target_prefix") {
-            Some(Value::String(s)) => s.clone(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             None => String::new(),
             _ => {
                 return Err(
@@ -157,7 +160,7 @@ impl AwsProvider {
 }
 
 fn build_key_format(id: &ResourceId, value: &Value) -> ProviderResult<TargetObjectKeyFormat> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("target_object_key_format must be a map")
                 .for_resource(id.clone()),
@@ -168,9 +171,9 @@ fn build_key_format(id: &ResourceId, value: &Value) -> ProviderResult<TargetObje
     if map.contains_key("simple_prefix") {
         builder = builder.simple_prefix(SimplePrefix::builder().build());
     }
-    if let Some(Value::Map(pp)) = map.get("partitioned_prefix") {
+    if let Some(Value::Concrete(ConcreteValue::Map(pp))) = map.get("partitioned_prefix") {
         let mut pb = PartitionedPrefix::builder();
-        if let Some(Value::String(s)) = pp.get("partition_date_source") {
+        if let Some(Value::Concrete(ConcreteValue::String(s))) = pp.get("partition_date_source") {
             let normalized = extract_enum_value(s);
             pb = pb.partition_date_source(PartitionDateSource::from(normalized));
         }
@@ -182,17 +185,23 @@ fn build_key_format(id: &ResourceId, value: &Value) -> ProviderResult<TargetObje
 fn target_object_key_format_to_value(fmt: &TargetObjectKeyFormat) -> Value {
     let mut m = IndexMap::new();
     if fmt.simple_prefix().is_some() {
-        m.insert("simple_prefix".to_string(), Value::Map(IndexMap::new()));
+        m.insert(
+            "simple_prefix".to_string(),
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+        );
     }
     if let Some(pp) = fmt.partitioned_prefix() {
         let mut inner = IndexMap::new();
         if let Some(src) = pp.partition_date_source() {
             inner.insert(
                 "partition_date_source".to_string(),
-                Value::String(src.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(src.as_str().to_string())),
             );
         }
-        m.insert("partitioned_prefix".to_string(), Value::Map(inner));
+        m.insert(
+            "partitioned_prefix".to_string(),
+            Value::Concrete(ConcreteValue::Map(inner)),
+        );
     }
-    Value::Map(m)
+    Value::Concrete(ConcreteValue::Map(m))
 }

--- a/carina-provider-aws/src/services/s3/bucket_notification.rs
+++ b/carina-provider-aws/src/services/s3/bucket_notification.rs
@@ -6,7 +6,7 @@ use aws_sdk_s3::types::{
     TopicConfiguration,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -33,7 +33,10 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
 
                 let topics: Vec<Value> = output
                     .topic_configurations()
@@ -41,7 +44,10 @@ impl AwsProvider {
                     .map(topic_to_value)
                     .collect();
                 if !topics.is_empty() {
-                    attributes.insert("topic_configurations".to_string(), Value::List(topics));
+                    attributes.insert(
+                        "topic_configurations".to_string(),
+                        Value::Concrete(ConcreteValue::List(topics)),
+                    );
                 }
                 let queues: Vec<Value> = output
                     .queue_configurations()
@@ -49,7 +55,10 @@ impl AwsProvider {
                     .map(queue_to_value)
                     .collect();
                 if !queues.is_empty() {
-                    attributes.insert("queue_configurations".to_string(), Value::List(queues));
+                    attributes.insert(
+                        "queue_configurations".to_string(),
+                        Value::Concrete(ConcreteValue::List(queues)),
+                    );
                 }
                 let lambdas: Vec<Value> = output
                     .lambda_function_configurations()
@@ -59,13 +68,13 @@ impl AwsProvider {
                 if !lambdas.is_empty() {
                     attributes.insert(
                         "lambda_function_configurations".to_string(),
-                        Value::List(lambdas),
+                        Value::Concrete(ConcreteValue::List(lambdas)),
                     );
                 }
                 if output.event_bridge_configuration().is_some() {
                     attributes.insert(
                         "event_bridge_configuration".to_string(),
-                        Value::Map(IndexMap::new()),
+                        Value::Concrete(ConcreteValue::Map(IndexMap::new())),
                     );
                 }
 
@@ -110,21 +119,21 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let topics = match resource.get_attr("topic_configurations") {
-            Some(Value::List(items)) => items
+            Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
                 .map(|v| build_topic(id, v))
                 .collect::<ProviderResult<Vec<_>>>()?,
             _ => Vec::new(),
         };
         let queues = match resource.get_attr("queue_configurations") {
-            Some(Value::List(items)) => items
+            Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
                 .map(|v| build_queue(id, v))
                 .collect::<ProviderResult<Vec<_>>>()?,
             _ => Vec::new(),
         };
         let lambdas = match resource.get_attr("lambda_function_configurations") {
-            Some(Value::List(items)) => items
+            Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
                 .map(|v| build_lambda(id, v))
                 .collect::<ProviderResult<Vec<_>>>()?,
@@ -200,7 +209,7 @@ impl AwsProvider {
 }
 
 fn build_topic(id: &ResourceId, value: &Value) -> ProviderResult<TopicConfiguration> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("topic_configurations entry must be a map")
                 .for_resource(id.clone()),
@@ -212,7 +221,7 @@ fn build_topic(id: &ResourceId, value: &Value) -> ProviderResult<TopicConfigurat
     let mut builder = TopicConfiguration::builder()
         .topic_arn(topic_arn)
         .set_events(Some(events));
-    if let Some(Value::String(s)) = map.get("id") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("id") {
         builder = builder.id(s);
     }
     if let Some(filter) = build_filter(id, map, "topic_configurations")? {
@@ -225,7 +234,7 @@ fn build_topic(id: &ResourceId, value: &Value) -> ProviderResult<TopicConfigurat
 }
 
 fn build_queue(id: &ResourceId, value: &Value) -> ProviderResult<QueueConfiguration> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("queue_configurations entry must be a map")
                 .for_resource(id.clone()),
@@ -237,7 +246,7 @@ fn build_queue(id: &ResourceId, value: &Value) -> ProviderResult<QueueConfigurat
     let mut builder = QueueConfiguration::builder()
         .queue_arn(queue_arn)
         .set_events(Some(events));
-    if let Some(Value::String(s)) = map.get("id") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("id") {
         builder = builder.id(s);
     }
     if let Some(filter) = build_filter(id, map, "queue_configurations")? {
@@ -250,7 +259,7 @@ fn build_queue(id: &ResourceId, value: &Value) -> ProviderResult<QueueConfigurat
 }
 
 fn build_lambda(id: &ResourceId, value: &Value) -> ProviderResult<LambdaFunctionConfiguration> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(ProviderError::invalid_input(
             "lambda_function_configurations entry must be a map",
         )
@@ -267,7 +276,7 @@ fn build_lambda(id: &ResourceId, value: &Value) -> ProviderResult<LambdaFunction
     let mut builder = LambdaFunctionConfiguration::builder()
         .lambda_function_arn(lambda_arn)
         .set_events(Some(events));
-    if let Some(Value::String(s)) = map.get("id") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("id") {
         builder = builder.id(s);
     }
     if let Some(filter) = build_filter(id, map, "lambda_function_configurations")? {
@@ -289,7 +298,7 @@ fn require_string_field(
     parent: &str,
 ) -> ProviderResult<String> {
     match map.get(field) {
-        Some(Value::String(s)) => Ok(s.clone()),
+        Some(Value::Concrete(ConcreteValue::String(s))) => Ok(s.clone()),
         _ => Err(
             ProviderError::invalid_input(format!("{parent}.{field} is required"))
                 .for_resource(id.clone()),
@@ -303,10 +312,10 @@ fn build_events(
     parent: &str,
 ) -> ProviderResult<Vec<Event>> {
     match map.get("events") {
-        Some(Value::List(items)) => items
+        Some(Value::Concrete(ConcreteValue::List(items))) => items
             .iter()
             .map(|v| match v {
-                Value::String(s) => Ok(Event::from(s.as_str())),
+                Value::Concrete(ConcreteValue::String(s)) => Ok(Event::from(s.as_str())),
                 _ => Err(ProviderError::invalid_input(format!(
                     "{parent}.events must be a list of strings"
                 ))
@@ -325,17 +334,17 @@ fn build_filter(
     map: &IndexMap<String, Value>,
     parent: &str,
 ) -> ProviderResult<Option<NotificationConfigurationFilter>> {
-    let Some(Value::Map(filter_map)) = map.get("filter") else {
+    let Some(Value::Concrete(ConcreteValue::Map(filter_map))) = map.get("filter") else {
         return Ok(None);
     };
-    let Some(Value::List(rules)) = filter_map.get("filter_rules") else {
+    let Some(Value::Concrete(ConcreteValue::List(rules))) = filter_map.get("filter_rules") else {
         return Ok(Some(NotificationConfigurationFilter::builder().build()));
     };
 
     let sdk_rules: Vec<FilterRule> = rules
         .iter()
         .map(|v| {
-            let Value::Map(rule_map) = v else {
+            let Value::Concrete(ConcreteValue::Map(rule_map)) = v else {
                 return Err(ProviderError::invalid_input(format!(
                     "{parent}.filter.filter_rules entry must be a map"
                 ))
@@ -361,58 +370,67 @@ fn build_filter(
 fn topic_to_value(t: &TopicConfiguration) -> Value {
     let mut m = IndexMap::new();
     if let Some(s) = t.id() {
-        m.insert("id".to_string(), Value::String(s.to_string()));
+        m.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String(s.to_string())),
+        );
     }
     m.insert(
         "topic_arn".to_string(),
-        Value::String(t.topic_arn().to_string()),
+        Value::Concrete(ConcreteValue::String(t.topic_arn().to_string())),
     );
     m.insert("events".to_string(), events_to_value(t.events()));
     if let Some(f) = t.filter() {
         m.insert("filter".to_string(), filter_to_value(f));
     }
-    Value::Map(m)
+    Value::Concrete(ConcreteValue::Map(m))
 }
 
 fn queue_to_value(q: &QueueConfiguration) -> Value {
     let mut m = IndexMap::new();
     if let Some(s) = q.id() {
-        m.insert("id".to_string(), Value::String(s.to_string()));
+        m.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String(s.to_string())),
+        );
     }
     m.insert(
         "queue_arn".to_string(),
-        Value::String(q.queue_arn().to_string()),
+        Value::Concrete(ConcreteValue::String(q.queue_arn().to_string())),
     );
     m.insert("events".to_string(), events_to_value(q.events()));
     if let Some(f) = q.filter() {
         m.insert("filter".to_string(), filter_to_value(f));
     }
-    Value::Map(m)
+    Value::Concrete(ConcreteValue::Map(m))
 }
 
 fn lambda_to_value(l: &LambdaFunctionConfiguration) -> Value {
     let mut m = IndexMap::new();
     if let Some(s) = l.id() {
-        m.insert("id".to_string(), Value::String(s.to_string()));
+        m.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String(s.to_string())),
+        );
     }
     m.insert(
         "lambda_function_arn".to_string(),
-        Value::String(l.lambda_function_arn().to_string()),
+        Value::Concrete(ConcreteValue::String(l.lambda_function_arn().to_string())),
     );
     m.insert("events".to_string(), events_to_value(l.events()));
     if let Some(f) = l.filter() {
         m.insert("filter".to_string(), filter_to_value(f));
     }
-    Value::Map(m)
+    Value::Concrete(ConcreteValue::Map(m))
 }
 
 fn events_to_value(events: &[Event]) -> Value {
-    Value::List(
+    Value::Concrete(ConcreteValue::List(
         events
             .iter()
             .map(|e| Value::String(e.as_str().to_string()))
             .collect(),
-    )
+    ))
 }
 
 fn filter_to_value(f: &NotificationConfigurationFilter) -> Value {
@@ -424,15 +442,24 @@ fn filter_to_value(f: &NotificationConfigurationFilter) -> Value {
             .map(|r| {
                 let mut m = IndexMap::new();
                 if let Some(n) = r.name() {
-                    m.insert("name".to_string(), Value::String(n.as_str().to_string()));
+                    m.insert(
+                        "name".to_string(),
+                        Value::Concrete(ConcreteValue::String(n.as_str().to_string())),
+                    );
                 }
                 if let Some(v) = r.value() {
-                    m.insert("value".to_string(), Value::String(v.to_string()));
+                    m.insert(
+                        "value".to_string(),
+                        Value::Concrete(ConcreteValue::String(v.to_string())),
+                    );
                 }
-                Value::Map(m)
+                Value::Concrete(ConcreteValue::Map(m))
             })
             .collect();
-        outer.insert("filter_rules".to_string(), Value::List(rules));
+        outer.insert(
+            "filter_rules".to_string(),
+            Value::Concrete(ConcreteValue::List(rules)),
+        );
     }
-    Value::Map(outer)
+    Value::Concrete(ConcreteValue::Map(outer))
 }

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::{ObjectOwnership, OwnershipControls, OwnershipControlsRule};
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -29,13 +29,18 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 if let Some(controls) = output.ownership_controls()
                     && let Some(rule) = controls.rules().first()
                 {
                     attributes.insert(
                         "object_ownership".to_string(),
-                        Value::String(rule.object_ownership().as_str().to_string()),
+                        Value::Concrete(ConcreteValue::String(
+                            rule.object_ownership().as_str().to_string(),
+                        )),
                     );
                 }
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
@@ -82,7 +87,7 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let ownership_str = match resource.get_attr("object_ownership") {
-            Some(Value::String(s)) => extract_enum_value(s).to_string(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => extract_enum_value(s).to_string(),
             _ => {
                 return Err(ProviderError::invalid_input("object_ownership is required")
                     .for_resource(id.clone()));

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
@@ -32,7 +32,10 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
 
                 if let Some(policy_json) = output.policy() {
                     let policy_value = iam_policy_json_to_value(policy_json).map_err(|e| {

--- a/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::PublicAccessBlockConfiguration;
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
@@ -33,20 +33,35 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
 
                 if let Some(config) = output.public_access_block_configuration() {
                     if let Some(v) = config.block_public_acls() {
-                        attributes.insert("block_public_acls".to_string(), Value::Bool(v));
+                        attributes.insert(
+                            "block_public_acls".to_string(),
+                            Value::Concrete(ConcreteValue::Bool(v)),
+                        );
                     }
                     if let Some(v) = config.ignore_public_acls() {
-                        attributes.insert("ignore_public_acls".to_string(), Value::Bool(v));
+                        attributes.insert(
+                            "ignore_public_acls".to_string(),
+                            Value::Concrete(ConcreteValue::Bool(v)),
+                        );
                     }
                     if let Some(v) = config.block_public_policy() {
-                        attributes.insert("block_public_policy".to_string(), Value::Bool(v));
+                        attributes.insert(
+                            "block_public_policy".to_string(),
+                            Value::Concrete(ConcreteValue::Bool(v)),
+                        );
                     }
                     if let Some(v) = config.restrict_public_buckets() {
-                        attributes.insert("restrict_public_buckets".to_string(), Value::Bool(v));
+                        attributes.insert(
+                            "restrict_public_buckets".to_string(),
+                            Value::Concrete(ConcreteValue::Bool(v)),
+                        );
                     }
                 }
 
@@ -92,16 +107,24 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let mut builder = PublicAccessBlockConfiguration::builder();
-        if let Some(Value::Bool(v)) = resource.get_attr("block_public_acls") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+            resource.get_attr("block_public_acls")
+        {
             builder = builder.block_public_acls(*v);
         }
-        if let Some(Value::Bool(v)) = resource.get_attr("ignore_public_acls") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+            resource.get_attr("ignore_public_acls")
+        {
             builder = builder.ignore_public_acls(*v);
         }
-        if let Some(Value::Bool(v)) = resource.get_attr("block_public_policy") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+            resource.get_attr("block_public_policy")
+        {
             builder = builder.block_public_policy(*v);
         }
-        if let Some(Value::Bool(v)) = resource.get_attr("restrict_public_buckets") {
+        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+            resource.get_attr("restrict_public_buckets")
+        {
             builder = builder.restrict_public_buckets(*v);
         }
         let config = builder.build();

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -4,7 +4,7 @@ use aws_sdk_s3::types::{
     Destination, ReplicationConfiguration, ReplicationRule, ReplicationRuleStatus, StorageClass,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 use indexmap::IndexMap;
 
@@ -32,12 +32,21 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 if let Some(config) = output.replication_configuration() {
-                    attributes.insert("role".to_string(), Value::String(config.role().to_string()));
+                    attributes.insert(
+                        "role".to_string(),
+                        Value::Concrete(ConcreteValue::String(config.role().to_string())),
+                    );
                     let rules: Vec<Value> = config.rules().iter().map(rule_to_value).collect();
                     if !rules.is_empty() {
-                        attributes.insert("rules".to_string(), Value::List(rules));
+                        attributes.insert(
+                            "rules".to_string(),
+                            Value::Concrete(ConcreteValue::List(rules)),
+                        );
                     }
                 }
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
@@ -84,7 +93,7 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let role = require_string_attr(resource, "role")?;
         let rules = match resource.get_attr("rules") {
-            Some(Value::List(items)) => items,
+            Some(Value::Concrete(ConcreteValue::List(items))) => items,
             _ => {
                 return Err(
                     ProviderError::invalid_input("rules is required and must be a list")
@@ -155,14 +164,14 @@ impl AwsProvider {
 }
 
 fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ReplicationRule> {
-    let Value::Map(map) = rule_value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = rule_value else {
         return Err(
             ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
         );
     };
 
     let status_str = match map.get("status") {
-        Some(Value::String(s)) => extract_enum_value(s).to_string(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => extract_enum_value(s).to_string(),
         _ => {
             return Err(
                 ProviderError::invalid_input("rule.status is required").for_resource(id.clone())
@@ -181,13 +190,13 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<Replication
         .status(ReplicationRuleStatus::from(status_str.as_str()))
         .destination(destination);
 
-    if let Some(Value::String(s)) = map.get("id") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("id") {
         builder = builder.id(s);
     }
-    if let Some(Value::Int(n)) = map.get("priority") {
+    if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("priority") {
         builder = builder.priority(*n as i32);
     }
-    if let Some(Value::String(s)) = map.get("prefix") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("prefix") {
         #[allow(deprecated)]
         {
             builder = builder.prefix(s);
@@ -201,13 +210,13 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<Replication
 }
 
 fn build_destination(id: &ResourceId, value: &Value) -> ProviderResult<Destination> {
-    let Value::Map(map) = value else {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("destination must be a map").for_resource(id.clone())
         );
     };
     let bucket = match map.get("bucket") {
-        Some(Value::String(s)) => s.clone(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
         _ => {
             return Err(
                 ProviderError::invalid_input("destination.bucket is required")
@@ -216,10 +225,10 @@ fn build_destination(id: &ResourceId, value: &Value) -> ProviderResult<Destinati
         }
     };
     let mut builder = Destination::builder().bucket(bucket);
-    if let Some(Value::String(s)) = map.get("account") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("account") {
         builder = builder.account(s);
     }
-    if let Some(Value::String(s)) = map.get("storage_class") {
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("storage_class") {
         let normalized = extract_enum_value(s);
         builder = builder.storage_class(StorageClass::from(normalized));
     }
@@ -234,37 +243,52 @@ fn rule_to_value(rule: &ReplicationRule) -> Value {
     if let Some(s) = rule.id()
         && !s.is_empty()
     {
-        map.insert("id".to_string(), Value::String(s.to_string()));
+        map.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String(s.to_string())),
+        );
     }
     if let Some(p) = rule.priority() {
-        map.insert("priority".to_string(), Value::Int(p as i64));
+        map.insert(
+            "priority".to_string(),
+            Value::Concrete(ConcreteValue::Int(p as i64)),
+        );
     }
     #[allow(deprecated)]
     if let Some(s) = rule.prefix()
         && !s.is_empty()
     {
-        map.insert("prefix".to_string(), Value::String(s.to_string()));
+        map.insert(
+            "prefix".to_string(),
+            Value::Concrete(ConcreteValue::String(s.to_string())),
+        );
     }
     map.insert(
         "status".to_string(),
-        Value::String(rule.status().as_str().to_string()),
+        Value::Concrete(ConcreteValue::String(rule.status().as_str().to_string())),
     );
     if let Some(dest) = rule.destination() {
         let mut d = IndexMap::new();
         d.insert(
             "bucket".to_string(),
-            Value::String(dest.bucket().to_string()),
+            Value::Concrete(ConcreteValue::String(dest.bucket().to_string())),
         );
         if let Some(a) = dest.account() {
-            d.insert("account".to_string(), Value::String(a.to_string()));
+            d.insert(
+                "account".to_string(),
+                Value::Concrete(ConcreteValue::String(a.to_string())),
+            );
         }
         if let Some(sc) = dest.storage_class() {
             d.insert(
                 "storage_class".to_string(),
-                Value::String(sc.as_str().to_string()),
+                Value::Concrete(ConcreteValue::String(sc.as_str().to_string())),
             );
         }
-        map.insert("destination".to_string(), Value::Map(d));
+        map.insert(
+            "destination".to_string(),
+            Value::Concrete(ConcreteValue::Map(d)),
+        );
     }
-    Value::Map(map)
+    Value::Concrete(ConcreteValue::Map(map))
 }

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::{BucketVersioningStatus, MfaDelete, VersioningConfiguration};
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
@@ -37,15 +37,18 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 };
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 attributes.insert(
                     "status".to_string(),
-                    Value::String(status.as_str().to_string()),
+                    Value::Concrete(ConcreteValue::String(status.as_str().to_string())),
                 );
                 if let Some(mfa) = output.mfa_delete() {
                     attributes.insert(
                         "mfa_delete".to_string(),
-                        Value::String(mfa.as_str().to_string()),
+                        Value::Concrete(ConcreteValue::String(mfa.as_str().to_string())),
                     );
                 }
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
@@ -89,7 +92,7 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let status_str = match resource.get_attr("status") {
-            Some(Value::String(s)) => extract_enum_value(s).to_string(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => extract_enum_value(s).to_string(),
             _ => {
                 return Err(
                     ProviderError::invalid_input("status is required").for_resource(id.clone())
@@ -99,7 +102,7 @@ impl AwsProvider {
         let status = BucketVersioningStatus::from(status_str.as_str());
 
         let mut config_builder = VersioningConfiguration::builder().status(status);
-        if let Some(Value::String(s)) = resource.get_attr("mfa_delete") {
+        if let Some(Value::Concrete(ConcreteValue::String(s))) = resource.get_attr("mfa_delete") {
             let mfa_str = extract_enum_value(s);
             config_builder = config_builder.mfa_delete(MfaDelete::from(mfa_str));
         }

--- a/carina-provider-aws/src/services/s3/bucket_website.rs
+++ b/carina-provider-aws/src/services/s3/bucket_website.rs
@@ -4,7 +4,7 @@ use aws_sdk_s3::types::{
     ErrorDocument, IndexDocument, Protocol, RedirectAllRequestsTo, WebsiteConfiguration,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::extract_enum_value;
 use indexmap::IndexMap;
 
@@ -32,33 +32,48 @@ impl AwsProvider {
         match result {
             Ok(output) => {
                 let mut attributes = HashMap::new();
-                attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+                attributes.insert(
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String(bucket.to_string())),
+                );
                 if let Some(idx) = output.index_document() {
                     let mut m = IndexMap::new();
                     m.insert(
                         "suffix".to_string(),
-                        Value::String(idx.suffix().to_string()),
+                        Value::Concrete(ConcreteValue::String(idx.suffix().to_string())),
                     );
-                    attributes.insert("index_document".to_string(), Value::Map(m));
+                    attributes.insert(
+                        "index_document".to_string(),
+                        Value::Concrete(ConcreteValue::Map(m)),
+                    );
                 }
                 if let Some(err) = output.error_document() {
                     let mut m = IndexMap::new();
-                    m.insert("key".to_string(), Value::String(err.key().to_string()));
-                    attributes.insert("error_document".to_string(), Value::Map(m));
+                    m.insert(
+                        "key".to_string(),
+                        Value::Concrete(ConcreteValue::String(err.key().to_string())),
+                    );
+                    attributes.insert(
+                        "error_document".to_string(),
+                        Value::Concrete(ConcreteValue::Map(m)),
+                    );
                 }
                 if let Some(r) = output.redirect_all_requests_to() {
                     let mut m = IndexMap::new();
                     m.insert(
                         "host_name".to_string(),
-                        Value::String(r.host_name().to_string()),
+                        Value::Concrete(ConcreteValue::String(r.host_name().to_string())),
                     );
                     if let Some(p) = r.protocol() {
                         m.insert(
                             "protocol".to_string(),
-                            Value::String(p.as_str().to_string()),
+                            Value::Concrete(ConcreteValue::String(p.as_str().to_string())),
                         );
                     }
-                    attributes.insert("redirect_all_requests_to".to_string(), Value::Map(m));
+                    attributes.insert(
+                        "redirect_all_requests_to".to_string(),
+                        Value::Concrete(ConcreteValue::Map(m)),
+                    );
                 }
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
             }
@@ -104,9 +119,10 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let mut config_builder = WebsiteConfiguration::builder();
 
-        if let Some(Value::Map(map)) = resource.get_attr("index_document") {
+        if let Some(Value::Concrete(ConcreteValue::Map(map))) = resource.get_attr("index_document")
+        {
             let suffix = match map.get("suffix") {
-                Some(Value::String(s)) => s.clone(),
+                Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
                 _ => {
                     return Err(
                         ProviderError::invalid_input("index_document.suffix is required")
@@ -127,9 +143,10 @@ impl AwsProvider {
                     })?,
             );
         }
-        if let Some(Value::Map(map)) = resource.get_attr("error_document") {
+        if let Some(Value::Concrete(ConcreteValue::Map(map))) = resource.get_attr("error_document")
+        {
             let key = match map.get("key") {
-                Some(Value::String(s)) => s.clone(),
+                Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
                 _ => {
                     return Err(
                         ProviderError::invalid_input("error_document.key is required")
@@ -144,9 +161,11 @@ impl AwsProvider {
                 })?,
             );
         }
-        if let Some(Value::Map(map)) = resource.get_attr("redirect_all_requests_to") {
+        if let Some(Value::Concrete(ConcreteValue::Map(map))) =
+            resource.get_attr("redirect_all_requests_to")
+        {
             let host_name = match map.get("host_name") {
-                Some(Value::String(s)) => s.clone(),
+                Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
                 _ => {
                     return Err(ProviderError::invalid_input(
                         "redirect_all_requests_to.host_name is required",
@@ -155,7 +174,7 @@ impl AwsProvider {
                 }
             };
             let mut rb = RedirectAllRequestsTo::builder().host_name(host_name);
-            if let Some(Value::String(p)) = map.get("protocol") {
+            if let Some(Value::Concrete(ConcreteValue::String(p))) = map.get("protocol") {
                 let normalized = extract_enum_value(p);
                 rb = rb.protocol(Protocol::from(normalized));
             }

--- a/carina-provider-aws/src/services/sts/account_guard.rs
+++ b/carina-provider-aws/src/services/sts/account_guard.rs
@@ -6,7 +6,7 @@
 //! initialization (before any read/plan/apply mutation) and fails fast
 //! when the credentials in use point at the wrong AWS account.
 
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 
 use crate::AwsProvider;
 use crate::helpers::sdk_error_message;
@@ -48,10 +48,10 @@ pub fn check_account_id(
 /// treats as "list not configured".
 pub fn extract_string_list(value: Option<&Value>) -> Vec<String> {
     match value {
-        Some(Value::List(items)) => items
+        Some(Value::Concrete(ConcreteValue::List(items))) => items
             .iter()
             .filter_map(|v| match v {
-                Value::String(s) => Some(s.clone()),
+                Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                 _ => None,
             })
             .collect(),
@@ -174,15 +174,18 @@ mod tests {
 
     #[test]
     fn extract_string_list_handles_non_list() {
-        assert!(extract_string_list(Some(&Value::String("oops".into()))).is_empty());
+        assert!(
+            extract_string_list(Some(&Value::Concrete(ConcreteValue::String("oops".into()))))
+                .is_empty()
+        );
     }
 
     #[test]
     fn extract_string_list_extracts_strings_in_order() {
-        let v = Value::List(vec![
+        let v = Value::Concrete(ConcreteValue::List(vec![
             Value::String("aaa".into()),
             Value::String("bbb".into()),
-        ]);
+        ]));
         assert_eq!(
             extract_string_list(Some(&v)),
             vec!["aaa".to_string(), "bbb".to_string()]
@@ -193,11 +196,11 @@ mod tests {
     fn extract_string_list_drops_non_string_entries() {
         // Type validation happens host-side via
         // `provider_config_attribute_types`; this is just the safety net.
-        let v = Value::List(vec![
+        let v = Value::Concrete(ConcreteValue::List(vec![
             Value::String("aaa".into()),
             Value::Int(42),
             Value::String("bbb".into()),
-        ]);
+        ]));
         assert_eq!(
             extract_string_list(Some(&v)),
             vec!["aaa".to_string(), "bbb".to_string()]

--- a/carina-provider-aws/src/services/sts/caller_identity.rs
+++ b/carina-provider-aws/src/services/sts/caller_identity.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
-use carina_core::resource::{Resource, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::sdk_error_message;
@@ -33,13 +33,22 @@ impl AwsProvider {
 
             let mut attributes = HashMap::new();
             if let Some(account) = response.account() {
-                attributes.insert("account_id".to_string(), Value::String(account.to_string()));
+                attributes.insert(
+                    "account_id".to_string(),
+                    Value::Concrete(ConcreteValue::String(account.to_string())),
+                );
             }
             if let Some(arn) = response.arn() {
-                attributes.insert("arn".to_string(), Value::String(arn.to_string()));
+                attributes.insert(
+                    "arn".to_string(),
+                    Value::Concrete(ConcreteValue::String(arn.to_string())),
+                );
             }
             if let Some(user_id) = response.user_id() {
-                attributes.insert("user_id".to_string(), Value::String(user_id.to_string()));
+                attributes.insert(
+                    "user_id".to_string(),
+                    Value::Concrete(ConcreteValue::String(user_id.to_string())),
+                );
             }
 
             Ok(State::existing(id, attributes))

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use indexmap::IndexMap;
 
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::AttributeType;
 
 use crate::AwsProvider;
@@ -23,15 +23,21 @@ fn test_extract_ec2_vpc_attributes() {
     assert_eq!(identifier, Some("vpc-12345678".to_string()));
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("instance_tenancy"),
-        Some(&Value::String("default".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "default".to_string()
+        )))
     );
 }
 
@@ -60,23 +66,31 @@ fn test_extract_ec2_subnet_attributes() {
     assert_eq!(identifier, Some("subnet-12345678".to_string()));
     assert_eq!(
         attributes.get("subnet_id"),
-        Some(&Value::String("subnet-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "subnet-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("cidr_block"),
-        Some(&Value::String("10.0.1.0/24".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.1.0/24".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("availability_zone"),
-        Some(&Value::String("ap-northeast-1a".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1a".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("map_public_ip_on_launch"),
-        Some(&Value::Bool(false))
+        Some(&Value::Concrete(ConcreteValue::Bool(false)))
     );
 }
 
@@ -114,18 +128,20 @@ fn test_extract_ec2_subnet_attributes_with_private_dns_name_options() {
         .get("private_dns_name_options_on_launch")
         .expect("private_dns_name_options_on_launch should be present");
 
-    if let Value::Map(fields) = dns_value {
+    if let Value::Concrete(ConcreteValue::Map(fields)) = dns_value {
         assert_eq!(
             fields.get("hostname_type"),
-            Some(&Value::String("ip-name".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "ip-name".to_string()
+            )))
         );
         assert_eq!(
             fields.get("enable_resource_name_dns_a_record"),
-            Some(&Value::Bool(true))
+            Some(&Value::Concrete(ConcreteValue::Bool(true)))
         );
         assert_eq!(
             fields.get("enable_resource_name_dns_aaaa_record"),
-            Some(&Value::Bool(false))
+            Some(&Value::Concrete(ConcreteValue::Bool(false)))
         );
     } else {
         panic!(
@@ -147,7 +163,9 @@ fn test_extract_ec2_internet_gateway_attributes() {
     assert_eq!(identifier, Some("igw-12345678".to_string()));
     assert_eq!(
         attributes.get("internet_gateway_id"),
-        Some(&Value::String("igw-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "igw-12345678".to_string()
+        )))
     );
 }
 
@@ -173,11 +191,15 @@ fn test_extract_ec2_route_table_attributes() {
     assert_eq!(identifier, Some("rtb-12345678".to_string()));
     assert_eq!(
         attributes.get("route_table_id"),
-        Some(&Value::String("rtb-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "rtb-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
 }
 
@@ -203,11 +225,15 @@ fn test_extract_ec2_route_attributes() {
     assert_eq!(identifier, None);
     assert_eq!(
         attributes.get("destination_cidr_block"),
-        Some(&Value::String("0.0.0.0/0".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "0.0.0.0/0".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("gateway_id"),
-        Some(&Value::String("igw-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "igw-12345678".to_string()
+        )))
     );
 }
 
@@ -221,11 +247,15 @@ fn test_extract_ec2_route_attributes_with_nat_gateway() {
     AwsProvider::extract_ec2_route_attributes(&route, &mut attributes);
     assert_eq!(
         attributes.get("destination_cidr_block"),
-        Some(&Value::String("10.0.0.0/8".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/8".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("nat_gateway_id"),
-        Some(&Value::String("nat-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "nat-12345678".to_string()
+        )))
     );
 }
 
@@ -240,7 +270,9 @@ fn test_extract_ec2_route_attributes_ignores_unsupported() {
     AwsProvider::extract_ec2_route_attributes(&route, &mut attributes);
     assert_eq!(
         attributes.get("destination_cidr_block"),
-        Some(&Value::String("172.16.0.0/12".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "172.16.0.0/12".to_string()
+        )))
     );
     assert_eq!(attributes.get("transit_gateway_id"), None);
 }
@@ -260,19 +292,27 @@ fn test_extract_ec2_security_group_attributes() {
     assert_eq!(identifier, Some("sg-12345678".to_string()));
     assert_eq!(
         attributes.get("group_id"),
-        Some(&Value::String("sg-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "sg-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("group_name"),
-        Some(&Value::String("test-sg".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "test-sg".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("description"),
-        Some(&Value::String("Test security group".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "Test security group".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
 }
 
@@ -302,21 +342,31 @@ fn test_extract_ec2_security_group_ingress_attributes() {
     assert_eq!(identifier, Some("sgr-12345678".to_string()));
     assert_eq!(
         attributes.get("security_group_rule_id"),
-        Some(&Value::String("sgr-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "sgr-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("group_id"),
-        Some(&Value::String("sg-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "sg-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("ip_protocol"),
-        Some(&Value::String("tcp".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("tcp".to_string())))
     );
-    assert_eq!(attributes.get("from_port"), Some(&Value::Int(443)));
-    assert_eq!(attributes.get("to_port"), Some(&Value::Int(443)));
+    assert_eq!(
+        attributes.get("from_port"),
+        Some(&Value::Concrete(ConcreteValue::Int(443)))
+    );
+    assert_eq!(
+        attributes.get("to_port"),
+        Some(&Value::Concrete(ConcreteValue::Int(443)))
+    );
     assert_eq!(
         attributes.get("description"),
-        Some(&Value::String("HTTPS".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("HTTPS".to_string())))
     );
 }
 
@@ -334,7 +384,9 @@ fn test_extract_ec2_security_group_ingress_attributes_with_prefix_list() {
     AwsProvider::extract_ec2_security_group_ingress_attributes(&rule, &mut attributes);
     assert_eq!(
         attributes.get("source_prefix_list_id"),
-        Some(&Value::String("pl-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "pl-12345678".to_string()
+        )))
     );
 }
 
@@ -355,14 +407,22 @@ fn test_extract_ec2_security_group_egress_attributes() {
     assert_eq!(identifier, Some("sgr-87654321".to_string()));
     assert_eq!(
         attributes.get("group_id"),
-        Some(&Value::String("sg-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "sg-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("ip_protocol"),
-        Some(&Value::String("-1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("-1".to_string())))
     );
-    assert_eq!(attributes.get("from_port"), Some(&Value::Int(0)));
-    assert_eq!(attributes.get("to_port"), Some(&Value::Int(0)));
+    assert_eq!(
+        attributes.get("from_port"),
+        Some(&Value::Concrete(ConcreteValue::Int(0)))
+    );
+    assert_eq!(
+        attributes.get("to_port"),
+        Some(&Value::Concrete(ConcreteValue::Int(0)))
+    );
 }
 
 #[test]
@@ -379,7 +439,9 @@ fn test_extract_ec2_security_group_egress_attributes_with_prefix_list() {
     AwsProvider::extract_ec2_security_group_egress_attributes(&rule, &mut attributes);
     assert_eq!(
         attributes.get("destination_prefix_list_id"),
-        Some(&Value::String("pl-87654321".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "pl-87654321".to_string()
+        )))
     );
 }
 
@@ -397,7 +459,7 @@ fn test_extract_ec2_security_group_egress_attributes_with_ipv6() {
     AwsProvider::extract_ec2_security_group_egress_attributes(&rule, &mut attributes);
     assert_eq!(
         attributes.get("cidr_ipv6"),
-        Some(&Value::String("::/0".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("::/0".to_string())))
     );
 }
 
@@ -427,35 +489,47 @@ fn test_route_table_routes_extraction() {
     for route in rt.routes() {
         let mut route_map = IndexMap::new();
         if let Some(dest) = route.destination_cidr_block() {
-            route_map.insert("destination".to_string(), Value::String(dest.to_string()));
+            route_map.insert(
+                "destination".to_string(),
+                Value::Concrete(ConcreteValue::String(dest.to_string())),
+            );
         }
         if let Some(gw) = route.gateway_id() {
-            route_map.insert("gateway_id".to_string(), Value::String(gw.to_string()));
+            route_map.insert(
+                "gateway_id".to_string(),
+                Value::Concrete(ConcreteValue::String(gw.to_string())),
+            );
         }
         if !route_map.is_empty() {
-            routes_list.push(Value::Map(route_map));
+            routes_list.push(Value::Concrete(ConcreteValue::Map(route_map)));
         }
     }
 
     assert_eq!(routes_list.len(), 2);
-    if let Value::Map(ref map) = routes_list[0] {
+    if let Value::Concrete(ConcreteValue::Map(ref map)) = routes_list[0] {
         assert_eq!(
             map.get("destination"),
-            Some(&Value::String("10.0.0.0/16".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "10.0.0.0/16".to_string()
+            )))
         );
         assert_eq!(
             map.get("gateway_id"),
-            Some(&Value::String("local".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("local".to_string())))
         );
     }
-    if let Value::Map(ref map) = routes_list[1] {
+    if let Value::Concrete(ConcreteValue::Map(ref map)) = routes_list[1] {
         assert_eq!(
             map.get("destination"),
-            Some(&Value::String("0.0.0.0/0".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "0.0.0.0/0".to_string()
+            )))
         );
         assert_eq!(
             map.get("gateway_id"),
-            Some(&Value::String("igw-12345678".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "igw-12345678".to_string()
+            )))
         );
     }
 }
@@ -487,12 +561,17 @@ fn test_internet_gateway_attachment_extraction() {
     if let Some(att) = igw.attachments().first()
         && let Some(vpc_id) = att.vpc_id()
     {
-        attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
+        attributes.insert(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String(vpc_id.to_string())),
+        );
     }
 
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
 }
 
@@ -506,7 +585,10 @@ fn test_internet_gateway_no_attachment() {
     if let Some(att) = igw.attachments().first()
         && let Some(vpc_id) = att.vpc_id()
     {
-        attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
+        attributes.insert(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String(vpc_id.to_string())),
+        );
     }
 
     assert!(!attributes.contains_key("vpc_id"));
@@ -528,7 +610,7 @@ fn test_extract_ec2_subnet_attributes_map_public_ip_true() {
     assert_eq!(identifier, Some("subnet-12345678".to_string()));
     assert_eq!(
         attributes.get("map_public_ip_on_launch"),
-        Some(&Value::Bool(true))
+        Some(&Value::Concrete(ConcreteValue::Bool(true)))
     );
 }
 
@@ -602,32 +684,38 @@ fn test_subnet_dns_options_fields_parsed_separately() {
     let mut fields = HashMap::new();
     fields.insert(
         "hostname_type".to_string(),
-        Value::String("aws.ec2.Subnet.HostnameType.ip_name".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "aws.ec2.Subnet.HostnameType.ip_name".to_string(),
+        )),
     );
     fields.insert(
         "enable_resource_name_dns_a_record".to_string(),
-        Value::Bool(true),
+        Value::Concrete(ConcreteValue::Bool(true)),
     );
     fields.insert(
         "enable_resource_name_dns_aaaa_record".to_string(),
-        Value::Bool(false),
+        Value::Concrete(ConcreteValue::Bool(false)),
     );
 
     // Each field should be independently extractable for separate API calls
-    if let Some(Value::String(ht)) = fields.get("hostname_type") {
+    if let Some(Value::Concrete(ConcreteValue::String(ht))) = fields.get("hostname_type") {
         let hostname_val = convert_enum_value(ht);
         assert_eq!(hostname_val, "ip_name");
     } else {
         panic!("hostname_type should be present and a String");
     }
 
-    if let Some(Value::Bool(v)) = fields.get("enable_resource_name_dns_a_record") {
+    if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+        fields.get("enable_resource_name_dns_a_record")
+    {
         assert!(*v);
     } else {
         panic!("enable_resource_name_dns_a_record should be present and a Bool");
     }
 
-    if let Some(Value::Bool(v)) = fields.get("enable_resource_name_dns_aaaa_record") {
+    if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
+        fields.get("enable_resource_name_dns_aaaa_record")
+    {
         assert!(!(*v));
     } else {
         panic!("enable_resource_name_dns_aaaa_record should be present and a Bool");
@@ -648,15 +736,19 @@ fn test_extract_ec2_eip_attributes() {
     assert_eq!(identifier, Some("eipalloc-12345678".to_string()));
     assert_eq!(
         attributes.get("allocation_id"),
-        Some(&Value::String("eipalloc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "eipalloc-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("domain"),
-        Some(&Value::String("vpc".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("vpc".to_string())))
     );
     assert_eq!(
         attributes.get("public_ip"),
-        Some(&Value::String("203.0.113.1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "203.0.113.1".to_string()
+        )))
     );
 }
 
@@ -687,19 +779,27 @@ fn test_extract_ec2_nat_gateway_attributes() {
     assert_eq!(identifier, Some("nat-12345678".to_string()));
     assert_eq!(
         attributes.get("nat_gateway_id"),
-        Some(&Value::String("nat-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "nat-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("subnet_id"),
-        Some(&Value::String("subnet-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "subnet-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("connectivity_type"),
-        Some(&Value::String("public".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "public".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("allocation_id"),
-        Some(&Value::String("eipalloc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "eipalloc-12345678".to_string()
+        )))
     );
 }
 
@@ -723,7 +823,9 @@ fn test_extract_ec2_nat_gateway_attributes_private() {
     assert_eq!(identifier, Some("nat-87654321".to_string()));
     assert_eq!(
         attributes.get("connectivity_type"),
-        Some(&Value::String("private".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "private".to_string()
+        )))
     );
     // Private NAT gateways don't have allocation_id
     assert_eq!(attributes.get("allocation_id"), None);
@@ -750,35 +852,43 @@ fn test_extract_ec2_vpc_endpoint_attributes() {
     assert_eq!(identifier, Some("vpce-12345678".to_string()));
     assert_eq!(
         attributes.get("vpc_endpoint_id"),
-        Some(&Value::String("vpce-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpce-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpc_endpoint_type"),
-        Some(&Value::String("Gateway".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "Gateway".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("service_name"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "com.amazonaws.ap-northeast-1.s3".to_string()
-        ))
+        )))
     );
     assert_eq!(
         attributes.get("private_dns_enabled"),
-        Some(&Value::Bool(false))
+        Some(&Value::Concrete(ConcreteValue::Bool(false)))
     );
     assert_eq!(
         attributes.get("route_table_ids"),
-        Some(&Value::List(vec![Value::String(
+        Some(&Value::Concrete(ConcreteValue::List(vec![Value::String(
             "rtb-12345678".to_string()
-        )]))
+        )])))
     );
     assert_eq!(
         attributes.get("security_group_ids"),
-        Some(&Value::List(vec![Value::String("sg-12345678".to_string())]))
+        Some(&Value::Concrete(ConcreteValue::List(vec![Value::String(
+            "sg-12345678".to_string()
+        )])))
     );
 }
 
@@ -809,17 +919,19 @@ fn test_extract_ec2_vpc_endpoint_attributes_interface() {
     assert_eq!(identifier, Some("vpce-99999999".to_string()));
     assert_eq!(
         attributes.get("vpc_endpoint_type"),
-        Some(&Value::String("Interface".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "Interface".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("private_dns_enabled"),
-        Some(&Value::Bool(true))
+        Some(&Value::Concrete(ConcreteValue::Bool(true)))
     );
     assert_eq!(
         attributes.get("subnet_ids"),
-        Some(&Value::List(vec![Value::String(
+        Some(&Value::Concrete(ConcreteValue::List(vec![Value::String(
             "subnet-12345678".to_string()
-        )]))
+        )])))
     );
 }
 
@@ -841,31 +953,37 @@ fn test_extract_ec2_flow_log_attributes() {
     assert_eq!(identifier, Some("fl-12345678".to_string()));
     assert_eq!(
         attributes.get("flow_log_id"),
-        Some(&Value::String("fl-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "fl-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("resource_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("traffic_type"),
-        Some(&Value::String("ALL".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("ALL".to_string())))
     );
     assert_eq!(
         attributes.get("log_destination_type"),
-        Some(&Value::String("s3".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("s3".to_string())))
     );
     assert_eq!(
         attributes.get("log_destination"),
-        Some(&Value::String("arn:aws:s3:::my-bucket".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "arn:aws:s3:::my-bucket".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("max_aggregation_interval"),
-        Some(&Value::Int(600))
+        Some(&Value::Concrete(ConcreteValue::Int(600)))
     );
     assert_eq!(
         attributes.get("resource_type"),
-        Some(&Value::String("VPC".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("VPC".to_string())))
     );
 }
 
@@ -893,17 +1011,21 @@ fn test_extract_ec2_flow_log_attributes_cloudwatch() {
     assert_eq!(identifier, Some("fl-87654321".to_string()));
     assert_eq!(
         attributes.get("log_group_name"),
-        Some(&Value::String("/aws/vpc/flow-logs".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "/aws/vpc/flow-logs".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("deliver_logs_permission_arn"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "arn:aws:iam::123456789012:role/flow-log-role".to_string()
-        ))
+        )))
     );
     assert_eq!(
         attributes.get("resource_type"),
-        Some(&Value::String("Subnet".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "Subnet".to_string()
+        )))
     );
 }
 
@@ -921,13 +1043,20 @@ fn test_extract_ec2_vpn_gateway_attributes() {
     assert_eq!(identifier, Some("vgw-12345678".to_string()));
     assert_eq!(
         attributes.get("vpn_gateway_id"),
-        Some(&Value::String("vgw-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vgw-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("type"),
-        Some(&Value::String("ipsec.1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ipsec.1".to_string()
+        )))
     );
-    assert_eq!(attributes.get("amazon_side_asn"), Some(&Value::Int(64512)));
+    assert_eq!(
+        attributes.get("amazon_side_asn"),
+        Some(&Value::Concrete(ConcreteValue::Int(64512)))
+    );
 }
 
 #[test]
@@ -961,38 +1090,44 @@ fn test_extract_iam_role_attributes() {
     assert_eq!(identifier, Some("test-role".to_string()));
     assert_eq!(
         attributes.get("role_name"),
-        Some(&Value::String("test-role".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "test-role".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("role_id"),
-        Some(&Value::String("AROAEXAMPLE12345".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "AROAEXAMPLE12345".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("arn"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "arn:aws:iam::123456789012:role/test-role".to_string()
-        ))
+        )))
     );
     assert_eq!(
         attributes.get("path"),
-        Some(&Value::String("/".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("/".to_string())))
     );
     assert_eq!(
         attributes.get("description"),
-        Some(&Value::String("Test role".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "Test role".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("max_session_duration"),
-        Some(&Value::Int(7200))
+        Some(&Value::Concrete(ConcreteValue::Int(7200)))
     );
     // Verify that the assume_role_policy_document is converted to a Map with snake_case keys
     let policy_doc = attributes
         .get("assume_role_policy_document")
         .expect("assume_role_policy_document should be present");
-    if let Value::Map(map) = policy_doc {
+    if let Value::Concrete(ConcreteValue::Map(map)) = policy_doc {
         assert!(map.contains_key("version"), "should have 'version' key");
         assert!(map.contains_key("statement"), "should have 'statement' key");
-        if let Some(Value::String(v)) = map.get("version") {
+        if let Some(Value::Concrete(ConcreteValue::String(v))) = map.get("version") {
             assert_eq!(v, "2012-10-17");
         } else {
             panic!("Expected version to be String");
@@ -1047,24 +1182,37 @@ fn test_extract_ec2_transit_gateway_attributes() {
     assert_eq!(identifier, Some("tgw-12345678".to_string()));
     assert_eq!(
         attributes.get("transit_gateway_id"),
-        Some(&Value::String("tgw-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "tgw-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("description"),
-        Some(&Value::String("Test TGW".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "Test TGW".to_string()
+        )))
     );
-    assert_eq!(attributes.get("amazon_side_asn"), Some(&Value::Int(64512)));
+    assert_eq!(
+        attributes.get("amazon_side_asn"),
+        Some(&Value::Concrete(ConcreteValue::Int(64512)))
+    );
     assert_eq!(
         attributes.get("auto_accept_shared_attachments"),
-        Some(&Value::String("enable".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "enable".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("dns_support"),
-        Some(&Value::String("enable".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "enable".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpn_ecmp_support"),
-        Some(&Value::String("enable".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "enable".to_string()
+        )))
     );
 }
 
@@ -1093,22 +1241,28 @@ fn test_extract_ec2_transit_gateway_attachment_attributes() {
     assert_eq!(identifier, Some("tgw-attach-12345678".to_string()));
     assert_eq!(
         attributes.get("transit_gateway_attachment_id"),
-        Some(&Value::String("tgw-attach-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "tgw-attach-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("transit_gateway_id"),
-        Some(&Value::String("tgw-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "tgw-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("subnet_ids"),
-        Some(&Value::List(vec![
+        Some(&Value::Concrete(ConcreteValue::List(vec![
             Value::String("subnet-12345678".to_string()),
             Value::String("subnet-87654321".to_string()),
-        ]))
+        ])))
     );
 }
 
@@ -1144,23 +1298,33 @@ fn test_extract_ec2_vpc_peering_connection_attributes() {
     assert_eq!(identifier, Some("pcx-12345678".to_string()));
     assert_eq!(
         attributes.get("vpc_peering_connection_id"),
-        Some(&Value::String("pcx-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "pcx-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-11111111".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-11111111".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("peer_vpc_id"),
-        Some(&Value::String("vpc-22222222".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-22222222".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("peer_owner_id"),
-        Some(&Value::String("123456789012".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "123456789012".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("peer_region"),
-        Some(&Value::String("ap-northeast-1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1".to_string()
+        )))
     );
 }
 
@@ -1191,11 +1355,15 @@ fn test_extract_ec2_egress_only_internet_gateway_attributes() {
     assert_eq!(identifier, Some("eigw-12345678".to_string()));
     assert_eq!(
         attributes.get("egress_only_internet_gateway_id"),
-        Some(&Value::String("eigw-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "eigw-12345678".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("vpc_id"),
-        Some(&Value::String("vpc-12345678".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345678".to_string()
+        )))
     );
 }
 
@@ -1226,31 +1394,37 @@ fn test_extract_organizations_organization_attributes() {
     assert_eq!(identifier, Some("o-abc123".to_string()));
     assert_eq!(
         attributes.get("id"),
-        Some(&Value::String("o-abc123".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "o-abc123".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("arn"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "arn:aws:organizations::123456789012:organization/o-abc123".to_string()
-        ))
+        )))
     );
     assert_eq!(
         attributes.get("feature_set"),
-        Some(&Value::String("ALL".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("ALL".to_string())))
     );
     assert_eq!(
         attributes.get("master_account_id"),
-        Some(&Value::String("123456789012".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "123456789012".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("master_account_arn"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "arn:aws:organizations::123456789012:account/o-abc123/123456789012".to_string()
-        ))
+        )))
     );
     assert_eq!(
         attributes.get("master_account_email"),
-        Some(&Value::String("admin@example.com".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "admin@example.com".to_string()
+        )))
     );
 }
 
@@ -1266,7 +1440,9 @@ fn test_extract_organizations_organization_attributes_consolidated_billing() {
     assert_eq!(identifier, Some("o-xyz789".to_string()));
     assert_eq!(
         attributes.get("feature_set"),
-        Some(&Value::String("CONSOLIDATED_BILLING".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "CONSOLIDATED_BILLING".to_string()
+        )))
     );
 }
 
@@ -1319,29 +1495,39 @@ fn test_extract_organizations_account_attributes() {
     assert_eq!(identifier, Some("123456789012".to_string()));
     assert_eq!(
         attributes.get("id"),
-        Some(&Value::String("123456789012".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "123456789012".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("arn"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "arn:aws:organizations::111111111111:account/o-abc123/123456789012".to_string()
-        ))
+        )))
     );
     assert_eq!(
         attributes.get("name"),
-        Some(&Value::String("production".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "production".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("email"),
-        Some(&Value::String("prod@example.com".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "prod@example.com".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("status"),
-        Some(&Value::String("ACTIVE".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ACTIVE".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("joined_method"),
-        Some(&Value::String("CREATED".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "CREATED".to_string()
+        )))
     );
     assert!(attributes.contains_key("joined_timestamp"));
 }
@@ -1369,11 +1555,15 @@ fn test_extract_organizations_account_attributes_suspended() {
     assert_eq!(identifier, Some("999999999999".to_string()));
     assert_eq!(
         attributes.get("status"),
-        Some(&Value::String("SUSPENDED".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "SUSPENDED".to_string()
+        )))
     );
     assert_eq!(
         attributes.get("joined_method"),
-        Some(&Value::String("INVITED".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "INVITED".to_string()
+        )))
     );
 }
 
@@ -1445,7 +1635,7 @@ fn test_security_group_ingress_schema_includes_all_variant() {
 /// the snake_case form alongside the canonical form.
 #[test]
 fn test_organization_feature_set_validates_snake_case_alias() {
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
 
     let config =
         crate::schemas::generated::organizations::organization::organizations_organization_config();
@@ -1458,25 +1648,31 @@ fn test_organization_feature_set_validates_snake_case_alias() {
     // Both the API form (`ALL`) and the DSL form (`all`) must validate.
     feature_set
         .attr_type
-        .validate(&Value::String("ALL".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String("ALL".to_string())))
         .expect("API spelling ALL should be accepted");
     feature_set
         .attr_type
-        .validate(&Value::String("all".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String("all".to_string())))
         .expect("DSL spelling all should be accepted");
     feature_set
         .attr_type
-        .validate(&Value::String("CONSOLIDATED_BILLING".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "CONSOLIDATED_BILLING".to_string(),
+        )))
         .expect("API spelling CONSOLIDATED_BILLING should be accepted");
     feature_set
         .attr_type
-        .validate(&Value::String("consolidated_billing".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "consolidated_billing".to_string(),
+        )))
         .expect("DSL spelling consolidated_billing should be accepted");
     // Bogus values still rejected.
     assert!(
         feature_set
             .attr_type
-            .validate(&Value::String("not_a_value".to_string()))
+            .validate(&Value::Concrete(ConcreteValue::String(
+                "not_a_value".to_string()
+            )))
             .is_err(),
         "unknown values must still be rejected"
     );
@@ -1487,7 +1683,7 @@ fn test_organization_feature_set_validates_snake_case_alias() {
 /// be SHOUTY) and their lowercase DSL aliases.
 #[test]
 fn test_route53_record_type_validates_snake_case_alias() {
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
 
     let config = crate::schemas::generated::route53::record_set::route53_record_set_config();
     let type_attr = config
@@ -1498,18 +1694,18 @@ fn test_route53_record_type_validates_snake_case_alias() {
 
     type_attr
         .attr_type
-        .validate(&Value::String("A".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String("A".to_string())))
         .expect("API spelling A should be accepted");
     type_attr
         .attr_type
-        .validate(&Value::String("a".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String("a".to_string())))
         .expect("DSL spelling a should be accepted");
     type_attr
         .attr_type
-        .validate(&Value::String("CNAME".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String("CNAME".to_string())))
         .expect("API spelling CNAME should be accepted");
     type_attr
         .attr_type
-        .validate(&Value::String("cname".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String("cname".to_string())))
         .expect("DSL spelling cname should be accepted");
 }


### PR DESCRIPTION
## Summary

Bumps the `carina-core` git rev from `1d5f1a24` to `e73e8bee`, which lands [RFC #2972](https://github.com/carina-rs/carina/issues/2972) Phase 5a (the physical `Value` enum split into nested `Concrete(ConcreteValue) / Deferred(DeferredValue)`) plus a few unrelated breaking changes that landed in between (`Directives.depends_on`, `ResourceSchema.default_wait_*`, `AttributeType::Duration`).

## What changed

- Every `Value::X` pattern site now matches `Value::Concrete(ConcreteValue::X(...))` or `Value::Deferred(DeferredValue::X(...))`. Constructor sites use the backward-compatible `Value::String(s)` helper methods.
- ` carina-provider-aws/src/convert.rs::core_to_proto_value` is now **exhaustive** over the new axis. The previous `_ => format!("{v:?}")` catch-all was a latent Secret-plaintext leak (`Debug` on `Value::Deferred(Secret(inner))` includes the inner plaintext); replaced with per-variant redacted sentinels (`<redacted-secret>`, `<unresolved-ref:...>`, etc.). New deferred variants now break compilation rather than silently leaking via Debug.
- `Duration` mapped to `ProtoValue::Int(seconds)` (WIT has no Duration variant today).
- New `Directives.depends_on` and `ResourceSchema.default_wait_*` fields initialized to empty / None — providers don't drive wait phases.
- Generated schemas regenerated from the updated codegen template.

## Test plan

- [x] `cargo nextest run --workspace` — 349 passed, 0 skipped
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --doc` — green
- [x] `cargo fmt --all --check` — clean
- [x] 5 fresh review rounds — all GO

## WIT contract

Unchanged. The Concrete/Deferred split is host-side only; the plugin-facing WIT `value` variant stays flat.

Refs carina-rs/carina#2972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)