### PR TITLE
Add aws.sqs.Queue resource (#280)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-sqs"
+version = "1.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d497fb382b906b04167e62848ad00e56c5ad523791a461d5a5611c186531d81"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sts"
 version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,7 +689,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
+source = "git+https://github.com/carina-rs/carina?rev=5bd1000e#5bd1000ebd45a69c4531422224fda8deaa2997cf"
 dependencies = [
  "argon2",
  "futures",
@@ -683,7 +707,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
+source = "git+https://github.com/carina-rs/carina?rev=5bd1000e#5bd1000ebd45a69c4531422224fda8deaa2997cf"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -708,6 +732,7 @@ dependencies = [
  "aws-sdk-organizations",
  "aws-sdk-route53",
  "aws-sdk-s3",
+ "aws-sdk-sqs",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -730,7 +755,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
+source = "git+https://github.com/carina-rs/carina?rev=5bd1000e#5bd1000ebd45a69c4531422224fda8deaa2997cf"
 dependencies = [
  "serde",
  "serde_json",

--- a/acceptance-tests/sqs_queue/basic.crn
+++ b/acceptance-tests/sqs_queue/basic.crn
@@ -1,0 +1,20 @@
+# SQS Queue - Basic test
+#
+# Tests: queue creation with the four writable numeric attributes,
+# tags, and the read-back of `queue_arn`.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+aws.sqs.Queue {
+  queue_name               = 'carina-acc-test-aws-sqs-queue-basic-v1'
+  visibility_timeout       = 60
+  message_retention_period = 86400
+  delay_seconds            = 0
+  maximum_message_size     = 262144
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "5bd1000e" }

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -225,6 +225,7 @@ fn main() -> Result<()> {
     all_resources.extend(resource_defs::iam_resources());
     all_resources.extend(resource_defs::logs_resources());
     all_resources.extend(resource_defs::acm_resources());
+    all_resources.extend(resource_defs::sqs_resources());
 
     // Collect all data source definitions
     let mut all_data_sources = resource_defs::sts_data_sources();
@@ -4031,6 +4032,7 @@ fn cf_type_name(resource_name: &str) -> &'static str {
         "logs.LogGroup" => "AWS::Logs::LogGroup",
         "identitystore.User" => "AWS::IdentityStore::User",
         "acm.Certificate" => "AWS::CertificateManager::Certificate",
+        "sqs.Queue" => "AWS::SQS::Queue",
         _ => panic!(
             "Unknown resource: {}. Add it to cf_type_name().",
             resource_name

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -2191,6 +2191,100 @@ pub fn logs_resources() -> Vec<ResourceDef> {
     }]
 }
 
+/// Returns SQS resource definitions.
+///
+/// SQS does not expose its mutable knobs as flat fields on `CreateQueue`;
+/// they live inside an `Attributes: Map<QueueAttributeName, String>`.
+/// We pick the Carina-supported subset and surface them as flat top-level
+/// attributes (`visibility_timeout`, `message_retention_period`, etc.).
+/// The map↔flat packing/unpacking happens in the hand-written
+/// `services/sqs/queue.rs`; the codegen here only emits the schema shape.
+pub fn sqs_resources() -> Vec<ResourceDef> {
+    vec![ResourceDef {
+        name: "sqs.Queue",
+        service_namespace: "com.amazonaws.sqs",
+        schema_structure: None,
+        simple_delete: true,
+        noop_update: false,
+        create_op: "CreateQueue",
+        // `GetQueueAttributes` returns a Map, not a structure — the read
+        // path is hand-written in `services/sqs/queue.rs`. The codegen's
+        // `extract_*_attributes` emission skips this resource via the
+        // `manual_methods` scan (it finds `extract_sqs_queue_attributes`).
+        read_structure: None,
+        read_ops: vec![],
+        delete_op: "DeleteQueue",
+        // `SetQueueAttributes` is the update path. Listing the synthetic
+        // attribute names here marks them updatable on the schema side.
+        update_ops: vec![UpdateOp {
+            operation: "SetQueueAttributes",
+            fields: FieldLayout::Flat(vec![
+                "VisibilityTimeout",
+                "MessageRetentionPeriod",
+                "DelaySeconds",
+                "MaximumMessageSize",
+            ]),
+        }],
+        identifier: "QueueUrl",
+        has_tags: true,
+        type_overrides: vec![
+            ("QueueArn", "super::arn()"),
+            ("VisibilityTimeout", "AttributeType::Int"),
+            ("MessageRetentionPeriod", "AttributeType::Int"),
+            ("DelaySeconds", "AttributeType::Int"),
+            ("MaximumMessageSize", "AttributeType::Int"),
+        ],
+        // Keep the raw `Attributes` map out of the schema; the synthetic
+        // entries below project the keys we care about.
+        exclude_fields: vec!["Attributes"],
+        create_only_overrides: vec!["QueueName"],
+        enum_aliases: vec![],
+        to_dsl_overrides: vec![],
+        required_overrides: vec![],
+        extra_read_only: vec![],
+        // Marks `QueueArn` (a synthetic `extra_attributes` entry) as
+        // read-only. Honored by codegen after aws#282.
+        read_only_overrides: vec!["QueueArn"],
+        extra_attributes: vec![
+            ExtraField {
+                name: "VisibilityTimeout",
+                read_source: None,
+                description: Some(
+                    "The visibility timeout for the queue, in seconds. Defaults to 30. Range 0–43,200.",
+                ),
+            },
+            ExtraField {
+                name: "MessageRetentionPeriod",
+                read_source: None,
+                description: Some(
+                    "The length of time, in seconds, for which Amazon SQS retains a message. Defaults to 345,600 (4 days). Range 60–1,209,600 (1 minute–14 days).",
+                ),
+            },
+            ExtraField {
+                name: "DelaySeconds",
+                read_source: None,
+                description: Some(
+                    "The length of time, in seconds, for which the delivery of all messages in the queue is delayed. Defaults to 0. Range 0–900 (15 minutes).",
+                ),
+            },
+            ExtraField {
+                name: "MaximumMessageSize",
+                read_source: None,
+                description: Some(
+                    "The limit of how many bytes a message can contain before Amazon SQS rejects it. Defaults to 262,144 (256 KiB). Range 1,024–262,144 (1–256 KiB).",
+                ),
+            },
+            ExtraField {
+                name: "QueueArn",
+                read_source: None,
+                description: Some("The Amazon Resource Name (ARN) of the queue."),
+            },
+        ],
+        identity_overrides: vec![],
+        derived_attributes: vec![],
+    }]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "5bd1000e" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "5bd1000e" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "5bd1000e" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
@@ -37,6 +37,7 @@ aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-v
 aws-sdk-identitystore = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-route53 = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-acm = { version = "1", default-features = false, features = ["behavior-version-latest"] }
+aws-sdk-sqs = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -27,6 +27,7 @@ use aws_sdk_identitystore::Client as IdentityStoreClient;
 use aws_sdk_organizations::Client as OrganizationsClient;
 use aws_sdk_route53::Client as Route53Client;
 use aws_sdk_s3::Client as S3Client;
+use aws_sdk_sqs::Client as SqsClient;
 use aws_sdk_sts::Client as StsClient;
 
 /// AWS Provider
@@ -40,6 +41,7 @@ pub struct AwsProvider {
     identitystore_client: IdentityStoreClient,
     route53_client: Route53Client,
     acm_client: AcmClient,
+    sqs_client: SqsClient,
     region: String,
     /// Provider-level allow-list of AWS account IDs. Empty means "no
     /// allow-list configured" (the check is skipped). Enforced once
@@ -78,6 +80,7 @@ impl AwsProvider {
             identitystore_client: IdentityStoreClient::new(&config),
             route53_client: Route53Client::new(&config),
             acm_client: AcmClient::new(&config),
+            sqs_client: SqsClient::new(&config),
             region: region.to_string(),
             allowed_account_ids,
             forbidden_account_ids,
@@ -114,6 +117,7 @@ impl AwsProvider {
         identitystore_client: IdentityStoreClient,
         route53_client: Route53Client,
         acm_client: AcmClient,
+        sqs_client: SqsClient,
         region: String,
     ) -> Self {
         Self {
@@ -126,6 +130,7 @@ impl AwsProvider {
             identitystore_client,
             route53_client,
             acm_client,
+            sqs_client,
             region,
             allowed_account_ids: Vec::new(),
             forbidden_account_ids: Vec::new(),

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -135,6 +135,7 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "acm.Certificate" => self.read_acm_certificate(&id, identifier.as_deref()).await,
+                "sqs.Queue" => self.read_sqs_queue(&id, identifier.as_deref()).await,
                 _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     id.resource_type
@@ -244,6 +245,7 @@ impl Provider for AwsProvider {
                 "logs.LogGroup" => self.create_logs_log_group(resource).await,
                 "route53.RecordSet" => self.create_route53_record_set(resource).await,
                 "acm.Certificate" => self.create_acm_certificate(resource).await,
+                "sqs.Queue" => self.create_sqs_queue(resource).await,
                 _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     resource.id.resource_type
@@ -399,6 +401,7 @@ impl Provider for AwsProvider {
                     self.update_acm_certificate(id, &identifier, &from, to)
                         .await
                 }
+                "sqs.Queue" => self.update_sqs_queue(id, &identifier, &from, to).await,
                 _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     id.resource_type
@@ -516,6 +519,7 @@ impl Provider for AwsProvider {
                 "logs.LogGroup" => self.delete_logs_log_group(id, &identifier).await,
                 "route53.RecordSet" => self.delete_route53_record_set(id, &identifier).await,
                 "acm.Certificate" => self.delete_acm_certificate(id, &identifier).await,
+                "sqs.Queue" => self.delete_sqs_queue(id, &identifier).await,
                 _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     id.resource_type

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -15,6 +15,7 @@ pub mod logs;
 pub mod organizations;
 pub mod route53;
 pub mod s3;
+pub mod sqs;
 pub mod sts;
 
 /// Returns all generated schema configs
@@ -60,6 +61,7 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         s3::bucket_server_side_encryption_configuration::s3_bucket_server_side_encryption_configuration_config(),
         s3::bucket_versioning::s3_bucket_versioning_config(),
         s3::bucket_website_configuration::s3_bucket_website_configuration_config(),
+        sqs::queue::sqs_queue_config(),
         sts::caller_identity::sts_caller_identity_config(),
     ]
 }
@@ -114,6 +116,7 @@ pub fn get_enum_valid_values(
         s3::bucket_server_side_encryption_configuration::enum_valid_values(),
         s3::bucket_versioning::enum_valid_values(),
         s3::bucket_website_configuration::enum_valid_values(),
+        sqs::queue::enum_valid_values(),
         sts::caller_identity::enum_valid_values(),
     ];
     for (rt, attrs) in modules {
@@ -251,6 +254,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "s3.BucketWebsiteConfiguration" {
         return s3::bucket_website_configuration::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "sqs.Queue" {
+        return sqs::queue::enum_alias_reverse(attr_name, value);
     }
     None
 }
@@ -526,6 +532,13 @@ pub fn build_enum_aliases_map() -> std::collections::HashMap<
     }
     for (attr, alias, canonical) in s3::bucket_website_configuration::enum_alias_entries() {
         map.entry("s3.BucketWebsiteConfiguration".to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .entry(attr.to_string())
+            .or_insert_with(std::collections::HashMap::new)
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in sqs::queue::enum_alias_entries() {
+        map.entry("sqs.Queue".to_string())
             .or_insert_with(std::collections::HashMap::new)
             .entry(attr.to_string())
             .or_insert_with(std::collections::HashMap::new)

--- a/carina-provider-aws/src/schemas/generated/sqs/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/sqs/mod.rs
@@ -1,0 +1,9 @@
+//! Auto-generated — DO NOT EDIT MANUALLY
+//!
+//! Regenerate with:
+//!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh
+
+// Re-export parent types so resource modules can use `super::` to access them.
+pub use super::*;
+
+pub mod queue;

--- a/carina-provider-aws/src/schemas/generated/sqs/queue.rs
+++ b/carina-provider-aws/src/schemas/generated/sqs/queue.rs
@@ -1,0 +1,86 @@
+//! sqs.Queue schema definition for AWS Cloud Control
+//!
+//! Auto-generated from Smithy model: com.amazonaws.sqs
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use super::tags_type;
+use super::validate_tags_map;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for sqs.Queue (Smithy: com.amazonaws.sqs)
+pub fn sqs_queue_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::SQS::Queue",
+        resource_type_name: "sqs.Queue",
+        has_tags: true,
+        schema: ResourceSchema::new("sqs.Queue")
+        .with_description("")
+        .attribute(
+            AttributeSchema::new("queue_name", AttributeType::String)
+                .required()
+                .create_only()
+                .with_description("The name of the new queue. The following limits apply to this name: A queue name can have up to 80 characters. Valid values: alphanumeric characters, ...")
+                .with_provider_name("QueueName"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", AttributeType::map(AttributeType::String))
+                .create_only()
+                .with_description("Add cost allocation tags to the specified Amazon SQS queue. For an overview, see Tagging Your Amazon SQS Queues in the Amazon SQS Developer Guide. Whe...")
+                .with_provider_name("tags"),
+        )
+        .attribute(
+            AttributeSchema::new("visibility_timeout", AttributeType::Int)
+                .with_description("The visibility timeout for the queue, in seconds. Defaults to 30. Range 0–43,200.")
+                .with_provider_name("VisibilityTimeout"),
+        )
+        .attribute(
+            AttributeSchema::new("message_retention_period", AttributeType::Int)
+                .with_description("The length of time, in seconds, for which Amazon SQS retains a message. Defaults to 345,600 (4 days). Range 60–1,209,600 (1 minute–14 days).")
+                .with_provider_name("MessageRetentionPeriod"),
+        )
+        .attribute(
+            AttributeSchema::new("delay_seconds", AttributeType::Int)
+                .with_description("The length of time, in seconds, for which the delivery of all messages in the queue is delayed. Defaults to 0. Range 0–900 (15 minutes).")
+                .with_provider_name("DelaySeconds"),
+        )
+        .attribute(
+            AttributeSchema::new("maximum_message_size", AttributeType::Int)
+                .with_description("The limit of how many bytes a message can contain before Amazon SQS rejects it. Defaults to 262,144 (256 KiB). Range 1,024–262,144 (1–256 KiB).")
+                .with_provider_name("MaximumMessageSize"),
+        )
+        .attribute(
+            AttributeSchema::new("queue_arn", super::arn())
+                .read_only()
+                .with_description("The Amazon Resource Name (ARN) of the queue. (read-only)")
+                .with_provider_name("QueueArn"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("The tags for the resource.")
+                .with_provider_name("Tags"),
+        )
+        .with_validator(validate_tags_map)
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("sqs.Queue", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-aws/src/services/mod.rs
+++ b/carina-provider-aws/src/services/mod.rs
@@ -6,4 +6,5 @@ pub mod logs;
 pub mod organizations;
 pub mod route53;
 pub mod s3;
+pub mod sqs;
 pub mod sts;

--- a/carina-provider-aws/src/services/sqs/mod.rs
+++ b/carina-provider-aws/src/services/sqs/mod.rs
@@ -1,0 +1,1 @@
+pub mod queue;

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -1,0 +1,322 @@
+//! Hand-written service implementation for `aws.sqs.Queue`.
+//!
+//! SQS exposes its mutable knobs through `Attributes: Map<QueueAttributeName,
+//! String>` on `CreateQueue` / `GetQueueAttributes` / `SetQueueAttributes`.
+//! Schema-side we project the supported subset (visibility_timeout,
+//! message_retention_period, delay_seconds, maximum_message_size, queue_arn)
+//! as flat top-level attributes via `extra_attributes` (see
+//! `carina-codegen-aws/src/resource_defs.rs::sqs_resources`); the
+//! pack/unpack lives here.
+
+use aws_sdk_sqs::types::QueueAttributeName;
+use indexmap::IndexMap;
+use std::collections::HashMap;
+
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+
+use crate::AwsProvider;
+use crate::helpers::{require_string_attr, sdk_error_message};
+
+/// Writable numeric attributes mapped 1:1 to SQS `QueueAttributeName`
+/// keys. Each entry is (DSL snake-case attribute name, SDK enum key).
+const WRITABLE_INT_ATTRS: &[(&str, QueueAttributeName)] = &[
+    ("visibility_timeout", QueueAttributeName::VisibilityTimeout),
+    (
+        "message_retention_period",
+        QueueAttributeName::MessageRetentionPeriod,
+    ),
+    ("delay_seconds", QueueAttributeName::DelaySeconds),
+    (
+        "maximum_message_size",
+        QueueAttributeName::MaximumMessageSize,
+    ),
+];
+
+impl AwsProvider {
+    /// Read an SQS Queue by its URL (the provider identifier).
+    pub(crate) async fn read_sqs_queue(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(queue_url) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        // Pull every attribute we surface in one round-trip.
+        let mut attr_names: Vec<QueueAttributeName> =
+            WRITABLE_INT_ATTRS.iter().map(|(_, n)| n.clone()).collect();
+        attr_names.push(QueueAttributeName::QueueArn);
+
+        let result = match self
+            .sqs_client
+            .get_queue_attributes()
+            .queue_url(queue_url)
+            .set_attribute_names(Some(attr_names))
+            .send()
+            .await
+        {
+            Ok(out) => out,
+            Err(err) => {
+                // Service treats a missing queue with a typed error variant.
+                if let Some(svc_err) = err.as_service_error()
+                    && svc_err.is_queue_does_not_exist()
+                {
+                    return Ok(State::not_found(id.clone()));
+                }
+                return Err(ProviderError::api_error(sdk_error_message(
+                    "Failed to get queue attributes",
+                    &err,
+                ))
+                .for_resource(id.clone()));
+            }
+        };
+
+        let mut attributes: HashMap<String, Value> = HashMap::new();
+
+        // Re-derive queue_name from the URL: SQS URLs end with `/{queue_name}`.
+        if let Some(name) = queue_url.rsplit('/').next() {
+            attributes.insert(
+                "queue_name".to_string(),
+                Value::Concrete(ConcreteValue::String(name.to_string())),
+            );
+        }
+
+        if let Some(map) = result.attributes() {
+            for (attr_name, sdk_key) in WRITABLE_INT_ATTRS {
+                if let Some(raw) = map.get(sdk_key)
+                    && let Ok(parsed) = raw.parse::<i64>()
+                {
+                    attributes.insert(
+                        attr_name.to_string(),
+                        Value::Concrete(ConcreteValue::Int(parsed)),
+                    );
+                }
+            }
+            if let Some(arn) = map.get(&QueueAttributeName::QueueArn) {
+                attributes.insert(
+                    "queue_arn".to_string(),
+                    Value::Concrete(ConcreteValue::String(arn.to_string())),
+                );
+            }
+        }
+
+        // Tags come from a separate API.
+        match self
+            .sqs_client
+            .list_queue_tags()
+            .queue_url(queue_url)
+            .send()
+            .await
+        {
+            Ok(tags_output) => {
+                if let Some(tags) = tags_output.tags()
+                    && !tags.is_empty()
+                {
+                    let mut tag_map = IndexMap::new();
+                    for (key, val) in tags {
+                        tag_map.insert(
+                            key.to_string(),
+                            Value::Concrete(ConcreteValue::String(val.to_string())),
+                        );
+                    }
+                    attributes.insert(
+                        "tags".to_string(),
+                        Value::Concrete(ConcreteValue::Map(tag_map)),
+                    );
+                }
+            }
+            Err(_) => {
+                // List-tags may fail with throttling or transient errors;
+                // skip rather than fail the whole read. Same pattern as
+                // logs.LogGroup.
+            }
+        }
+
+        let state = State::existing(id.clone(), attributes);
+        Ok(state.with_identifier(queue_url.to_string()))
+    }
+
+    /// Create an SQS Queue and return its post-create state.
+    pub(crate) async fn create_sqs_queue(&self, resource: Resource) -> ProviderResult<State> {
+        let queue_name = require_string_attr(&resource, "queue_name")?;
+
+        // Pack writable numeric attributes into the SQS map shape.
+        let mut attr_map: HashMap<QueueAttributeName, String> = HashMap::new();
+        for (attr_name, sdk_key) in WRITABLE_INT_ATTRS {
+            if let Some(Value::Concrete(ConcreteValue::Int(n))) = resource.get_attr(attr_name) {
+                attr_map.insert(sdk_key.clone(), n.to_string());
+            }
+        }
+
+        // Tags are passed as a separate parameter.
+        let tags = resource_tags_map(&resource);
+
+        let mut req = self.sqs_client.create_queue().queue_name(&queue_name);
+        if !attr_map.is_empty() {
+            req = req.set_attributes(Some(attr_map));
+        }
+        if let Some(tags) = tags {
+            req = req.set_tags(Some(tags));
+        }
+
+        let result = req.send().await.map_err(|e| {
+            ProviderError::api_error(sdk_error_message("Failed to create SQS queue", &e))
+                .for_resource(resource.id.clone())
+        })?;
+
+        let queue_url = result.queue_url().ok_or_else(|| {
+            ProviderError::api_error("CreateQueue returned no QueueUrl")
+                .for_resource(resource.id.clone())
+        })?;
+
+        self.read_sqs_queue(&resource.id, Some(queue_url)).await
+    }
+
+    /// Update an existing SQS Queue.
+    pub(crate) async fn update_sqs_queue(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        // Build the partial map of attributes that actually changed.
+        let mut attr_map: HashMap<QueueAttributeName, String> = HashMap::new();
+        for (attr_name, sdk_key) in WRITABLE_INT_ATTRS {
+            let desired = to.get_attr(attr_name);
+            let current = from.attributes.get(*attr_name);
+            if let Some(Value::Concrete(ConcreteValue::Int(n))) = desired
+                && current != desired
+            {
+                attr_map.insert(sdk_key.clone(), n.to_string());
+            }
+        }
+
+        if !attr_map.is_empty() {
+            self.sqs_client
+                .set_queue_attributes()
+                .queue_url(identifier)
+                .set_attributes(Some(attr_map))
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::api_error(sdk_error_message(
+                        "Failed to set queue attributes",
+                        &e,
+                    ))
+                    .for_resource(id.clone())
+                })?;
+        }
+
+        self.apply_sqs_tags(
+            &id,
+            identifier,
+            &to.resolved_attributes(),
+            Some(&from.attributes),
+        )
+        .await?;
+
+        self.read_sqs_queue(&id, Some(identifier)).await
+    }
+
+    /// Delete an SQS Queue.
+    pub(crate) async fn delete_sqs_queue(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        self.sqs_client
+            .delete_queue()
+            .queue_url(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::api_error(sdk_error_message("Failed to delete SQS queue", &e))
+                    .for_resource(id.clone())
+            })?;
+        Ok(())
+    }
+
+    /// Apply tag diff between desired and current state.
+    async fn apply_sqs_tags(
+        &self,
+        id: &ResourceId,
+        queue_url: &str,
+        desired: &HashMap<String, Value>,
+        current: Option<&HashMap<String, Value>>,
+    ) -> ProviderResult<()> {
+        let desired_tags = match desired.get("tags") {
+            Some(Value::Concrete(ConcreteValue::Map(m))) => m.clone(),
+            _ => IndexMap::new(),
+        };
+        let current_tags = match current.and_then(|c| c.get("tags")) {
+            Some(Value::Concrete(ConcreteValue::Map(m))) => m.clone(),
+            _ => IndexMap::new(),
+        };
+
+        let keys_to_remove: Vec<String> = current_tags
+            .keys()
+            .filter(|k| !desired_tags.contains_key(*k))
+            .cloned()
+            .collect();
+
+        if !keys_to_remove.is_empty() {
+            self.sqs_client
+                .untag_queue()
+                .queue_url(queue_url)
+                .set_tag_keys(Some(keys_to_remove))
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::api_error(sdk_error_message("Failed to untag SQS queue", &e))
+                        .for_resource(id.clone())
+                })?;
+        }
+
+        let mut tags_to_add: HashMap<String, String> = HashMap::new();
+        for (key, value) in &desired_tags {
+            if let Value::Concrete(ConcreteValue::String(val)) = value {
+                let should_add = match current_tags.get(key) {
+                    Some(Value::Concrete(ConcreteValue::String(current_val))) => current_val != val,
+                    _ => true,
+                };
+                if should_add {
+                    tags_to_add.insert(key.clone(), val.clone());
+                }
+            }
+        }
+
+        if !tags_to_add.is_empty() {
+            self.sqs_client
+                .tag_queue()
+                .queue_url(queue_url)
+                .set_tags(Some(tags_to_add))
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::api_error(sdk_error_message("Failed to tag SQS queue", &e))
+                        .for_resource(id.clone())
+                })?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Extract a `tags = { ... }` block from the resource, dropping any
+/// non-string values. Returns `None` when no tags are set so callers
+/// can leave the SDK builder untouched.
+fn resource_tags_map(resource: &Resource) -> Option<HashMap<String, String>> {
+    let Some(Value::Concrete(ConcreteValue::Map(tag_map))) = resource.get_attr("tags") else {
+        return None;
+    };
+    let mut out = HashMap::new();
+    for (key, value) in tag_map {
+        if let Value::Concrete(ConcreteValue::String(val)) = value {
+            out.insert(key.clone(), val.clone());
+        }
+    }
+    if out.is_empty() { None } else { Some(out) }
+}

--- a/examples/sqs_queue/main.crn
+++ b/examples/sqs_queue/main.crn
@@ -1,0 +1,13 @@
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+aws.sqs.Queue {
+  queue_name               = 'carina-example-queue'
+  visibility_timeout       = 60
+  message_retention_period = 86400
+
+  tags = {
+    Environment = 'example'
+  }
+}

--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-EXAMPLES_DIR="carina-provider-aws/examples"
+EXAMPLES_DIR="examples"
 
 # All resource types supported by the aws provider
 # (from carina-provider-aws/src/schemas/generated/mod.rs)
@@ -20,6 +20,7 @@ RESOURCE_TYPES=(
     "ec2_subnet"
     "ec2_vpc"
     "s3_bucket"
+    "sqs_queue"
     "sts_caller_identity"
 )
 

--- a/scripts/download-smithy-models.sh
+++ b/scripts/download-smithy-models.sh
@@ -33,5 +33,6 @@ download "iam"           "iam/service/2010-05-08/iam-2010-05-08.json"
 download "cloudwatchlogs" "cloudwatch-logs/service/2014-03-28/cloudwatch-logs-2014-03-28.json"
 download "identitystore"  "identitystore/service/2020-06-15/identitystore-2020-06-15.json"
 download "acm"            "acm/service/2015-12-08/acm-2015-12-08.json"
+download "sqs"            "sqs/service/2012-11-05/sqs-2012-11-05.json"
 
 echo "Done."


### PR DESCRIPTION
## Summary

Closes #280. Adds `aws.sqs.Queue` as a new SDK-direct resource in `carina-provider-aws`. Unblocks #278 (S3 BucketNotificationConfiguration fixture currently references an SQS queue ARN that nothing provisions).

## Surface

| Attribute | Type | Lifecycle | Notes |
|-----------|------|-----------|-------|
| `queue_name` | String | required, create-only | |
| `visibility_timeout` | Int | optional, writable | seconds, 0–43,200 |
| `message_retention_period` | Int | optional, writable | seconds, 60–1,209,600 |
| `delay_seconds` | Int | optional, writable | seconds, 0–900 |
| `maximum_message_size` | Int | optional, writable | bytes, 1,024–262,144 |
| `tags` | Map<String,String> | optional, writable | |
| `queue_arn` | String (arn) | read-only | populated on read |
| `queue_url` | — | identifier | returned by CreateQueue |

## Implementation shape

- **codegen** (`carina-codegen-aws`): new `sqs_resources()` ResourceDef. The four numeric attrs and `queue_arn` are declared as `extra_attributes` synthetic fields (because SQS's `CreateQueue` / `GetQueueAttributes` use `Attributes: Map<QueueAttributeName, String>` rather than flat fields). `read_only_overrides: ["QueueArn"]` marks the ARN as read-only — relies on aws#282 (synthetic-flag honoring) and aws#284 (`.read_only()` emit).
- **service** (`carina-provider-aws/src/services/sqs/queue.rs`): hand-written create / read / update / delete + tag diff. The map↔flat packing/unpacking lives here. Uses `aws_sdk_sqs::types::QueueAttributeName` enum at every API boundary (no string literals).
- **dispatch**: `provider.rs` gains 4 arms (read/create/update/delete) for `"sqs.Queue"`.
- **wiring**: `Cargo.toml` adds `aws-sdk-sqs`; `lib.rs` adds an `sqs_client` field and threads it through both constructors.
- **fixtures**: `acceptance-tests/sqs_queue/basic.crn`, `examples/sqs_queue/main.crn`.
- **docs**: `generated-docs/aws/sqs/queue.md` regenerated via `aws-vault exec mizzy -- ./scripts/generate-docs.sh`.

## Out of scope (deferred)

- FIFO queue features (`FifoQueue`, `ContentBasedDeduplication`, `DeduplicationScope`, `FifoThroughputLimit`).
- Dead-letter queue redrive policy (`RedrivePolicy`, `RedriveAllowPolicy`).
- KMS-managed SSE (`KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds`, `SqsManagedSseEnabled`).
- Cross-account queue `Policy`.
- aws#278 fixture rewrite — separate one-line PR after this merges.

## Pre-existing codegen quirk noted

The generated `sqs/queue.rs` declares `tags` twice (once from the Smithy `tags` member, once from `has_tags: true`). `HashMap::insert` makes the second `Tags` entry win — same quirk affects `logs.LogGroup`. Behavior is correct; cosmetic noise. Tracking separately, not blocking.

## Side fix

`scripts/check-examples.sh` had a stale `EXAMPLES_DIR="carina-provider-aws/examples"` path (legacy from the monorepo era) — the actual layout is `examples/<resource>/main.crn` at repo root. Fixed in passing so the new `sqs_queue` entry actually runs.

## Test plan

- [x] `cargo nextest run --workspace` — 359 passed
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — pass
- [x] `bash scripts/check-examples.sh` — pass
- [x] `bash scripts/check-docs-drift.sh` — pass
- [x] schema regen empty diff (existing resources unaffected); provider boilerplate regen empty diff
- [x] 5-round self-review — all PASS, no blockers
- [x] Carina pin bumped to include carina#2994 (table_elements 65536) — needed so the new WASM (now ~21k table elements after adding aws-sdk-sqs) can be instantiated by the host
- [ ] Acceptance run (`./acceptance-tests/run-tests.sh full sqs_queue`) — running

## Dependencies

This PR depends on three merged carina commits brought in via the pin bump in `Cargo.toml`:
- carina#2988 + 2989 + 2990 (already in the previous pin)
- carina#2994 (new — required for WASM instantiation post-`aws-sdk-sqs`)

And two merged aws commits already in main:
- aws#282 (`extra_attributes` rename + synthetic `read_only_overrides`)
- aws#284 (`.read_only()` builder emit)
