### PR TITLE
codegen: emit .read_only() for AttrInfo::is_read_only fields (#283)

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -983,6 +983,9 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         if attr.is_create_only {
             attr_code.push_str("\n\x20               .create_only()");
         }
+        if attr.is_read_only {
+            attr_code.push_str("\n\x20               .read_only()");
+        }
         if attr.is_identity {
             attr_code.push_str("\n\x20               .identity()");
         }

--- a/carina-provider-aws/src/schemas/generated/acm/certificate.rs
+++ b/carina-provider-aws/src/schemas/generated/acm/certificate.rs
@@ -196,6 +196,7 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("certificate_arn", super::arn())
+                .read_only()
                 .with_description("The Amazon Resource Name (ARN) of the certificate. For more information about ARNs, see Amazon Resource Names (ARNs) in the Amazon Web Services Genera... (read-only)")
                 .with_provider_name("CertificateArn"),
         )
@@ -206,6 +207,7 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
                 namespace: Some("aws.acm.Certificate".to_string()),
                 dsl_aliases: vec![("ELIGIBLE".to_string(), "eligible".to_string()), ("INELIGIBLE".to_string(), "ineligible".to_string())],
             })
+                .read_only()
                 .with_description("Specifies whether the certificate is eligible for renewal. At this time, only exported private certificates can be renewed with the RenewCertificate c... (read-only)")
                 .with_provider_name("RenewalEligibility"),
         )
@@ -268,6 +270,7 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
                     StructField::new("updated_at", AttributeType::String).required().with_description("The time at which the renewal summary was last updated.").with_provider_name("UpdatedAt")
                     ],
                 })
+                .read_only()
                 .with_description("Contains information about the status of ACM's managed renewal for the certificate. This field exists only when the certificate type is AMAZON_ISSUED. (read-only)")
                 .with_provider_name("RenewalSummary"),
         )
@@ -278,6 +281,7 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
                 namespace: Some("aws.acm.Certificate".to_string()),
                 dsl_aliases: vec![("EXPIRED".to_string(), "expired".to_string()), ("FAILED".to_string(), "failed".to_string()), ("INACTIVE".to_string(), "inactive".to_string()), ("ISSUED".to_string(), "issued".to_string()), ("PENDING_VALIDATION".to_string(), "pending_validation".to_string()), ("REVOKED".to_string(), "revoked".to_string()), ("VALIDATION_TIMED_OUT".to_string(), "validation_timed_out".to_string())],
             })
+                .read_only()
                 .with_description("The status of the certificate. A certificate enters status PENDING_VALIDATION upon being requested, unless it fails for any of the reasons given in th... (read-only)")
                 .with_provider_name("Status"),
         )
@@ -288,6 +292,7 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
                 namespace: Some("aws.acm.Certificate".to_string()),
                 dsl_aliases: vec![("AMAZON_ISSUED".to_string(), "amazon_issued".to_string()), ("IMPORTED".to_string(), "imported".to_string()), ("PRIVATE".to_string(), "private".to_string())],
             })
+                .read_only()
                 .with_description("The source of the certificate. For certificates provided by ACM, this value is AMAZON_ISSUED. For certificates that you imported with ImportCertificat... (read-only)")
                 .with_provider_name("Type"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
@@ -31,6 +31,7 @@ pub fn ec2_egress_only_internet_gateway_config() -> AwsSchemaConfig {
                     "egress_only_internet_gateway_id",
                     super::egress_only_internet_gateway_id(),
                 )
+                .read_only()
                 .with_description("The ID of the egress-only internet gateway. (read-only)")
                 .with_provider_name("EgressOnlyInternetGatewayId"),
             )

