### PR TITLE
codegen: rename extra_writable → extra_attributes + honor read_only_overrides for synthetics (#281)

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -576,8 +576,8 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         }
     }
 
-    // Add extra writable fields from read structure
-    for extra in &res.extra_writable {
+    // Add extra_attributes fields sourced from the read structure
+    for extra in &res.extra_attributes {
         if writable_fields.contains_key(extra.name) {
             continue;
         }
@@ -617,9 +617,9 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         }
     }
 
-    // Build extra_writable description override map
-    let extra_writable_descs: HashMap<&str, Option<&str>> = res
-        .extra_writable
+    // Build extra_attributes description override map
+    let extra_attribute_descs: HashMap<&str, Option<&str>> = res
+        .extra_attributes
         .iter()
         .map(|e| (e.name, e.description))
         .collect();
@@ -633,19 +633,19 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             || required_overrides.contains(name.as_str()))
             && !read_only_overrides.contains(name.as_str());
         let is_read_only = read_only_overrides.contains(name.as_str());
-        // `extra_writable` fields with `read_source = None` are synthetic:
+        // `extra_attributes` fields with `read_source = None` are synthetic:
         // the codegen has no Smithy member to ground them in. They default
         // to create-only — UNLESS they appear in `update_ops` (typically as
         // `FieldLayout::InsideStruct` members, e.g. PutPublicAccessBlock's
         // `PublicAccessBlockConfiguration` sub-fields), in which case they
         // are updatable just like any other writable field.
-        let is_synthetic_extra_writable = res
-            .extra_writable
+        let is_synthetic_extra_attribute = res
+            .extra_attributes
             .iter()
             .any(|e| e.name == name.as_str() && e.read_source.is_none());
         let is_create_only = if is_read_only {
             false
-        } else if is_synthetic_extra_writable {
+        } else if is_synthetic_extra_attribute {
             !updatable_fields.contains(name.as_str())
                 || create_only_overrides.contains(name.as_str())
         } else if schema_structure.is_some() {
@@ -657,7 +657,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
                 || !updatable_fields.contains(name.as_str())
         };
         // Use ExtraField description override if available, otherwise Smithy docs
-        let description = if let Some(Some(desc)) = extra_writable_descs.get(name.as_str()) {
+        let description = if let Some(Some(desc)) = extra_attribute_descs.get(name.as_str()) {
             Some(desc.to_string())
         } else {
             SmithyModel::documentation(&member_ref.traits).map(|s| s.to_string())
@@ -692,11 +692,13 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         });
     }
 
-    // Process synthetic extra writable fields (no read_source).
+    // Process synthetic extra_attributes fields (no read_source).
     // A synthetic field defaults to create-only, but is treated as updatable
     // when it appears in `update_ops` (typically as a `FieldLayout::InsideStruct`
