### PR TITLE
codegen: pascalize all-uppercase enum TypeNames as initialisms

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3556,6 +3556,16 @@ fn type_code_to_display(type_code: &str) -> String {
 /// shape name is sometimes a generic alias (`Tenancy` for `InstanceTenancy`)
 /// that doesn't match user expectations.
 fn pascalize_enum_type_name(_shape_name: &str, field_name: &str) -> String {
+    // Initialism (all ASCII uppercase, e.g. "ACL", "MFA", "VPC") → first
+    // letter kept, rest lowercased so the DSL TypeName segment follows
+    // Rust's RFC 430 acronym convention. Mixed-case names (e.g.
+    // "VersioningStatus") pass through unchanged. Names starting with a
+    // lowercase letter get their first character uppercased.
+    if !field_name.is_empty() && field_name.chars().all(|c| c.is_ascii_uppercase()) {
+        let mut chars = field_name.chars();
+        let first = chars.next().unwrap();
+        return format!("{}{}", first, chars.as_str().to_ascii_lowercase());
+    }
     let mut chars = field_name.chars();
     match chars.next() {
         Some(c) if c.is_ascii_uppercase() => field_name.to_string(),
@@ -4883,5 +4893,44 @@ mod tests {
         let missing = tmp.path().join("does_not_exist");
         let methods = scan_manual_methods(&missing);
         assert!(methods.is_empty());
+    }
+
+    #[test]
+    fn pascalize_enum_type_name_initialism_to_pascal() {
+        // All-uppercase initialisms become Rust-RFC-430 PascalCase so the
+        // DSL TypeName segment matches the convention used by every other
+        // enum (e.g. `Acl`, not `ACL`).
+        assert_eq!(pascalize_enum_type_name("BucketCannedACL", "ACL"), "Acl");
+        assert_eq!(pascalize_enum_type_name("MFADelete", "MFA"), "Mfa");
+        assert_eq!(pascalize_enum_type_name("VPC", "VPC"), "Vpc");
+    }
+
+    #[test]
+    fn pascalize_enum_type_name_mixed_case_passes_through() {
+        // Already-PascalCase names with mixed case (the common case for
+        // AWS enums like `InstanceTenancy`) must not be touched.
+        assert_eq!(
+            pascalize_enum_type_name("InstanceTenancy", "InstanceTenancy"),
+            "InstanceTenancy"
+        );
+        assert_eq!(
+            pascalize_enum_type_name("VersioningStatus", "VersioningStatus"),
+            "VersioningStatus"
+        );
+    }
+
+    #[test]
+    fn pascalize_enum_type_name_camel_case_first_letter_uppercased() {
+        // camelCase field names like `logGroupClass` get their first
+        // letter uppercased only — the rest of the casing is preserved.
+        assert_eq!(
+            pascalize_enum_type_name("LogGroupClass", "logGroupClass"),
+            "LogGroupClass"
+        );
+    }
+
+    #[test]
+    fn pascalize_enum_type_name_empty_input_returns_empty() {
+        assert_eq!(pascalize_enum_type_name("", ""), "");
     }
 }

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_acl.rs
@@ -28,7 +28,7 @@ pub fn s3_bucket_acl_config() -> AwsSchemaConfig {
                 AttributeSchema::new(
                     "acl",
                     AttributeType::StringEnum {
-                        name: "ACL".to_string(),
+                        name: "Acl".to_string(),
                         values: vec![
                             "authenticated-read".to_string(),
                             "private".to_string(),


### PR DESCRIPTION
Closes #259.

## Summary

`pascalize_enum_type_name` previously preserved any field name that already started with an uppercase letter, which left initialism-shaped names like `ACL`, `MFA`, `VPC` in all-uppercase form. That broke the DSL TypeName segment convention: every other enum (`VersioningStatus`, `InstanceTenancy`, `BucketOwnershipControls`, …) uses PascalCase, so `aws.s3.BucketAcl.ACL.private` was the only odd one out. The validator surfaced the inconsistency as:

```
Invalid ACL 'aws.s3.BucketAcl.Acl.private': expected format aws.s3.BucketAcl.ACL.value
```

Now codegen treats all-ASCII-uppercase inputs as initialisms and lowercases the tail, following Rust's RFC 430 acronym convention:

| Before | After |
|--------|-------|
| `ACL`  | `Acl` |
| `MFA`  | `Mfa` |
| `VPC`  | `Vpc` |

Mixed-case names (`VersioningStatus`) and camelCase (`logGroupClass`) pass through unchanged.

## Scope

Today only `s3.BucketAcl.acl` is affected — codegen regenerates one schema file (`generated/s3/bucket_acl.rs`) with `name: "Acl"`. The fixture (`acceptance-tests/s3_bucket_acl/basic.crn`) already writes `aws.s3.BucketAcl.Acl.private`, so it now passes validation.

## Test plan

- [x] 4 new unit tests in `carina-codegen-aws`: initialism / mixed-case / camelCase / empty
- [x] `cargo nextest run` — 356/356 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/generate-schemas-smithy.sh` + `scripts/generate-docs.sh` regenerated; diff is one line in `bucket_acl.rs`
- [ ] Acceptance: `s3_bucket_acl/basic.crn` validate + apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)