--- a/carina-provider-aws/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/eip.rs
@@ -44,11 +44,13 @@ pub fn ec2_eip_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("allocation_id", super::allocation_id())
+                .read_only()
                 .with_description("The ID representing the allocation of the address. (read-only)")
                 .with_provider_name("AllocationId"),
         )
         .attribute(
             AttributeSchema::new("public_ip", types::ipv4_address())
+                .read_only()
                 .with_description("The Elastic IP address. (read-only)")
                 .with_provider_name("PublicIp"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -115,6 +115,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("flow_log_id", AttributeType::String)
+                .read_only()
                 .with_description("The ID of the flow log. (read-only)")
                 .with_provider_name("FlowLogId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
@@ -25,6 +25,7 @@ pub fn ec2_internet_gateway_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("internet_gateway_id", super::internet_gateway_id())
+                .read_only()
                 .with_description("The ID of the internet gateway. (read-only)")
                 .with_provider_name("InternetGatewayId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/nat_gateway.rs
@@ -83,6 +83,7 @@ pub fn ec2_nat_gateway_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("nat_gateway_id", super::nat_gateway_id())
+                .read_only()
                 .with_description("The ID of the NAT gateway. (read-only)")
                 .with_provider_name("NatGatewayId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
@@ -26,6 +26,7 @@ pub fn ec2_route_table_config() -> AwsSchemaConfig {
             )
             .attribute(
                 AttributeSchema::new("route_table_id", super::route_table_id())
+                    .read_only()
                     .with_description("The ID of the route table. (read-only)")
                     .with_provider_name("RouteTableId"),
             )

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
@@ -39,6 +39,7 @@ pub fn ec2_security_group_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("group_id", super::security_group_id())
+                .read_only()
                 .with_description("The ID of the security group. (read-only)")
                 .with_provider_name("GroupId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -158,6 +158,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
             )
             .attribute(
                 AttributeSchema::new("security_group_rule_id", super::security_group_rule_id())
+                    .read_only()
                     .with_description("The ID of the security group rule. (read-only)")
                     .with_provider_name("SecurityGroupRuleId"),
             ),

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -140,6 +140,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("security_group_rule_id", super::security_group_rule_id())
+                .read_only()
                 .with_description("The ID of the security group rule. (read-only)")
                 .with_provider_name("SecurityGroupRuleId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -168,6 +168,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("subnet_id", super::subnet_id())
+                .read_only()
                 .with_description("The ID of the subnet. (read-only)")
                 .with_provider_name("SubnetId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
@@ -92,6 +92,7 @@ pub fn ec2_transit_gateway_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("transit_gateway_id", super::transit_gateway_id())
+                .read_only()
                 .with_description("The ID of the transit gateway. (read-only)")
                 .with_provider_name("TransitGatewayId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -82,6 +82,7 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("transit_gateway_attachment_id", AttributeType::String)
+                .read_only()
                 .with_description("The ID of the attachment. (read-only)")
                 .with_provider_name("TransitGatewayAttachmentId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -83,6 +83,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
+                .read_only()
                 .with_description("The ID of the VPC. (read-only)")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -103,6 +103,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("vpc_endpoint_id", super::vpc_endpoint_id())
+                .read_only()
                 .with_description("The ID of the endpoint. (read-only)")
                 .with_provider_name("VpcEndpointId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -39,6 +39,7 @@ pub fn ec2_vpc_peering_connection_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("vpc_peering_connection_id", super::vpc_peering_connection_id())
+                .read_only()
                 .with_description("The ID of the VPC peering connection. (read-only)")
                 .with_provider_name("VpcPeeringConnectionId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
@@ -45,6 +45,7 @@ pub fn ec2_vpn_gateway_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("vpn_gateway_id", super::vpn_gateway_id())
+                .read_only()
                 .with_description("The ID of the virtual private gateway. (read-only)")
                 .with_provider_name("VpnGatewayId"),
         )

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -72,11 +72,13 @@ pub fn iam_role_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("arn", super::iam_role_arn())
+                .read_only()
                 .with_description("The Amazon Resource Name (ARN) specifying the role. For more information about ARNs and how to use them in policies, see IAM identifiers in the IAM Us... (read-only)")
                 .with_provider_name("Arn"),
         )
         .attribute(
             AttributeSchema::new("role_id", super::iam_role_id())
+                .read_only()
                 .with_description("The stable and unique string identifying the role. For more information about IDs, see IAM identifiers in the IAM User Guide. (read-only)")
                 .with_provider_name("RoleId"),
         )

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -63,11 +63,13 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("arn", super::arn())
+                .read_only()
                 .with_description("The Amazon Resource Name (ARN) of the account. For more information about ARNs in Organizations, see ARN Formats Supported by Organizations in the Ama... (read-only)")
                 .with_provider_name("Arn"),
         )
         .attribute(
             AttributeSchema::new("id", AttributeType::String)
+                .read_only()
                 .with_description("The unique identifier (ID) of the account. The regex pattern for an account ID string requires exactly 12 digits. (read-only)")
                 .with_provider_name("Id"),
         )
@@ -78,16 +80,19 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
                 namespace: Some("aws.organizations.Account".to_string()),
                 dsl_aliases: vec![("CREATED".to_string(), "created".to_string()), ("INVITED".to_string(), "invited".to_string())],
             })
+                .read_only()
                 .with_description("The method by which the account joined the organization. (read-only)")
                 .with_provider_name("JoinedMethod"),
         )
         .attribute(
             AttributeSchema::new("joined_timestamp", AttributeType::String)
+                .read_only()
                 .with_description("The date the account became a part of the organization. (read-only)")
                 .with_provider_name("JoinedTimestamp"),
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
+                .read_only()
                 .with_description("The friendly name of the account. The regex pattern that is used to validate this parameter is a string of any of the characters in the ASCII characte... (read-only)")
                 .with_provider_name("Name"),
         )
@@ -98,6 +103,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
                 namespace: Some("aws.organizations.Account".to_string()),
                 dsl_aliases: vec![("ACTIVE".to_string(), "active".to_string()), ("PENDING_CLOSURE".to_string(), "pending_closure".to_string()), ("SUSPENDED".to_string(), "suspended".to_string())],
             })
+                .read_only()
                 .with_description("The status of the account in the organization. The Status parameter in the Account object will be retired on September 9, 2026. Although both the acco... (read-only)")
                 .with_provider_name("Status"),
         )

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -30,26 +30,31 @@ pub fn organizations_organization_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("arn", super::arn())
+                .read_only()
                 .with_description("The Amazon Resource Name (ARN) of an organization. For more information about ARNs in Organizations, see ARN Formats Supported by Organizations in the... (read-only)")
                 .with_provider_name("Arn"),
         )
         .attribute(
             AttributeSchema::new("id", AttributeType::String)
+                .read_only()
                 .with_description("The unique identifier (ID) of an organization. The regex pattern for an organization ID string requires \"o-\" followed by from 10 to 32 lowercase let... (read-only)")
                 .with_provider_name("Id"),
         )
         .attribute(
             AttributeSchema::new("master_account_arn", super::arn())
+                .read_only()
                 .with_description("The Amazon Resource Name (ARN) of the account that is designated as the management account for the organization. For more information about ARNs in Or... (read-only)")
                 .with_provider_name("MasterAccountArn"),
         )
         .attribute(
             AttributeSchema::new("master_account_email", types::email())
+                .read_only()
                 .with_description("The email address that is associated with the Amazon Web Services account that is designated as the management account for the organization. (read-only)")
                 .with_provider_name("MasterAccountEmail"),
         )
         .attribute(
             AttributeSchema::new("master_account_id", super::aws_account_id())
+                .read_only()
                 .with_description("The unique identifier (ID) of the management account of an organization. The regex pattern for an account ID string requires exactly 12 digits. (read-only)")
                 .with_provider_name("MasterAccountId"),
         )


### PR DESCRIPTION
## Summary

Closes #283. Follow-on to aws#282. Prereq for aws#280.

`carina-codegen-aws` computes `AttrInfo::is_read_only` correctly (since aws#282), but the schema emitter only appended a `(read-only)` text suffix to the description — the `.read_only()` builder call on `AttributeSchema` was never emitted. This PR closes the gap.

## Changes

- `carina-codegen-aws/src/main.rs`: emit `.read_only()` after `.create_only()` when `AttrInfo::is_read_only` is true (3-line addition).
- `carina-provider-aws/src/schemas/generated/**` (19 files, 35 attribute insertions): mechanical regen output. Every added `.read_only()` is on an attribute that already carried the `(read-only)` description suffix. The pre-existing description suffix is kept (belt-and-suspenders; harmless and informational).

Resources / attributes affected:
- acm/certificate: 5
- ec2/* (vpc, subnet, eip, nat_gateway, vpc_endpoint, etc.): 16 (mostly 1 each, eip has 2)
- iam/role: 2
- organizations/account: 6
- organizations/organization: 5

## Visible effect

Plan display now groups these attributes under the read-only detail section via `detail_rows.rs:463` (`compute_read_only_attrs()` consumes the schema flag). No `.crn` validation behavior change today — `validator/*.rs` and `differ/*.rs` do not yet enforce "user cannot write to a read_only attribute".

## Out of scope

- Data-source attributes (`sts.caller_identity`, etc.) are untouched. They ride on resource-level `Resource::with_read_only(true)` rather than per-attribute flag, so the codegen `is_read_only` is false on them today and no `.read_only()` is emitted. Separate gap if desired.

## Unblocks

aws#280 (`aws.sqs.Queue`): the synthetic `QueueArn` attribute, marked via `read_only_overrides` per aws#282, will now actually carry the schema flag.

## Test plan

- [x] `cargo nextest run -p carina-codegen-aws` — 63 passed
- [x] `cargo nextest run --workspace` — 359 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `./scripts/generate-schemas-smithy.sh && git status` — diff matches the 19 expected files; no other regen drift
- [x] 5-round self-review — PASS, no blockers
