### PR TITLE
hand-written: switch all Value::X(...) emission to nested ConcreteValue form

### DIFF
--- a/carina-provider-aws/src/ec2_tags.rs
+++ b/carina-provider-aws/src/ec2_tags.rs
@@ -178,8 +178,14 @@ mod tests {
     #[test]
     fn test_value_to_ec2_tags_from_map() {
         let value = Value::Concrete(ConcreteValue::Map(IndexMap::from([
-            ("Name".to_string(), Value::String("test".to_string())),
-            ("Env".to_string(), Value::String("prod".to_string())),
+            (
+                "Name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            (
+                "Env".to_string(),
+                Value::Concrete(ConcreteValue::String("prod".to_string())),
+            ),
         ])));
         let tags = AwsProvider::value_to_ec2_tags(&value);
         assert_eq!(tags.len(), 2);
@@ -207,8 +213,11 @@ mod tests {
     #[test]
     fn test_value_to_ec2_tags_non_string_values_skipped() {
         let value = Value::Concrete(ConcreteValue::Map(IndexMap::from([
-            ("Name".to_string(), Value::String("test".to_string())),
-            ("Count".to_string(), Value::Int(42)),
+            (
+                "Name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            ("Count".to_string(), Value::Concrete(ConcreteValue::Int(42))),
         ])));
         let tags = AwsProvider::value_to_ec2_tags(&value);
         assert_eq!(tags.len(), 1);

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -249,9 +249,12 @@ mod tests {
         from_attrs.insert(
             "tags".into(),
             Value::Concrete(ConcreteValue::Map(
-                [("Name".to_string(), Value::String("old".into()))]
-                    .into_iter()
-                    .collect(),
+                [(
+                    "Name".to_string(),
+                    Value::Concrete(ConcreteValue::String("old".into())),
+                )]
+                .into_iter()
+                .collect(),
             )),
         );
         let from = State::existing(id, from_attrs);
@@ -269,9 +272,12 @@ mod tests {
                     kind: PatchOpKind::Replace,
                     key: "tags".into(),
                     value: Some(Value::Concrete(ConcreteValue::Map(
-                        [("Name".to_string(), Value::String("new".into()))]
-                            .into_iter()
-                            .collect(),
+                        [(
+                            "Name".to_string(),
+                            Value::Concrete(ConcreteValue::String("new".into())),
+                        )]
+                        .into_iter()
+                        .collect(),
                     ))),
                 },
                 // Remove cidr_block

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -197,7 +197,9 @@ impl AwsProvider {
             attributes.insert(
                 "subject_alternative_names".to_string(),
                 Value::Concrete(ConcreteValue::List(
-                    sans.iter().map(|s| Value::String(s.clone())).collect(),
+                    sans.iter()
+                        .map(|s| Value::Concrete(ConcreteValue::String(s.clone())))
+                        .collect(),
                 )),
             );
         }

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -51,7 +51,9 @@ impl AwsProvider {
             {
                 attributes.insert(
                     "resource_ids".to_string(),
-                    Value::Concrete(ConcreteValue::List(vec![Value::String(rid)])),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::String(rid),
+                    )])),
                 );
             }
 

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -734,7 +734,9 @@ mod tests {
         );
         policy.insert(
             "statement".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Map(stmt)])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt),
+            )])),
         );
 
         let r = make_resource(Some(Value::Concrete(ConcreteValue::Map(policy))));
