### PR TITLE
deps: bump carina pin to 2f403317 (carina#2986 strict enum identifier)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=8de52fd1#8de52fd1d75431e67d284ca9b2302c5958b233b6"
+source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
 dependencies = [
  "argon2",
  "futures",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=8de52fd1#8de52fd1d75431e67d284ca9b2302c5958b233b6"
+source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=8de52fd1#8de52fd1d75431e67d284ca9b2302c5958b233b6"
+source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "8de52fd1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "8de52fd1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "8de52fd1" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "8de52fd1" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -41,7 +41,14 @@ pub fn proto_to_core_resource_id(id: &ProtoResourceId) -> CoreResourceId {
 
 pub fn core_to_proto_value(v: &CoreValue) -> ProtoValue {
     match v {
-        CoreValue::Concrete(ConcreteValue::String(s)) => ProtoValue::String(s.clone()),
+        // `EnumIdentifier` carries identifier-shape text (parser-level
+        // distinction from quoted-string literals, carina#2986). The
+        // provider wire protocol has no native identifier variant, so we
+        // emit it as `ProtoValue::String` — identical to the `String`
+        // arm. The shape distinction is consumed at the validator entry
+        // before reaching this conversion.
+        CoreValue::Concrete(ConcreteValue::String(s))
+        | CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => ProtoValue::String(s.clone()),
         CoreValue::Concrete(ConcreteValue::Int(i)) => ProtoValue::Int(*i),
         CoreValue::Concrete(ConcreteValue::Float(f)) => ProtoValue::Float(*f),
         CoreValue::Concrete(ConcreteValue::Bool(b)) => ProtoValue::Bool(*b),

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -1645,24 +1645,32 @@ fn test_organization_feature_set_validates_snake_case_alias() {
         .get("feature_set")
         .expect("feature_set attribute not found");
 
-    // Both the API form (`ALL`) and the DSL form (`all`) must validate.
+    // Phase 4 of carina#2986: enum attributes accept only
+    // `EnumIdentifier` shape; a `ConcreteValue::String` here would route
+    // to `StringLiteralExpectedEnum`. Both the API form (`ALL`) and the
+    // DSL form (`all`) are identifier-shape inputs in real DSL — the
+    // parser would emit `EnumIdentifier` for both. Mirror that here.
     feature_set
         .attr_type
-        .validate(&Value::Concrete(ConcreteValue::String("ALL".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "ALL".to_string(),
+        )))
         .expect("API spelling ALL should be accepted");
     feature_set
         .attr_type
-        .validate(&Value::Concrete(ConcreteValue::String("all".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "all".to_string(),
+        )))
         .expect("DSL spelling all should be accepted");
     feature_set
         .attr_type
-        .validate(&Value::Concrete(ConcreteValue::String(
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "CONSOLIDATED_BILLING".to_string(),
         )))
         .expect("API spelling CONSOLIDATED_BILLING should be accepted");
     feature_set
         .attr_type
-        .validate(&Value::Concrete(ConcreteValue::String(
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "consolidated_billing".to_string(),
         )))
         .expect("DSL spelling consolidated_billing should be accepted");
@@ -1670,7 +1678,7 @@ fn test_organization_feature_set_validates_snake_case_alias() {
     assert!(
         feature_set
             .attr_type
-            .validate(&Value::Concrete(ConcreteValue::String(
+            .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
                 "not_a_value".to_string()
             )))
             .is_err(),
@@ -1692,20 +1700,31 @@ fn test_route53_record_type_validates_snake_case_alias() {
         .get("type")
         .expect("type attribute not found");
 
+    // Phase 4 of carina#2986: use `EnumIdentifier` shape to reach the
+    // variant-match path. A `ConcreteValue::String` here would route
+    // to `StringLiteralExpectedEnum`.
     type_attr
         .attr_type
-        .validate(&Value::Concrete(ConcreteValue::String("A".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "A".to_string(),
+        )))
         .expect("API spelling A should be accepted");
     type_attr
         .attr_type
-        .validate(&Value::Concrete(ConcreteValue::String("a".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "a".to_string(),
+        )))
         .expect("DSL spelling a should be accepted");
     type_attr
         .attr_type
-        .validate(&Value::Concrete(ConcreteValue::String("CNAME".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "CNAME".to_string(),
+        )))
         .expect("API spelling CNAME should be accepted");
     type_attr
         .attr_type
-        .validate(&Value::Concrete(ConcreteValue::String("cname".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "cname".to_string(),
+        )))
         .expect("DSL spelling cname should be accepted");
 }


### PR DESCRIPTION
## Summary

Pulls in carina#2988 + #2989 + #2990 from the carina main: the `ConcreteValue::EnumIdentifier` variant and the strict-mode validator that rejects quoted string literals on `StringEnum`-typed attributes.

## Provider-side changes

- `convert.rs::core_to_proto_value` handles `EnumIdentifier` the same as `String` — the wire protocol has no identifier variant, so we flatten to `ProtoValue::String`. The shape distinction is consumed at the validator entry before reaching this conversion.
- `tests::test_organization_feature_set_validates_snake_case_alias` and `tests::test_route53_record_type_validates_snake_case_alias` now construct `EnumIdentifier` inputs rather than `String`. Both API and DSL spellings are identifier-shape in real DSL — the parser would emit `EnumIdentifier` for both, so the test inputs mirror that.

## Fixture sweep — no changes needed

Every enum value under `acceptance-tests/**/*.crn` already uses the identifier form (e.g. `aws.ec2.FlowLog.ResourceType.vpc`) — the snake_case rollout through #269 covered this.

## Test plan

- [x] `cargo nextest run --workspace` — 359 passed, 0 failed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Refs carina-rs/carina#2986.