### PR TITLE
Revert PascalCase fixture rewrite (restore snake_case DSL alias)

### DIFF
--- a/acceptance-tests/s3_bucket_lifecycle_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_lifecycle_configuration/basic.crn
@@ -18,11 +18,11 @@ aws.s3.BucketLifecycleConfiguration {
   rules = [
     {
       id     = 'transition-then-expire'
-      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.Enabled
+      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.enabled
       transitions = [
         {
           days          = 30
-          storage_class = aws.s3.BucketLifecycleConfiguration.TransitionStorageClass.STANDARD_IA
+          storage_class = aws.s3.BucketLifecycleConfiguration.TransitionStorageClass.standard_ia
         },
       ]
       expiration = {

--- a/acceptance-tests/s3_bucket_ownership_controls/basic.crn
+++ b/acceptance-tests/s3_bucket_ownership_controls/basic.crn
@@ -10,5 +10,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketOwnershipControls {
   bucket           = bucket.bucket
-  object_ownership = aws.s3.BucketOwnershipControls.ObjectOwnership.BucketOwnerEnforced
+  object_ownership = aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced
 }

--- a/acceptance-tests/s3_bucket_replication_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/basic.crn
@@ -14,7 +14,7 @@ let source = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = source.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
 }
 
 let dest = aws.s3.Bucket {
@@ -23,7 +23,7 @@ let dest = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = dest.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
 }
 
 let role = aws.iam.Role {
@@ -48,7 +48,7 @@ aws.s3.BucketReplicationConfiguration {
   rules = [
     {
       id     = 'replicate-all'
-      status = aws.s3.BucketReplicationConfiguration.ReplicationRuleStatus.Enabled
+      status = aws.s3.BucketReplicationConfiguration.ReplicationRuleStatus.enabled
       destination = {
         bucket = 'arn:aws:s3:::carina-acc-test-aws-s3-repl-dst-v1'
       }

--- a/acceptance-tests/s3_bucket_server_side_encryption_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_server_side_encryption_configuration/basic.crn
@@ -17,7 +17,7 @@ aws.s3.BucketServerSideEncryptionConfiguration {
   rules = [
     {
       apply_server_side_encryption_by_default = {
-        sse_algorithm = aws.s3.BucketServerSideEncryptionConfiguration.SseAlgorithm.AES256
+        sse_algorithm = aws.s3.BucketServerSideEncryptionConfiguration.SseAlgorithm.aes256
       }
       bucket_key_enabled = true
     },

--- a/acceptance-tests/s3_bucket_versioning/basic.crn
+++ b/acceptance-tests/s3_bucket_versioning/basic.crn
@@ -12,5 +12,5 @@ let bucket = aws.s3.Bucket {
 
 aws.s3.BucketVersioning {
   bucket = bucket.bucket
-  status = aws.s3.BucketVersioning.VersioningStatus.Enabled
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
 }


### PR DESCRIPTION
Reverts the PascalCase rewrite that was accidentally merged via #264.

## What happened

The branch behind #264 was based on the closed-but-still-present commit `81efe59` ("acceptance-tests: use API-canonical enum values in s3_bucket_* fixtures"), which had been closed as PR #262 because it violated the snake_case alias convention. When #264 was merged, that commit rode along.

Now that #264's normalizer change is on main, the provider canonicalizes DSL aliases (`enabled`) to API spelling (`Enabled`) automatically. Fixtures should use the snake_case DSL form per `feedback_dsl_enum_snake_case_convention.md`.

## Changes

Reverts `81efe59` — 5 fixture files restored to snake_case alias form:

- `s3_bucket_versioning/basic.crn`: `Enabled` → `enabled`
- `s3_bucket_lifecycle_configuration/basic.crn`: 2 enum values
- `s3_bucket_ownership_controls/basic.crn`: `BucketOwnerEnforced` → `bucket_owner_enforced`
- `s3_bucket_replication_configuration/basic.crn`: 3 enum values
- `s3_bucket_server_side_encryption_configuration/basic.crn`: `AES256` → `aes256`

## Test plan

- [x] `cargo check` clean
- [ ] Acceptance tests for s3_bucket_* — should now pass with snake_case DSL aliases (the original #258 verification)