-    // member of a wrapper struct in the API request shape).
-    for extra in &res.extra_writable {
+    // member of a wrapper struct in the API request shape). When the field is
+    // listed in `read_only_overrides`, it is emitted as read-only instead —
+    // mirrors the behaviour for Smithy-grounded fields.
+    for extra in &res.extra_attributes {
         if extra.read_source.is_some() {
             continue; // Already handled via writable_fields
         }
@@ -708,8 +710,10 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         } else {
             "AttributeType::String".to_string()
         };
-        let is_create_only =
-            !updatable_fields.contains(extra.name) || create_only_overrides.contains(extra.name);
+        let is_read_only = read_only_overrides.contains(extra.name);
+        let is_create_only = !is_read_only
+            && (!updatable_fields.contains(extra.name)
+                || create_only_overrides.contains(extra.name));
         let is_required = required_overrides.contains(extra.name);
         attrs.push(AttrInfo {
             snake_name,
@@ -717,7 +721,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             type_code,
             is_required,
             is_create_only,
-            is_read_only: false,
+            is_read_only,
             is_identity: identity_overrides.contains(extra.name),
             description: extra.description.map(|s| s.to_string()),
             enum_info: None,
@@ -2203,8 +2207,8 @@ fn generate_provider_code(
             fields_to_extract.push((snake_name.clone(), snake_name, member_ref));
         }
 
-        // Add extra_writable fields with read_source (different attr name vs accessor)
-        for extra in &res.extra_writable {
+        // Add extra_attributes fields with read_source (different attr name vs accessor)
+        for extra in &res.extra_attributes {
             if let Some(read_source) = extra.read_source
                 && let Some(member_ref) = read_struct.members.get(read_source)
             {
@@ -2877,8 +2881,8 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
         }
     }
 
-    // Add extra writable fields from read structure
-    for extra in &res.extra_writable {
+    // Add extra_attributes fields sourced from the read structure
+    for extra in &res.extra_attributes {
         if writable_fields.contains_key(extra.name) {
             continue;
         }
@@ -2925,9 +2929,9 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
         description: Option<String>,
     }
 
-    // Build extra_writable description override map
-    let extra_writable_descs: HashMap<&str, Option<&str>> = res
-        .extra_writable
+    // Build extra_attributes description override map
+    let extra_attribute_descs: HashMap<&str, Option<&str>> = res
+        .extra_attributes
         .iter()
         .map(|e| (e.name, e.description))
         .collect();
@@ -2938,7 +2942,7 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
         let is_required = (SmithyModel::is_required(member_ref)
             || required_overrides.contains(name.as_str()))
             && !read_only_overrides.contains(name.as_str());
-        let description = if let Some(Some(desc)) = extra_writable_descs.get(name.as_str()) {
+        let description = if let Some(Some(desc)) = extra_attribute_descs.get(name.as_str()) {
             Some(desc.to_string())
         } else {
             SmithyModel::documentation(&member_ref.traits).map(|s| s.to_string())
@@ -2961,8 +2965,12 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
         });
     }
 
-    // Add synthetic extra writable fields (no read_source) to markdown
-    for extra in &res.extra_writable {
+    let mut read_only_attrs: Vec<MdAttrInfo> = Vec::new();
+
+    // Add synthetic extra_attributes fields (no read_source) to markdown.
+    // A field listed in `read_only_overrides` goes into the read-only
+    // table; otherwise into the writable table.
+    for extra in &res.extra_attributes {
         if extra.read_source.is_some() {
             continue;
         }
@@ -2974,15 +2982,19 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
         } else {
             "String".to_string()
         };
-        writable_attrs.push(MdAttrInfo {
+        let entry = MdAttrInfo {
             snake_name,
             type_display,
             is_required: false,
             description: extra.description.map(|s| s.to_string()),
-        });
+        };
+        if read_only_overrides.contains(extra.name) {
+            read_only_attrs.push(entry);
+        } else {
+            writable_attrs.push(entry);
+        }
     }
 
-    let mut read_only_attrs: Vec<MdAttrInfo> = Vec::new();
     for (name, member_ref) in &read_only_fields {
         let snake_name = name.to_snake_case();
         let description = SmithyModel::documentation(&member_ref.traits).map(|s| s.to_string());

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -79,9 +79,12 @@ pub struct ResourceDef {
     pub extra_read_only: Vec<&'static str>,
     /// Fields to force as read-only even if they appear in create input
     pub read_only_overrides: Vec<&'static str>,
-    /// Extra writable fields to add as create-only attributes.
-    /// These are fields not present in the create operation input.
-    pub extra_writable: Vec<ExtraField>,
+    /// Extra schema attributes (writable or read-only) that are not present
+    /// in the create operation input. Each entry is emitted as an
+    /// `AttributeSchema::new(...)` line with the usual flag combination:
+    /// - `update_ops` lists the field → updatable (else create-only).
+    /// - `read_only_overrides` lists the field → read-only.
+    pub extra_attributes: Vec<ExtraField>,
     /// Fields to mark as identity (contribute to anonymous resource identifier hashing).
     /// Use for attributes that distinguish same-type resources sharing create-only values.
     pub identity_overrides: Vec<&'static str>,
@@ -271,7 +274,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -306,7 +309,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             // private_dns_name_options_on_launch is a nested struct on the
             // read shape; collapse it into a single Value::Map attribute
@@ -345,7 +348,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![ExtraField {
+            extra_attributes: vec![ExtraField {
                 name: "VpcId",
                 read_source: None,
                 description: Some(
@@ -377,7 +380,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -421,7 +424,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -447,7 +450,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -480,7 +483,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["IpProtocol"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "CidrIpv6",
                     read_source: Some("CidrIpv6"),
@@ -534,7 +537,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["IpProtocol", "GroupId"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "CidrIpv6",
                     read_source: Some("CidrIpv6"),
@@ -581,7 +584,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["VpcId"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             // VpcId lives on Attachments[0].VpcId in the read response;
             // there is no top-level VpcId getter on EgressOnlyInternetGateway.
@@ -621,7 +624,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec!["PublicIp"],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -654,7 +657,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["ResourceId", "ResourceType"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -687,7 +690,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["SubnetId"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             // AllocationId lives on NatGatewayAddresses[0].AllocationId in the
             // read response; there is no top-level AllocationId getter on
@@ -722,7 +725,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["RouteTableId", "SubnetId"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -751,7 +754,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             // The TransitGatewayRequestOptions sub-struct on the response
             // is flattened into top-level attributes (matching the DSL
@@ -823,7 +826,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["TransitGatewayId", "VpcId", "SubnetIds"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -859,7 +862,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["ServiceName", "VpcId"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             // SecurityGroupIds is a write-side input
             // (CreateVpcEndpointRequest.SecurityGroupIds: List<String>) but
@@ -895,7 +898,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["VpcId"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "InternetGatewayId",
                     read_source: None,
@@ -932,7 +935,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["VpcId", "PeerVpcId"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             // The peering response carries the requester / accepter VPCs
             // in two parallel `VpcPeeringConnectionVpcInfo` sub-structs;
@@ -991,7 +994,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Type"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1128,7 +1131,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
                 "MasterAccountEmail",
             ],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1159,7 +1162,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["AccountName", "Email"],
             extra_read_only: vec!["Arn", "Name", "Status", "JoinedMethod", "JoinedTimestamp"],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1210,7 +1213,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1253,7 +1256,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "Policy"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1307,7 +1310,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "Status"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "Status",
                     read_source: None,
@@ -1367,7 +1370,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "ACL"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![],
+            extra_attributes: vec![],
             identity_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1409,7 +1412,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "ObjectOwnership"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![ExtraField {
+            extra_attributes: vec![ExtraField {
                 name: "ObjectOwnership",
                 read_source: None,
                 description: Some(
@@ -1460,7 +1463,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "Rules"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![ExtraField {
+            extra_attributes: vec![ExtraField {
                 name: "Rules",
                 read_source: None,
                 description: Some("List of server-side encryption rules to apply to the bucket."),
@@ -1504,7 +1507,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "Role", "Rules"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "Role",
                     read_source: None,
@@ -1555,7 +1558,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "Rules"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![ExtraField {
+            extra_attributes: vec![ExtraField {
                 name: "Rules",
                 read_source: None,
                 description: Some("Lifecycle rules to apply to the bucket."),
@@ -1604,7 +1607,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "IndexDocument",
                     read_source: None,
@@ -1660,7 +1663,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "CORSRules"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![ExtraField {
+            extra_attributes: vec![ExtraField {
                 name: "CORSRules",
                 read_source: None,
                 description: Some("CORS rules to apply to the bucket."),
@@ -1729,7 +1732,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "TopicConfigurations",
                     read_source: None,
@@ -1794,7 +1797,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket", "TargetBucket"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "TargetBucket",
                     read_source: None,
@@ -1869,7 +1872,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Bucket"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![
+            extra_attributes: vec![
                 ExtraField {
                     name: "BlockPublicAcls",
                     read_source: None,
@@ -2041,7 +2044,7 @@ pub fn acm_resources() -> Vec<ResourceDef> {
             "RenewalSummary",
         ],
         read_only_overrides: vec![],
-        extra_writable: vec![],
+        extra_attributes: vec![],
         identity_overrides: vec![],
         derived_attributes: vec![],
     }]
@@ -2094,7 +2097,7 @@ pub fn route53_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["Name", "Type"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
-            extra_writable: vec![ExtraField {
+            extra_attributes: vec![ExtraField {
                 name: "HostedZoneId",
                 read_source: None,
                 description: Some("The ID of the hosted zone that contains this record set."),
@@ -2137,7 +2140,7 @@ pub fn iam_resources() -> Vec<ResourceDef> {
         required_overrides: vec!["AssumeRolePolicyDocument"],
         extra_read_only: vec!["Arn", "RoleId"],
         read_only_overrides: vec![],
-        extra_writable: vec![],
+        extra_attributes: vec![],
         identity_overrides: vec![],
         derived_attributes: vec![],
     }]
@@ -2176,7 +2179,7 @@ pub fn logs_resources() -> Vec<ResourceDef> {
         required_overrides: vec![],
         extra_read_only: vec!["Arn"],
         read_only_overrides: vec![],
-        extra_writable: vec![ExtraField {
+        extra_attributes: vec![ExtraField {
             name: "retentionInDays",
             read_source: Some("retentionInDays"),
             description: Some(

--- a/docs/specs/2026-04-14-schema-structure-codegen.md
+++ b/docs/specs/2026-04-14-schema-structure-codegen.md
@@ -21,7 +21,7 @@ Add `schema_structure: Option<&'static str>` to `ResourceDef`. When set, the cod
    - Resolves `com.amazonaws.route53#ResourceRecordSet` from the Smithy model
    - Uses its members as the writable field source (replacing the create input)
    - Still respects `exclude_fields`, `type_overrides`, `create_only_overrides`, `identity_overrides`, `required_overrides`
-   - `extra_writable` adds fields not in the schema structure (e.g., `HostedZoneId`)
+   - `extra_attributes` adds fields not in the schema structure (e.g., `HostedZoneId`)
 
 2. If `schema_structure` is `None` (default), existing behavior unchanged — fields come from create input.
 
@@ -56,7 +56,7 @@ ResourceDef {
     required_overrides: vec!["Name", "Type"],
     create_only_overrides: vec!["Name"],
     identity_overrides: vec!["Type"],
-    extra_writable: vec![
+    extra_attributes: vec![
         ExtraField {
             name: "HostedZoneId",
             read_source: None,
@@ -74,6 +74,6 @@ ResourceDef {
 
 ## Edge cases
 
-- `extra_writable` fields with `schema_structure` should be marked `create_only` (same as current behavior)
+- `extra_attributes` fields with `schema_structure` should be marked `create_only` (same as current behavior)
 - `exclude_fields` removes fields from the schema structure that aren't needed in the initial version (routing policies, health checks)
 - `TTL` in Route 53 Smithy model is typed as `Long` — codegen should map to `Int`


### PR DESCRIPTION
## Summary

Closes #281. Prereq for aws#280 (`aws.sqs.Queue` resource).

`ResourceDef::extra_writable` is the existing hook that injects schema attributes which are NOT present in the create operation input. The name reflects its original use (LogGroup's `retentionInDays`) but is misleading once the same hook is reused for **read-only** synthetic attributes — which aws#280 needs for `QueueArn`.

This PR:

1. **Renames** `ResourceDef::extra_writable` → `ResourceDef::extra_attributes`. Updates every call-site in `carina-codegen-aws/src/{resource_defs.rs,main.rs}`, the internal locals `extra_writable_descs` / `is_synthetic_extra_writable`, the relevant comments, and the three references in `docs/specs/2026-04-14-schema-structure-codegen.md`. The user-facing struct `ExtraField` is already neutral and keeps its name.

2. **Honors `read_only_overrides` for synthetic attributes**: in `main.rs` the synthetic-attribute loop hard-coded `is_read_only: false`. Now it consults `read_only_overrides` the way Smithy-grounded fields already do. Same fix mirrored on the markdown-emit side (a `read_only_overrides`-listed synthetic now lands in the read-only table instead of the writable table).

The new read-only path has **no in-tree users yet** — every current `extra_attributes` entry is either non-synthetic (has `read_source: Some(...)`) or absent from `read_only_overrides`. aws#280 will be the first user. Behaviour for every existing resource is identical, confirmed by empty regen diffs:

- `./scripts/generate-schemas-smithy.sh` → empty diff under `carina-provider-aws/src/schemas/`.
- `./scripts/generate-provider.sh` → empty diff for `provider_generated.rs`.

## Test plan

- [x] `cargo nextest run -p carina-codegen-aws` — 63 passed, 0 failed
- [x] `cargo nextest run --workspace` — 359 passed, 0 failed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/generate-schemas-smithy.sh && git diff carina-provider-aws/src/schemas/` — empty
- [x] `./scripts/generate-provider.sh && git diff carina-provider-aws/src/provider_generated.rs` — empty

## What's next

aws#280 will add `aws.sqs.Queue` on top of this rename, using `extra_attributes: vec![...]` with one read-only entry (`QueueArn`) and four writable entries (`VisibilityTimeout`, `MessageRetentionPeriod`, `DelaySeconds`, `MaximumMessageSize`).