@@ -802,8 +804,10 @@ mod tests {
         stmt.insert(
             "resource".to_string(),
             Value::Concrete(ConcreteValue::List(vec![
-                Value::String("arn:aws:s3:::my-bucket".to_string()),
-                Value::String("arn:aws:s3:::my-bucket/*".to_string()),
+                Value::Concrete(ConcreteValue::String("arn:aws:s3:::my-bucket".to_string())),
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:s3:::my-bucket/*".to_string(),
+                )),
             ])),
         );
         stmt.insert(
@@ -818,7 +822,9 @@ mod tests {
         );
         doc.insert(
             "statement".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Map(stmt)])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt),
+            )])),
         );
         Value::Concrete(ConcreteValue::Map(doc))
     }
@@ -1005,8 +1011,8 @@ mod tests {
         let mut inner = IndexMap::new();
         inner.insert(
             "aws:TagKeys".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::String(
-                "Environment".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("Environment".to_string()),
             )])),
         );
         let mut condition = IndexMap::new();
@@ -1034,7 +1040,9 @@ mod tests {
         );
         doc.insert(
             "statement".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Map(stmt)])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt),
+            )])),
         );
 
         let original = Value::Concrete(ConcreteValue::Map(doc));
@@ -1083,7 +1091,9 @@ mod tests {
         );
         doc.insert(
             "statement".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Map(stmt)])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt),
+            )])),
         );
 
         let original = Value::Concrete(ConcreteValue::Map(doc));

--- a/carina-provider-aws/src/services/s3/bucket_notification.rs
+++ b/carina-provider-aws/src/services/s3/bucket_notification.rs
@@ -428,7 +428,7 @@ fn events_to_value(events: &[Event]) -> Value {
     Value::Concrete(ConcreteValue::List(
         events
             .iter()
-            .map(|e| Value::String(e.as_str().to_string()))
+            .map(|e| Value::Concrete(ConcreteValue::String(e.as_str().to_string())))
             .collect(),
     ))
 }

--- a/carina-provider-aws/src/services/sts/account_guard.rs
+++ b/carina-provider-aws/src/services/sts/account_guard.rs
@@ -183,8 +183,8 @@ mod tests {
     #[test]
     fn extract_string_list_extracts_strings_in_order() {
         let v = Value::Concrete(ConcreteValue::List(vec![
-            Value::String("aaa".into()),
-            Value::String("bbb".into()),
+            Value::Concrete(ConcreteValue::String("aaa".into())),
+            Value::Concrete(ConcreteValue::String("bbb".into())),
         ]));
         assert_eq!(
             extract_string_list(Some(&v)),
@@ -197,9 +197,9 @@ mod tests {
         // Type validation happens host-side via
         // `provider_config_attribute_types`; this is just the safety net.
         let v = Value::Concrete(ConcreteValue::List(vec![
-            Value::String("aaa".into()),
-            Value::Int(42),
-            Value::String("bbb".into()),
+            Value::Concrete(ConcreteValue::String("aaa".into())),
+            Value::Concrete(ConcreteValue::Int(42)),
+            Value::Concrete(ConcreteValue::String("bbb".into())),
         ]));
         assert_eq!(
             extract_string_list(Some(&v)),

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -880,15 +880,15 @@ fn test_extract_ec2_vpc_endpoint_attributes() {
     );
     assert_eq!(
         attributes.get("route_table_ids"),
-        Some(&Value::Concrete(ConcreteValue::List(vec![Value::String(
-            "rtb-12345678".to_string()
-        )])))
+        Some(&Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("rtb-12345678".to_string()))
+        ])))
     );
     assert_eq!(
         attributes.get("security_group_ids"),
-        Some(&Value::Concrete(ConcreteValue::List(vec![Value::String(
-            "sg-12345678".to_string()
-        )])))
+        Some(&Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("sg-12345678".to_string()))
+        ])))
     );
 }
 
@@ -929,9 +929,9 @@ fn test_extract_ec2_vpc_endpoint_attributes_interface() {
     );
     assert_eq!(
         attributes.get("subnet_ids"),
-        Some(&Value::Concrete(ConcreteValue::List(vec![Value::String(
-            "subnet-12345678".to_string()
-        )])))
+        Some(&Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("subnet-12345678".to_string()))
+        ])))
     );
 }
 
@@ -1260,8 +1260,8 @@ fn test_extract_ec2_transit_gateway_attachment_attributes() {
     assert_eq!(
         attributes.get("subnet_ids"),
         Some(&Value::Concrete(ConcreteValue::List(vec![
-            Value::String("subnet-12345678".to_string()),
-            Value::String("subnet-87654321".to_string()),
+            Value::Concrete(ConcreteValue::String("subnet-12345678".to_string())),
+            Value::Concrete(ConcreteValue::String("subnet-87654321".to_string())),
         ])))
     );
 }


### PR DESCRIPTION
## Summary

- The helper-method form (`Value::String(s)`, `Value::Int(n)`, etc.) was introduced as a backward-compat shim during the RFC #2972 Value Concrete/Deferred split (carina#2975).
- All machine-emitted code has since been migrated to the nested form via the codegen template fix (#255). The remaining hand-written sites kept using the helper methods, blocking the eventual removal of the `#[allow(non_snake_case)] impl Value { fn String(...), ... }` helpers from carina-core.
- Switch every hand-written `Value::X(expr)` site to `Value::Concrete(ConcreteValue::X(expr))`. Skips `serde_json::Value::*`, `ConcreteValue::*`, `EnumValue::*`.
- After this change, no live caller in carina-provider-aws uses the helper methods.

## Test plan

- [x] `cargo nextest run --workspace` → 349/349 pass
- [x] `cargo test --workspace --doc` → pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green

Follow-up: parallel awscc PR + carina-core helper deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
