### PR TITLE
acceptance-tests: use API-canonical enum values in s3_bucket_* fixtures (refs #258)

### DIFF
--- a/acceptance-tests/s3_bucket_lifecycle_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_lifecycle_configuration/basic.crn
@@ -18,11 +18,11 @@ aws.s3.BucketLifecycleConfiguration {
   rules = [
     {
       id     = 'transition-then-expire'
-      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.enabled
+      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.Enabled
       transitions = [
         {
           days          = 30
-          storage_class = aws.s3.BucketLifecycleConfiguration.TransitionStorageClass.standard_ia
+          storage_class = aws.s3.BucketLifecycleConfiguration.TransitionStorageClass.STANDARD_IA
         },
       ]
       expiration = {

--- a/acceptance-tests/s3_bucket_ownership_controls/basic.crn
+++ b/acceptance-tests/s3_bucket_ownership_controls/basic.crn
@@ -10,5 +10,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketOwnershipControls {
   bucket           = bucket.bucket
-  object_ownership = aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced
+  object_ownership = aws.s3.BucketOwnershipControls.ObjectOwnership.BucketOwnerEnforced
 }

--- a/acceptance-tests/s3_bucket_replication_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/basic.crn
@@ -14,7 +14,7 @@ let source = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = source.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
 }
 
 let dest = aws.s3.Bucket {
@@ -23,7 +23,7 @@ let dest = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = dest.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
 }
 
 let role = aws.iam.Role {
@@ -48,7 +48,7 @@ aws.s3.BucketReplicationConfiguration {
   rules = [
     {
       id     = 'replicate-all'
-      status = aws.s3.BucketReplicationConfiguration.ReplicationRuleStatus.enabled
+      status = aws.s3.BucketReplicationConfiguration.ReplicationRuleStatus.Enabled
       destination = {
         bucket = 'arn:aws:s3:::carina-acc-test-aws-s3-repl-dst-v1'
       }

--- a/acceptance-tests/s3_bucket_server_side_encryption_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_server_side_encryption_configuration/basic.crn
@@ -17,7 +17,7 @@ aws.s3.BucketServerSideEncryptionConfiguration {
   rules = [
     {
       apply_server_side_encryption_by_default = {
-        sse_algorithm = aws.s3.BucketServerSideEncryptionConfiguration.SseAlgorithm.aes256
+        sse_algorithm = aws.s3.BucketServerSideEncryptionConfiguration.SseAlgorithm.AES256
       }
       bucket_key_enabled = true
     },

--- a/acceptance-tests/s3_bucket_versioning/basic.crn
+++ b/acceptance-tests/s3_bucket_versioning/basic.crn
@@ -12,5 +12,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = bucket.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
 }


### PR DESCRIPTION
Refs #258. Structural follow-up: carina-rs/carina#2977.

## Summary

S3 hand-written provider code calls `carina_core::utils::extract_enum_value` on DSL-spelled enum attributes and feeds the result straight to AWS SDK builders. The SDK's `From<&str>` for enum types (`BucketVersioningStatus`, `MfaDelete`, `StorageClass`, `ObjectOwnership`, `ServerSideEncryption`, `ReplicationRuleStatus`, `LifecycleRuleStatus`) only recognizes the API-canonical spelling — DSL alias forms become `Unknown("enabled")` and get serialized as such into the request XML, which S3 rejects with `MalformedXML`.

Update the affected fixtures to use the canonical spelling that matches the SDK's accepted values. This unblocks the acceptance tests in question without changing provider-side semantics.

## Changes

- `s3_bucket_versioning/basic.crn` — `enabled` → `Enabled`
- `s3_bucket_lifecycle_configuration/basic.crn` — `enabled` → `Enabled`, `standard_ia` → `STANDARD_IA`
- `s3_bucket_ownership_controls/basic.crn` — `bucket_owner_enforced` → `BucketOwnerEnforced`
- `s3_bucket_server_side_encryption_configuration/basic.crn` — `aes256` → `AES256`
- `s3_bucket_replication_configuration/basic.crn` — `enabled` → `Enabled` (both versioning entries + the replication rule)

## Why this is a fixture fix, not a code fix

The DSL accepts both PascalCase and lowercase alias for these enums (per the codegen-generated `dsl_aliases`), but the provider-side hand-written code currently has no first-class way to canonicalize back to API form. The cleanest cross-cutting fix is to add `DslMap::api_for(dsl)` and thread it through the provider's enum-extraction helpers — that work is tracked at carina-rs/carina#2977. Until then, the fixtures must use the canonical spelling so the SDK accepts them.

## Test plan

- [ ] CI green
- [ ] Acceptance: re-run `./acceptance-tests/run-tests.sh full s3_bucket_versioning s3_bucket_lifecycle_configuration s3_bucket_ownership_controls s3_bucket_server_side_encryption_configuration s3_bucket_replication_configuration` to confirm all 5 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
