### PR TITLE
codegen: emit Value::Concrete pattern after Phase 5a Value split

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -820,7 +820,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         code.push_str("use super::validate_tags_map;\n");
     }
     if has_ranged_ints {
-        code.push_str("use carina_core::resource::{ConcreteValue, DeferredValue, Value};\n");
+        code.push_str("use carina_core::resource::{ConcreteValue, Value};\n");
     }
     code.push_str(&format!(
         "use carina_core::schema::{{{}}};\n\n",
@@ -874,7 +874,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         let (condition, display) = int_range_condition_and_display(range.min, range.max);
         code.push_str(&format!(
             "fn {}(value: &Value) -> Result<(), String> {{\n\
-             \x20   if let Value::Int(n) = value {{\n\
+             \x20   if let Value::Concrete(ConcreteValue::Int(n)) = value {{\n\
              \x20       if {} {{\n\
              \x20           Err(format!(\"Value {{}} is out of range {}\", n))\n\
              \x20       }} else {{\n\


### PR DESCRIPTION
## Summary

Follow-up to [#253](https://github.com/carina-rs/carina-provider-aws/pull/253). The template in `carina-codegen-aws` was still emitting `Value::Int(n)` in pattern positions, which compiles only because PR #253's mechanical rewrite had already substituted `Value::Concrete(ConcreteValue::Int(n))` in the checked-in generated files. Re-running codegen would re-introduce the broken form.

This commit:

- Updates the template to emit `Value::Concrete(ConcreteValue::Int(n))` in pattern position.
- Drops the unused `DeferredValue` import emission.

Codegen output now matches the checked-in schemas, fixing the **Codegen Check** CI gate that was red on #253.

## Test plan

- [x] `bash scripts/generate-schemas-smithy.sh` produces no diff
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Pre-commit hook (fmt + clippy) passed

Refs carina-rs/carina#2972, #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)