### PR TITLE
Add aws.sqs.Queue full attribute surface + iam policy converter idempotency fixes

### DIFF
--- a/acceptance-tests/s3_bucket_notification_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_notification_configuration/basic.crn
@@ -1,9 +1,8 @@
 # S3 BucketNotificationConfiguration - Basic test
 #
-# NOTE: this fixture references an SQS queue ARN that must already exist
-# (and grant s3.amazonaws.com permission to send messages) when running
-# the acceptance test. Carina does not yet manage SQS, so the queue is a
-# precondition rather than a fixture-managed resource.
+# Self-contained: the SQS queue is provisioned by the fixture itself,
+# with a queue policy that grants s3.amazonaws.com permission to send
+# messages for events on this specific bucket.
 
 provider aws {
   region = aws.Region.ap_northeast_1
@@ -13,13 +12,32 @@ let bucket = aws.s3.Bucket {
   bucket = 'carina-acc-test-aws-s3-bucket-notification-basic-v1'
 }
 
+let queue = aws.sqs.Queue {
+  queue_name = 'carina-acc-test-aws-s3-bucket-notification-queue'
+
+  policy = {
+    version = '2012-10-17'
+    statement = [
+      {
+        sid = 'AllowS3SendMessage'
+        effect = allow
+        principal = {
+          service = ['s3.amazonaws.com']
+        }
+        action = ['sqs:SendMessage']
+        resource = ['arn:aws:sqs:ap-northeast-1:*:carina-acc-test-aws-s3-bucket-notification-queue']
+      },
+    ]
+  }
+}
+
 aws.s3.BucketNotificationConfiguration {
   bucket = bucket.bucket
 
   queue_configurations = [
     {
       id = 'object-created'
-      queue_arn = 'arn:aws:sqs:ap-northeast-1:000000000000:carina-acc-test-aws-s3-bucket-notification-queue'
+      queue_arn = queue.queue_arn
       events = ['s3:ObjectCreated:*']
     },
   ]

--- a/acceptance-tests/sqs_queue/basic.crn
+++ b/acceptance-tests/sqs_queue/basic.crn
@@ -1,18 +1,35 @@
 # SQS Queue - Basic test
 #
-# Tests: queue creation with the four writable numeric attributes,
-# tags, and the read-back of `queue_arn`.
+# Tests: standard queue creation covering policy (IAM-shaped struct),
+# numeric knobs, long-polling, SSE-SQS, and tags.
 
 provider aws {
   region = aws.Region.ap_northeast_1
 }
 
 aws.sqs.Queue {
-  queue_name               = 'carina-acc-test-aws-sqs-queue-basic-v1'
-  visibility_timeout       = 60
-  message_retention_period = 86400
-  delay_seconds            = 0
-  maximum_message_size     = 262144
+  queue_name                          = 'carina-acc-test-aws-sqs-queue-basic-v1'
+  visibility_timeout                  = 60
+  message_retention_period            = 86400
+  delay_seconds                       = 0
+  maximum_message_size                = 262144
+  receive_message_wait_time_seconds   = 20
+  sqs_managed_sse_enabled             = true
+
+  policy = {
+    version = '2012-10-17'
+    statement = [
+      {
+        sid    = 'AllowSelf'
+        effect = allow
+        principal = {
+          aws = ['*']
+        }
+        action   = ['sqs:SendMessage']
+        resource = ['*']
+      },
+    ]
+  }
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/sqs_queue/fifo.crn
+++ b/acceptance-tests/sqs_queue/fifo.crn
@@ -1,0 +1,22 @@
+# SQS Queue - FIFO test
+#
+# Tests: FIFO queue (fifo_queue + content_based_deduplication +
+# deduplication_scope + fifo_throughput_limit). Queue name must end in
+# `.fifo`.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+aws.sqs.Queue {
+  queue_name                  = 'carina-acc-test-aws-sqs-queue-fifo-v1.fifo'
+  fifo_queue                  = true
+  content_based_deduplication = true
+  deduplication_scope         = 'messageGroup'
+  fifo_throughput_limit       = 'perMessageGroupId'
+  visibility_timeout          = 30
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1443,6 +1443,60 @@ pub fn iam_policy_document() -> AttributeType {
     }
 }
 
+/// SQS dead-letter queue redrive policy. Returned by the SQS API as a
+/// stringified JSON document under the `RedrivePolicy` queue attribute,
+/// but it is a fixed, narrow shape (target ARN + retry count) rather
+/// than an IAM-style policy — so it gets its own Struct rather than
+/// reusing `iam_policy_document()`.
+pub fn sqs_redrive_policy() -> AttributeType {
+    AttributeType::Struct {
+        name: "SqsRedrivePolicy".to_string(),
+        fields: vec![
+            StructField::new("dead_letter_target_arn", arn())
+                .with_provider_name("deadLetterTargetArn")
+                .required()
+                .with_description("ARN of the dead-letter queue to which Amazon SQS moves messages after `max_receive_count` is exceeded."),
+            StructField::new("max_receive_count", AttributeType::Int)
+                .with_provider_name("maxReceiveCount")
+                .required()
+                .with_description("Number of times a consumer can receive a message before it is moved to the dead-letter queue. Range 1–1,000."),
+        ],
+    }
+}
+
+/// `redrive_permission` enum used inside `sqs_redrive_allow_policy`.
+fn sqs_redrive_permission() -> AttributeType {
+    AttributeType::StringEnum {
+        name: "SqsRedrivePermission".to_string(),
+        values: vec![
+            "allowAll".to_string(),
+            "denyAll".to_string(),
+            "byQueue".to_string(),
+        ],
+        namespace: Some("aws.sqs.Queue".to_string()),
+        dsl_aliases: dsl_aliases_for(&["allowAll", "denyAll", "byQueue"]),
+    }
+}
+
+/// SQS redrive-allow policy. Controls which source queues may use this
+/// queue as their dead-letter destination. Distinct from
+/// `iam_policy_document()`: the shape is `{redrivePermission, sourceQueueArns?}`,
+/// not a generic IAM statement list.
+pub fn sqs_redrive_allow_policy() -> AttributeType {
+    AttributeType::Struct {
+        name: "SqsRedriveAllowPolicy".to_string(),
+        fields: vec![
+            StructField::new("redrive_permission", sqs_redrive_permission())
+                .with_provider_name("redrivePermission")
+                .required()
+                .with_description("Which source queues may redrive into this queue. `allowAll`: any queue in the account; `denyAll`: none; `byQueue`: only the ARNs in `source_queue_arns`."),
+            StructField::new("source_queue_arns", AttributeType::list(arn()))
+                .with_provider_name("sourceQueueArns")
+                .with_description("Up to 10 source queue ARNs permitted to redrive into this queue. Required when `redrive_permission` is `byQueue`."),
+        ],
+    }
+}
+
 /// SSE algorithm enum for `aws.s3.BucketServerSideEncryptionConfiguration`.
 fn s3_sse_algorithm() -> AttributeType {
     AttributeType::StringEnum {

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -2195,10 +2195,15 @@ pub fn logs_resources() -> Vec<ResourceDef> {
 ///
 /// SQS does not expose its mutable knobs as flat fields on `CreateQueue`;
 /// they live inside an `Attributes: Map<QueueAttributeName, String>`.
-/// We pick the Carina-supported subset and surface them as flat top-level
-/// attributes (`visibility_timeout`, `message_retention_period`, etc.).
-/// The map↔flat packing/unpacking happens in the hand-written
+/// We surface every `QueueAttributeName` variant as a flat top-level
+/// attribute. The map↔flat packing/unpacking happens in the hand-written
 /// `services/sqs/queue.rs`; the codegen here only emits the schema shape.
+///
+/// Variants intentionally skipped (per
+/// `feedback_resource_unit_complete_attrs.md` we surface "every attribute
+/// the API exposes" — these are the genuinely non-attribute entries):
+/// - `All`: meta marker used by `GetQueueAttributes` to mean "fetch
+///   everything". Not a queue attribute itself.
 pub fn sqs_resources() -> Vec<ResourceDef> {
     vec![ResourceDef {
         name: "sqs.Queue",
@@ -2214,38 +2219,87 @@ pub fn sqs_resources() -> Vec<ResourceDef> {
         read_structure: None,
         read_ops: vec![],
         delete_op: "DeleteQueue",
-        // `SetQueueAttributes` is the update path. Listing the synthetic
-        // attribute names here marks them updatable on the schema side.
+        // Every queue attribute SetQueueAttributes accepts goes here.
+        // Listing them marks them updatable on the schema side; the
+        // immutable ones (FifoQueue, FifoThroughputLimit, DeduplicationScope)
+        // are forced create-only via `create_only_overrides`.
         update_ops: vec![UpdateOp {
             operation: "SetQueueAttributes",
             fields: FieldLayout::Flat(vec![
+                "Policy",
                 "VisibilityTimeout",
+                "MaximumMessageSize",
                 "MessageRetentionPeriod",
                 "DelaySeconds",
-                "MaximumMessageSize",
+                "ReceiveMessageWaitTimeSeconds",
+                "RedrivePolicy",
+                "RedriveAllowPolicy",
+                "ContentBasedDeduplication",
+                "KmsMasterKeyId",
+                "KmsDataKeyReusePeriodSeconds",
+                "SqsManagedSseEnabled",
             ]),
         }],
         identifier: "QueueUrl",
         has_tags: true,
         type_overrides: vec![
             ("QueueArn", "super::arn()"),
+            ("KmsMasterKeyId", "super::kms_key_id()"),
+            ("Policy", "super::iam_policy_document()"),
+            ("RedrivePolicy", "super::sqs_redrive_policy()"),
+            ("RedriveAllowPolicy", "super::sqs_redrive_allow_policy()"),
             ("VisibilityTimeout", "AttributeType::Int"),
+            ("MaximumMessageSize", "AttributeType::Int"),
             ("MessageRetentionPeriod", "AttributeType::Int"),
             ("DelaySeconds", "AttributeType::Int"),
-            ("MaximumMessageSize", "AttributeType::Int"),
+            ("ReceiveMessageWaitTimeSeconds", "AttributeType::Int"),
+            ("KmsDataKeyReusePeriodSeconds", "AttributeType::Int"),
+            ("FifoQueue", "AttributeType::Bool"),
+            ("ContentBasedDeduplication", "AttributeType::Bool"),
+            ("SqsManagedSseEnabled", "AttributeType::Bool"),
+            ("ApproximateNumberOfMessages", "AttributeType::Int"),
+            ("ApproximateNumberOfMessagesDelayed", "AttributeType::Int"),
+            (
+                "ApproximateNumberOfMessagesNotVisible",
+                "AttributeType::Int",
+            ),
+            ("CreatedTimestamp", "AttributeType::Int"),
+            ("LastModifiedTimestamp", "AttributeType::Int"),
         ],
         // Keep the raw `Attributes` map out of the schema; the synthetic
-        // entries below project the keys we care about.
+        // entries below project every QueueAttributeName key.
         exclude_fields: vec!["Attributes"],
-        create_only_overrides: vec!["QueueName"],
+        // FifoQueue, FifoThroughputLimit, and DeduplicationScope cannot be
+        // changed after the queue is created — AWS rejects SetQueueAttributes
+        // for these.
+        create_only_overrides: vec![
+            "QueueName",
+            "FifoQueue",
+            "FifoThroughputLimit",
+            "DeduplicationScope",
+        ],
         enum_aliases: vec![],
         to_dsl_overrides: vec![],
         required_overrides: vec![],
         extra_read_only: vec![],
-        // Marks `QueueArn` (a synthetic `extra_attributes` entry) as
-        // read-only. Honored by codegen after aws#282.
-        read_only_overrides: vec!["QueueArn"],
+        // QueueArn + the runtime counters and timestamps are read-only.
+        read_only_overrides: vec![
+            "QueueArn",
+            "ApproximateNumberOfMessages",
+            "ApproximateNumberOfMessagesDelayed",
+            "ApproximateNumberOfMessagesNotVisible",
+            "CreatedTimestamp",
+            "LastModifiedTimestamp",
+        ],
         extra_attributes: vec![
+            // Writable / mutable knobs
+            ExtraField {
+                name: "Policy",
+                read_source: None,
+                description: Some(
+                    "The queue's access policy, as a JSON-encoded IAM policy document.",
+                ),
+            },
             ExtraField {
                 name: "VisibilityTimeout",
                 read_source: None,
@@ -2275,9 +2329,115 @@ pub fn sqs_resources() -> Vec<ResourceDef> {
                 ),
             },
             ExtraField {
+                name: "ReceiveMessageWaitTimeSeconds",
+                read_source: None,
+                description: Some(
+                    "The duration, in seconds, for which a ReceiveMessage call waits for a message to arrive (long polling). Defaults to 0. Range 0–20.",
+                ),
+            },
+            ExtraField {
+                name: "RedrivePolicy",
+                read_source: None,
+                description: Some(
+                    "Dead-letter queue redrive policy, as a JSON document with `deadLetterTargetArn` and `maxReceiveCount` keys.",
+                ),
+            },
+            ExtraField {
+                name: "RedriveAllowPolicy",
+                read_source: None,
+                description: Some(
+                    "Permissions for source queues that can use this queue as their dead-letter destination, as a JSON document.",
+                ),
+            },
+            // FIFO-specific (all create-only except ContentBasedDeduplication)
+            ExtraField {
+                name: "FifoQueue",
+                read_source: None,
+                description: Some(
+                    "Whether the queue is FIFO. Create-only. The queue name must end with `.fifo` when true.",
+                ),
+            },
+            ExtraField {
+                name: "ContentBasedDeduplication",
+                read_source: None,
+                description: Some(
+                    "FIFO only: enables content-based message deduplication using a SHA-256 hash of the message body.",
+                ),
+            },
+            ExtraField {
+                name: "DeduplicationScope",
+                read_source: None,
+                description: Some(
+                    "FIFO only, create-only: scope of message deduplication. Valid values: `messageGroup`, `queue`.",
+                ),
+            },
+            ExtraField {
+                name: "FifoThroughputLimit",
+                read_source: None,
+                description: Some(
+                    "FIFO only, create-only: per-queue or per-message-group throughput limit. Valid values: `perQueue`, `perMessageGroupId`.",
+                ),
+            },
+            // KMS encryption
+            ExtraField {
+                name: "KmsMasterKeyId",
+                read_source: None,
+                description: Some(
+                    "The ID of an AWS KMS customer master key (CMK) to use for server-side encryption (SSE-KMS). Use `alias/aws/sqs` for the AWS-managed key.",
+                ),
+            },
+            ExtraField {
+                name: "KmsDataKeyReusePeriodSeconds",
+                read_source: None,
+                description: Some(
+                    "Length of time, in seconds, that SQS can reuse a data key before invoking KMS again. Defaults to 300 (5 minutes). Range 60–86,400.",
+                ),
+            },
+            ExtraField {
+                name: "SqsManagedSseEnabled",
+                read_source: None,
+                description: Some(
+                    "Enables SQS-managed server-side encryption (SSE-SQS). Mutually exclusive with KmsMasterKeyId.",
+                ),
+            },
+            // Read-only
+            ExtraField {
                 name: "QueueArn",
                 read_source: None,
                 description: Some("The Amazon Resource Name (ARN) of the queue."),
+            },
+            ExtraField {
+                name: "ApproximateNumberOfMessages",
+                read_source: None,
+                description: Some(
+                    "Approximate number of visible messages in the queue. Runtime metric reported by the SQS service.",
+                ),
+            },
+            ExtraField {
+                name: "ApproximateNumberOfMessagesDelayed",
+                read_source: None,
+                description: Some(
+                    "Approximate number of messages currently being delayed before becoming visible. Runtime metric.",
+                ),
+            },
+            ExtraField {
+                name: "ApproximateNumberOfMessagesNotVisible",
+                read_source: None,
+                description: Some(
+                    "Approximate number of messages that are in flight (received but not yet deleted or returned to the queue). Runtime metric.",
+                ),
+            },
+            ExtraField {
+                name: "CreatedTimestamp",
+                read_source: None,
+                description: Some("Unix epoch seconds at which the queue was created."),
+            },
+            ExtraField {
+                name: "LastModifiedTimestamp",
+                read_source: None,
+                description: Some(
+                    "Unix epoch seconds at which the queue's attributes were last modified.",
+                ),
             },
         ],
         identity_overrides: vec![],

--- a/carina-provider-aws/src/schemas/generated/sqs/queue.rs
+++ b/carina-provider-aws/src/schemas/generated/sqs/queue.rs
@@ -31,6 +31,11 @@ pub fn sqs_queue_config() -> AwsSchemaConfig {
                 .with_provider_name("tags"),
         )
         .attribute(
+            AttributeSchema::new("policy", super::iam_policy_document())
+                .with_description("The queue's access policy, as a JSON-encoded IAM policy document.")
+                .with_provider_name("Policy"),
+        )
+        .attribute(
             AttributeSchema::new("visibility_timeout", AttributeType::Int)
                 .with_description("The visibility timeout for the queue, in seconds. Defaults to 30. Range 0–43,200.")
                 .with_provider_name("VisibilityTimeout"),
@@ -51,10 +56,93 @@ pub fn sqs_queue_config() -> AwsSchemaConfig {
                 .with_provider_name("MaximumMessageSize"),
         )
         .attribute(
+            AttributeSchema::new("receive_message_wait_time_seconds", AttributeType::Int)
+                .with_description("The duration, in seconds, for which a ReceiveMessage call waits for a message to arrive (long polling). Defaults to 0. Range 0–20.")
+                .with_provider_name("ReceiveMessageWaitTimeSeconds"),
+        )
+        .attribute(
+            AttributeSchema::new("redrive_policy", super::sqs_redrive_policy())
+                .with_description("Dead-letter queue redrive policy, as a JSON document with `deadLetterTargetArn` and `maxReceiveCount` keys.")
+                .with_provider_name("RedrivePolicy"),
+        )
+        .attribute(
+            AttributeSchema::new("redrive_allow_policy", super::sqs_redrive_allow_policy())
+                .with_description("Permissions for source queues that can use this queue as their dead-letter destination, as a JSON document.")
+                .with_provider_name("RedriveAllowPolicy"),
+        )
+        .attribute(
+            AttributeSchema::new("fifo_queue", AttributeType::Bool)
+                .create_only()
+                .with_description("Whether the queue is FIFO. Create-only. The queue name must end with `.fifo` when true.")
+                .with_provider_name("FifoQueue"),
+        )
+        .attribute(
+            AttributeSchema::new("content_based_deduplication", AttributeType::Bool)
+                .with_description("FIFO only: enables content-based message deduplication using a SHA-256 hash of the message body.")
+                .with_provider_name("ContentBasedDeduplication"),
+        )
+        .attribute(
+            AttributeSchema::new("deduplication_scope", AttributeType::String)
+                .create_only()
+                .with_description("FIFO only, create-only: scope of message deduplication. Valid values: `messageGroup`, `queue`.")
+                .with_provider_name("DeduplicationScope"),
+        )
+        .attribute(
+            AttributeSchema::new("fifo_throughput_limit", AttributeType::String)
+                .create_only()
+                .with_description("FIFO only, create-only: per-queue or per-message-group throughput limit. Valid values: `perQueue`, `perMessageGroupId`.")
+                .with_provider_name("FifoThroughputLimit"),
+        )
+        .attribute(
+            AttributeSchema::new("kms_master_key_id", super::kms_key_id())
+                .with_description("The ID of an AWS KMS customer master key (CMK) to use for server-side encryption (SSE-KMS). Use `alias/aws/sqs` for the AWS-managed key.")
+                .with_provider_name("KmsMasterKeyId"),
+        )
+        .attribute(
+            AttributeSchema::new("kms_data_key_reuse_period_seconds", AttributeType::Int)
+                .with_description("Length of time, in seconds, that SQS can reuse a data key before invoking KMS again. Defaults to 300 (5 minutes). Range 60–86,400.")
+                .with_provider_name("KmsDataKeyReusePeriodSeconds"),
+        )
+        .attribute(
+            AttributeSchema::new("sqs_managed_sse_enabled", AttributeType::Bool)
+                .with_description("Enables SQS-managed server-side encryption (SSE-SQS). Mutually exclusive with KmsMasterKeyId.")
+                .with_provider_name("SqsManagedSseEnabled"),
+        )
+        .attribute(
             AttributeSchema::new("queue_arn", super::arn())
                 .read_only()
                 .with_description("The Amazon Resource Name (ARN) of the queue. (read-only)")
                 .with_provider_name("QueueArn"),
+        )
+        .attribute(
+            AttributeSchema::new("approximate_number_of_messages", AttributeType::Int)
+                .read_only()
+                .with_description("Approximate number of visible messages in the queue. Runtime metric reported by the SQS service. (read-only)")
+                .with_provider_name("ApproximateNumberOfMessages"),
+        )
+        .attribute(
+            AttributeSchema::new("approximate_number_of_messages_delayed", AttributeType::Int)
+                .read_only()
+                .with_description("Approximate number of messages currently being delayed before becoming visible. Runtime metric. (read-only)")
+                .with_provider_name("ApproximateNumberOfMessagesDelayed"),
+        )
+        .attribute(
+            AttributeSchema::new("approximate_number_of_messages_not_visible", AttributeType::Int)
+                .read_only()
+                .with_description("Approximate number of messages that are in flight (received but not yet deleted or returned to the queue). Runtime metric. (read-only)")
+                .with_provider_name("ApproximateNumberOfMessagesNotVisible"),
+        )
+        .attribute(
+            AttributeSchema::new("created_timestamp", AttributeType::Int)
+                .read_only()
+                .with_description("Unix epoch seconds at which the queue was created. (read-only)")
+                .with_provider_name("CreatedTimestamp"),
+        )
+        .attribute(
+            AttributeSchema::new("last_modified_timestamp", AttributeType::Int)
+                .read_only()
+                .with_description("Unix epoch seconds at which the queue's attributes were last modified. (read-only)")
+                .with_provider_name("LastModifiedTimestamp"),
         )
         .attribute(
             AttributeSchema::new("tags", tags_type())

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -434,7 +434,7 @@ fn lookup_snake(
 /// Convert a Carina policy document Value to JSON. Top-level fields are
 /// case-mapped via `POLICY_TOP_FIELDS`; the value of `Statement` is
 /// further converted by `policy_statement_to_json`.
-fn policy_doc_to_json(value: &Value) -> serde_json::Value {
+pub(crate) fn policy_doc_to_json(value: &Value) -> serde_json::Value {
     let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return scalar_to_json(value);
     };
@@ -538,6 +538,20 @@ fn scalar_to_json(value: &Value) -> serde_json::Value {
         Value::Concrete(ConcreteValue::Int(n)) => serde_json::Value::Number((*n).into()),
         Value::Concrete(ConcreteValue::Float(f)) => serde_json::json!(*f),
         Value::Concrete(ConcreteValue::Bool(b)) => serde_json::Value::Bool(*b),
+        // `effect` lands here as `EnumIdentifier("allow"|"deny")` after
+        // the read-side canonicalization. AWS's wire form is the
+        // PascalCase canonical (`Allow` / `Deny`), so map the snake_case
+        // alias back. Trailing-segment strip handles any namespaced
+        // form too (`aws.iam.PolicyStatement.Effect.allow` → `allow`).
+        Value::Concrete(ConcreteValue::EnumIdentifier(id)) => {
+            let trailing = id.rsplit('.').next().unwrap_or(id.as_str());
+            let canonical = match trailing {
+                "allow" => "Allow",
+                "deny" => "Deny",
+                other => other,
+            };
+            serde_json::Value::String(canonical.to_string())
+        }
         Value::Concrete(ConcreteValue::List(_)) | Value::Concrete(ConcreteValue::Map(_)) => {
             scalar_or_passthrough_to_json(value)
         }
@@ -557,7 +571,7 @@ pub fn iam_policy_json_to_value(json_str: &str) -> Result<Value, String> {
     Ok(json_to_policy_doc(&json))
 }
 
-fn json_to_policy_doc(json: &serde_json::Value) -> Value {
+pub(crate) fn json_to_policy_doc(json: &serde_json::Value) -> Value {
     let serde_json::Value::Object(obj) = json else {
         return json_scalar_to_value(json);
     };
@@ -596,11 +610,54 @@ fn json_to_policy_statement(json: &serde_json::Value) -> Value {
         let value = match snake_key {
             "principal" | "not_principal" => json_to_principal(v),
             "condition" => json_to_condition(v),
+            // `effect` is a StringEnum with `dsl_aliases: [("Allow",
+            // "allow"), ("Deny", "deny")]`. AWS returns the canonical
+            // PascalCase ("Allow"); the DSL surface is the snake_case
+            // alias ("allow"). Emit `EnumIdentifier` directly with the
+            // DSL form so post-apply plan-verify compares equal.
+            "effect" => json_effect_to_enum_identifier(v),
+            // `Action` / `Resource` are `Map<String, StringOrList>`
+            // — AWS may return a scalar (`"sts:AssumeRole"`) or a list.
+            // The DSL schema accepts both, but to avoid post-apply
+            // plan-verify churn we normalize scalars to a single-element
+            // list (the typical DSL spelling).
+            "action" | "not_action" | "resource" | "not_resource" => {
+                json_scalar_to_singleton_list(v)
+            }
             _ => json_scalar_or_passthrough_to_value(v),
         };
         map.insert(snake_key.to_string(), value);
     }
     Value::Concrete(ConcreteValue::Map(map))
+}
+
+/// AWS returns `Effect: "Allow"`; the DSL StringEnum surface for that
+/// field is the snake_case alias (`allow` / `deny`). Emit
+/// `EnumIdentifier` carrying the alias so the read state matches what
+/// the DSL produces.
+fn json_effect_to_enum_identifier(v: &serde_json::Value) -> Value {
+    let Some(s) = v.as_str() else {
+        return json_scalar_to_value(v);
+    };
+    let alias = match s {
+        "Allow" => "allow",
+        "Deny" => "deny",
+        _ => s,
+    };
+    Value::Concrete(ConcreteValue::EnumIdentifier(alias.to_string()))
+}
+
+/// AWS returns `Principal: {"AWS": "*"}` (scalar) for single-element
+/// principals; the DSL schema declares `aws: List<String>`. Wrap the
+/// scalar into a single-element list so post-apply plan-verify does
+/// not see a shape mismatch.
+fn json_scalar_to_singleton_list(v: &serde_json::Value) -> Value {
+    match v {
+        serde_json::Value::Array(items) => Value::Concrete(ConcreteValue::List(
+            items.iter().map(json_scalar_to_value).collect(),
+        )),
+        _ => Value::Concrete(ConcreteValue::List(vec![json_scalar_to_value(v)])),
+    }
 }
 
 fn json_to_principal(json: &serde_json::Value) -> Value {
@@ -612,7 +669,12 @@ fn json_to_principal(json: &serde_json::Value) -> Value {
                     continue;
                 }
                 let key = lookup_snake(PRINCIPAL_FIELDS, k).unwrap_or(k.as_str());
-                map.insert(key.to_string(), json_scalar_or_passthrough_to_value(v));
+                // All Principal sub-fields (`aws`, `service`,
+                // `federated`, `canonical_user`) are declared as
+                // `List<String>` in the schema; normalize scalar JSON
+                // (which AWS returns when there is only one entry)
+                // into a singleton list.
+                map.insert(key.to_string(), json_scalar_to_singleton_list(v));
             }
             Value::Concrete(ConcreteValue::Map(map))
         }
@@ -767,10 +829,20 @@ mod tests {
     /// Exercises principal map, list-valued action/resource, and a
     /// `bool` condition with the `aws:SecureTransport` value key.
     fn full_deny_policy_value() -> Value {
+        // Canonical post-read shape:
+        //   - `effect`: EnumIdentifier carrying snake_case alias
+        //   - `principal.aws`: singleton List (schema declares List<String>)
+        //   - `action`: singleton List (schema declares List<String>)
+        // value_to_iam_policy_json serializes both List-of-one and bare
+        // scalars to the same JSON, and json_to_policy_doc normalizes
+        // scalars to singleton lists, so this is the round-trip fixed
+        // point.
         let mut principal = IndexMap::new();
         principal.insert(
             "aws".to_string(),
-            Value::Concrete(ConcreteValue::String("*".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("*".to_string()),
+            )])),
         );
 
         let mut bool_inner = IndexMap::new();
@@ -791,7 +863,7 @@ mod tests {
         );
         stmt.insert(
             "effect".to_string(),
-            Value::Concrete(ConcreteValue::String("Deny".to_string())),
+            Value::Concrete(ConcreteValue::EnumIdentifier("deny".to_string())),
         );
         stmt.insert(
             "principal".to_string(),
@@ -799,7 +871,9 @@ mod tests {
         );
         stmt.insert(
             "action".to_string(),
-            Value::Concrete(ConcreteValue::String("s3:*".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("s3:*".to_string()),
+            )])),
         );
         stmt.insert(
             "resource".to_string(),
@@ -918,10 +992,29 @@ mod tests {
             panic!()
         };
         assert!(principal.contains_key("aws"));
+        // Schema declares principal sub-fields as List<String>; scalar
+        // JSON (`"AWS": "*"`) is normalized to a singleton list on read
+        // so post-apply plan-verify does not see a shape mismatch.
         assert_eq!(
             principal.get("aws"),
-            Some(&Value::Concrete(ConcreteValue::String("*".to_string()))),
-            "principal value should round-trip verbatim"
+            Some(&Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("*".to_string()))
+            ])))
+        );
+
+        // Effect is the snake_case alias of the StringEnum on read.
+        assert_eq!(
+            stmt.get("effect"),
+            Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+                "deny".to_string()
+            )))
+        );
+        // Action scalar is wrapped to singleton list.
+        assert_eq!(
+            stmt.get("action"),
+            Some(&Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("s3:*".to_string()))
+            ])))
         );
     }
 
@@ -968,9 +1061,12 @@ mod tests {
         let Value::Concrete(ConcreteValue::Map(stmt)) = doc.get("statement").unwrap() else {
             panic!("statement should be a Map for single-object form")
         };
+        // Effect is the snake_case alias of the StringEnum on read.
         assert_eq!(
             stmt.get("effect"),
-            Some(&Value::Concrete(ConcreteValue::String("Allow".to_string())))
+            Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+                "allow".to_string()
+            )))
         );
     }
 
@@ -1021,13 +1117,17 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(inner)),
         );
         let mut stmt = IndexMap::new();
+        // Canonical post-read form: effect EnumIdentifier alias, action
+        // singleton List.
         stmt.insert(
             "effect".to_string(),
-            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+            Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
         );
         stmt.insert(
             "action".to_string(),
-            Value::Concrete(ConcreteValue::String("s3:*".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("s3:*".to_string()),
+            )])),
         );
         stmt.insert(
             "condition".to_string(),
@@ -1072,13 +1172,17 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(inner)),
         );
         let mut stmt = IndexMap::new();
+        // Canonical post-read form: effect EnumIdentifier alias, action
+        // singleton List.
         stmt.insert(
             "effect".to_string(),
-            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+            Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
         );
         stmt.insert(
             "action".to_string(),
-            Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("s3:GetObject".to_string()),
+            )])),
         );
         stmt.insert(
             "condition".to_string(),

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -1,12 +1,11 @@
 //! Hand-written service implementation for `aws.sqs.Queue`.
 //!
-//! SQS exposes its mutable knobs through `Attributes: Map<QueueAttributeName,
-//! String>` on `CreateQueue` / `GetQueueAttributes` / `SetQueueAttributes`.
-//! Schema-side we project the supported subset (visibility_timeout,
-//! message_retention_period, delay_seconds, maximum_message_size, queue_arn)
-//! as flat top-level attributes via `extra_attributes` (see
-//! `carina-codegen-aws/src/resource_defs.rs::sqs_resources`); the
-//! pack/unpack lives here.
+//! SQS exposes every per-queue knob through
+//! `Attributes: Map<QueueAttributeName, String>` on `CreateQueue` /
+//! `GetQueueAttributes` / `SetQueueAttributes`. Schema-side we project
+//! every `QueueAttributeName` variant as a flat top-level attribute
+//! via `extra_attributes` (see `carina-codegen-aws/src/resource_defs.rs::
+//! sqs_resources`); the map↔flat packing lives here.
 
 use aws_sdk_sqs::types::QueueAttributeName;
 use indexmap::IndexMap;
@@ -17,21 +16,362 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
+// IAM policy doc Struct↔JSON converters are borrowed via pub(crate)
+// from services/iam/role.rs until aws#286 extracts them into a shared
+// module. SQS's Policy and RedriveAllowPolicy are IAM-shaped.
+use crate::services::iam::role::{json_to_policy_doc, policy_doc_to_json};
 
-/// Writable numeric attributes mapped 1:1 to SQS `QueueAttributeName`
-/// keys. Each entry is (DSL snake-case attribute name, SDK enum key).
-const WRITABLE_INT_ATTRS: &[(&str, QueueAttributeName)] = &[
-    ("visibility_timeout", QueueAttributeName::VisibilityTimeout),
+/// Classification of how a `QueueAttributeName` value moves between
+/// the DSL `Value` layer and the SQS wire format (strings).
+#[derive(Clone, Copy)]
+enum AttrKind {
+    /// Stored / surfaced as integer; serialized to/from string with
+    /// `i64::to_string` / `str::parse::<i64>`.
+    Int,
+    /// Stored / surfaced as bool; serialized to/from string with
+    /// `"true"` / `"false"` (the SQS conventions).
+    Bool,
+    /// Stored / surfaced as String; serialized verbatim.
+    String,
+    /// Stored as a Struct shaped like an IAM policy document. Serialized
+    /// to / from a JSON string via the IAM policy converters.
+    IamPolicy,
+    /// Stored as a Struct shaped like `{deadLetterTargetArn,
+    /// maxReceiveCount}`. Serialized to / from a JSON string by the
+    /// local `redrive_policy_to_json` / `json_to_redrive_policy`
+    /// helpers below.
+    RedrivePolicyStruct,
+    /// Stored as a Struct shaped like `{redrivePermission,
+    /// sourceQueueArns?}`. Serialized to / from a JSON string by the
+    /// local `redrive_allow_policy_to_json` /
+    /// `json_to_redrive_allow_policy` helpers below.
+    RedriveAllowPolicyStruct,
+}
+
+/// Every queue attribute Carina surfaces. The tuple is
+/// (DSL snake-case name, SDK enum key, AttrKind, is_writable).
+///
+/// `is_writable=false` entries skip pack-on-create / pack-on-update
+/// but participate in read-back.
+const QUEUE_ATTRS: &[(&str, QueueAttributeName, AttrKind, bool)] = &[
+    // Writable: policies and JSON-shaped settings
+    (
+        "policy",
+        QueueAttributeName::Policy,
+        AttrKind::IamPolicy,
+        true,
+    ),
+    (
+        "redrive_policy",
+        QueueAttributeName::RedrivePolicy,
+        AttrKind::RedrivePolicyStruct,
+        true,
+    ),
+    (
+        "redrive_allow_policy",
+        QueueAttributeName::RedriveAllowPolicy,
+        AttrKind::RedriveAllowPolicyStruct,
+        true,
+    ),
+    // Writable: numeric knobs
+    (
+        "visibility_timeout",
+        QueueAttributeName::VisibilityTimeout,
+        AttrKind::Int,
+        true,
+    ),
     (
         "message_retention_period",
         QueueAttributeName::MessageRetentionPeriod,
+        AttrKind::Int,
+        true,
     ),
-    ("delay_seconds", QueueAttributeName::DelaySeconds),
+    (
+        "delay_seconds",
+        QueueAttributeName::DelaySeconds,
+        AttrKind::Int,
+        true,
+    ),
     (
         "maximum_message_size",
         QueueAttributeName::MaximumMessageSize,
+        AttrKind::Int,
+        true,
+    ),
+    (
+        "receive_message_wait_time_seconds",
+        QueueAttributeName::ReceiveMessageWaitTimeSeconds,
+        AttrKind::Int,
+        true,
+    ),
+    (
+        "kms_data_key_reuse_period_seconds",
+        QueueAttributeName::KmsDataKeyReusePeriodSeconds,
+        AttrKind::Int,
+        true,
+    ),
+    // Writable: FIFO + dedup
+    (
+        "fifo_queue",
+        QueueAttributeName::FifoQueue,
+        AttrKind::Bool,
+        true,
+    ),
+    (
+        "content_based_deduplication",
+        QueueAttributeName::ContentBasedDeduplication,
+        AttrKind::Bool,
+        true,
+    ),
+    (
+        "deduplication_scope",
+        QueueAttributeName::DeduplicationScope,
+        AttrKind::String,
+        true,
+    ),
+    (
+        "fifo_throughput_limit",
+        QueueAttributeName::FifoThroughputLimit,
+        AttrKind::String,
+        true,
+    ),
+    // Writable: KMS encryption
+    (
+        "kms_master_key_id",
+        QueueAttributeName::KmsMasterKeyId,
+        AttrKind::String,
+        true,
+    ),
+    (
+        "sqs_managed_sse_enabled",
+        QueueAttributeName::SqsManagedSseEnabled,
+        AttrKind::Bool,
+        true,
+    ),
+    // Read-only: ARN + runtime metrics + timestamps
+    (
+        "queue_arn",
+        QueueAttributeName::QueueArn,
+        AttrKind::String,
+        false,
+    ),
+    (
+        "approximate_number_of_messages",
+        QueueAttributeName::ApproximateNumberOfMessages,
+        AttrKind::Int,
+        false,
+    ),
+    (
+        "approximate_number_of_messages_delayed",
+        QueueAttributeName::ApproximateNumberOfMessagesDelayed,
+        AttrKind::Int,
+        false,
+    ),
+    (
+        "approximate_number_of_messages_not_visible",
+        QueueAttributeName::ApproximateNumberOfMessagesNotVisible,
+        AttrKind::Int,
+        false,
+    ),
+    (
+        "created_timestamp",
+        QueueAttributeName::CreatedTimestamp,
+        AttrKind::Int,
+        false,
+    ),
+    (
+        "last_modified_timestamp",
+        QueueAttributeName::LastModifiedTimestamp,
+        AttrKind::Int,
+        false,
     ),
 ];
+
+/// Attributes that AWS rejects in `SetQueueAttributes` (must be set at
+/// CreateQueue time and are immutable afterwards). DSL-side
+/// `create_only_overrides` already protects users from emitting an
+/// update plan for these; this list mirrors that decision so the
+/// update path drops them too.
+fn is_create_only(name: &QueueAttributeName) -> bool {
+    matches!(
+        name,
+        QueueAttributeName::FifoQueue
+            | QueueAttributeName::FifoThroughputLimit
+            | QueueAttributeName::DeduplicationScope
+    )
+}
+
+/// Read `resource[attr_name]` and serialise it into the SQS wire
+/// string for `kind`. Returns `None` when the attribute is not set or
+/// the value is the wrong shape.
+fn pack_attr(value: &Value, kind: AttrKind) -> Option<String> {
+    match (kind, value) {
+        (AttrKind::Int, Value::Concrete(ConcreteValue::Int(n))) => Some(n.to_string()),
+        (AttrKind::Bool, Value::Concrete(ConcreteValue::Bool(b))) => {
+            Some(if *b { "true" } else { "false" }.to_string())
+        }
+        (AttrKind::String, Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
+        (AttrKind::IamPolicy, Value::Concrete(ConcreteValue::Map(_))) => {
+            let json = policy_doc_to_json(value);
+            serde_json::to_string(&json).ok()
+        }
+        (AttrKind::RedrivePolicyStruct, Value::Concrete(ConcreteValue::Map(_))) => {
+            redrive_policy_to_json_string(value)
+        }
+        (AttrKind::RedriveAllowPolicyStruct, Value::Concrete(ConcreteValue::Map(_))) => {
+            redrive_allow_policy_to_json_string(value)
+        }
+        _ => None,
+    }
+}
+
+/// Reverse of `pack_attr`: deserialise the SQS wire string into a
+/// `Value` of the kind we declared in `QUEUE_ATTRS`.
+fn unpack_attr(raw: &str, kind: AttrKind) -> Option<Value> {
+    match kind {
+        AttrKind::Int => raw
+            .parse::<i64>()
+            .ok()
+            .map(|n| Value::Concrete(ConcreteValue::Int(n))),
+        AttrKind::Bool => match raw {
+            "true" => Some(Value::Concrete(ConcreteValue::Bool(true))),
+            "false" => Some(Value::Concrete(ConcreteValue::Bool(false))),
+            _ => None,
+        },
+        AttrKind::String => Some(Value::Concrete(ConcreteValue::String(raw.to_string()))),
+        AttrKind::IamPolicy => {
+            let json: serde_json::Value = serde_json::from_str(raw).ok()?;
+            Some(json_to_policy_doc(&json))
+        }
+        AttrKind::RedrivePolicyStruct => {
+            let json: serde_json::Value = serde_json::from_str(raw).ok()?;
+            json_to_redrive_policy(&json)
+        }
+        AttrKind::RedriveAllowPolicyStruct => {
+            let json: serde_json::Value = serde_json::from_str(raw).ok()?;
+            json_to_redrive_allow_policy(&json)
+        }
+    }
+}
+
+/// Serialise a `Value::Map { dead_letter_target_arn, max_receive_count }`
+/// to the `{"deadLetterTargetArn": "...", "maxReceiveCount": N}` JSON
+/// string SQS expects.
+fn redrive_policy_to_json_string(value: &Value) -> Option<String> {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
+        return None;
+    };
+    let arn = match map.get("dead_letter_target_arn") {
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+        _ => return None,
+    };
+    let count = match map.get("max_receive_count") {
+        Some(Value::Concrete(ConcreteValue::Int(n))) => *n,
+        _ => return None,
+    };
+    let json = serde_json::json!({
+        "deadLetterTargetArn": arn,
+        "maxReceiveCount": count,
+    });
+    serde_json::to_string(&json).ok()
+}
+
+/// Parse the `{deadLetterTargetArn, maxReceiveCount}` JSON document
+/// SQS returns into a `Value::Map` with the DSL-side snake_case keys.
+fn json_to_redrive_policy(json: &serde_json::Value) -> Option<Value> {
+    let obj = json.as_object()?;
+    let arn = obj.get("deadLetterTargetArn")?.as_str()?;
+    let count = obj.get("maxReceiveCount")?.as_i64()?;
+    let mut out = IndexMap::new();
+    out.insert(
+        "dead_letter_target_arn".to_string(),
+        Value::Concrete(ConcreteValue::String(arn.to_string())),
+    );
+    out.insert(
+        "max_receive_count".to_string(),
+        Value::Concrete(ConcreteValue::Int(count)),
+    );
+    Some(Value::Concrete(ConcreteValue::Map(out)))
+}
+
+/// Serialise a `Value::Map { redrive_permission, source_queue_arns? }`
+/// to the `{"redrivePermission": "...", "sourceQueueArns": [...]}`
+/// JSON string SQS expects.
+fn redrive_allow_policy_to_json_string(value: &Value) -> Option<String> {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
+        return None;
+    };
+    let permission = match map.get("redrive_permission") {
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+        Some(Value::Concrete(ConcreteValue::EnumIdentifier(s))) => {
+            // Strip any namespace prefix (e.g. aws.sqs.Queue.SqsRedrivePermission.allowAll
+            // → allowAll); the enum surface is the trailing segment.
+            s.rsplit('.').next().unwrap_or(s.as_str()).to_string()
+        }
+        _ => return None,
+    };
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "redrivePermission".to_string(),
+        serde_json::Value::String(permission),
+    );
+    if let Some(Value::Concrete(ConcreteValue::List(items))) = map.get("source_queue_arns") {
+        let arns: Vec<serde_json::Value> = items
+            .iter()
+            .filter_map(|v| match v {
+                Value::Concrete(ConcreteValue::String(s)) => {
+                    Some(serde_json::Value::String(s.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        if !arns.is_empty() {
+            obj.insert(
+                "sourceQueueArns".to_string(),
+                serde_json::Value::Array(arns),
+            );
+        }
+    }
+    serde_json::to_string(&serde_json::Value::Object(obj)).ok()
+}
+
+/// Parse the `{redrivePermission, sourceQueueArns?}` JSON document
+/// SQS returns into a `Value::Map` with the DSL-side snake_case keys.
+fn json_to_redrive_allow_policy(json: &serde_json::Value) -> Option<Value> {
+    let obj = json.as_object()?;
+    let permission_raw = obj.get("redrivePermission")?.as_str()?;
+    // AWS returns the canonical camelCase form (`allowAll`); the DSL
+    // surface is the snake_case alias (`allow_all`). Emit
+    // `EnumIdentifier` carrying the alias so post-apply plan-verify
+    // compares equal.
+    let permission_alias = match permission_raw {
+        "allowAll" => "allow_all",
+        "denyAll" => "deny_all",
+        "byQueue" => "by_queue",
+        other => other,
+    };
+    let mut out = IndexMap::new();
+    out.insert(
+        "redrive_permission".to_string(),
+        Value::Concrete(ConcreteValue::EnumIdentifier(permission_alias.to_string())),
+    );
+    if let Some(arns_json) = obj.get("sourceQueueArns")
+        && let Some(arr) = arns_json.as_array()
+    {
+        let arns: Vec<Value> = arr
+            .iter()
+            .filter_map(|v| {
+                v.as_str()
+                    .map(|s| Value::Concrete(ConcreteValue::String(s.to_string())))
+            })
+            .collect();
+        out.insert(
+            "source_queue_arns".to_string(),
+            Value::Concrete(ConcreteValue::List(arns)),
+        );
+    }
+    Some(Value::Concrete(ConcreteValue::Map(out)))
+}
 
 impl AwsProvider {
     /// Read an SQS Queue by its URL (the provider identifier).
@@ -44,10 +384,10 @@ impl AwsProvider {
             return Ok(State::not_found(id.clone()));
         };
 
-        // Pull every attribute we surface in one round-trip.
-        let mut attr_names: Vec<QueueAttributeName> =
-            WRITABLE_INT_ATTRS.iter().map(|(_, n)| n.clone()).collect();
-        attr_names.push(QueueAttributeName::QueueArn);
+        // Use the `All` meta-name so SQS returns every queue attribute
+        // applicable to this queue (standard queues reject explicit
+        // FIFO-only attribute names like `DeduplicationScope`).
+        let attr_names: Vec<QueueAttributeName> = vec![QueueAttributeName::All];
 
         let result = match self
             .sqs_client
@@ -59,7 +399,6 @@ impl AwsProvider {
         {
             Ok(out) => out,
             Err(err) => {
-                // Service treats a missing queue with a typed error variant.
                 if let Some(svc_err) = err.as_service_error()
                     && svc_err.is_queue_does_not_exist()
                 {
@@ -84,21 +423,12 @@ impl AwsProvider {
         }
 
         if let Some(map) = result.attributes() {
-            for (attr_name, sdk_key) in WRITABLE_INT_ATTRS {
+            for (attr_name, sdk_key, kind, _) in QUEUE_ATTRS {
                 if let Some(raw) = map.get(sdk_key)
-                    && let Ok(parsed) = raw.parse::<i64>()
+                    && let Some(value) = unpack_attr(raw, *kind)
                 {
-                    attributes.insert(
-                        attr_name.to_string(),
-                        Value::Concrete(ConcreteValue::Int(parsed)),
-                    );
+                    attributes.insert((*attr_name).to_string(), value);
                 }
-            }
-            if let Some(arn) = map.get(&QueueAttributeName::QueueArn) {
-                attributes.insert(
-                    "queue_arn".to_string(),
-                    Value::Concrete(ConcreteValue::String(arn.to_string())),
-                );
             }
         }
 
@@ -142,15 +472,19 @@ impl AwsProvider {
     pub(crate) async fn create_sqs_queue(&self, resource: Resource) -> ProviderResult<State> {
         let queue_name = require_string_attr(&resource, "queue_name")?;
 
-        // Pack writable numeric attributes into the SQS map shape.
+        // Pack every writable attribute the user actually set.
         let mut attr_map: HashMap<QueueAttributeName, String> = HashMap::new();
-        for (attr_name, sdk_key) in WRITABLE_INT_ATTRS {
-            if let Some(Value::Concrete(ConcreteValue::Int(n))) = resource.get_attr(attr_name) {
-                attr_map.insert(sdk_key.clone(), n.to_string());
+        for (attr_name, sdk_key, kind, writable) in QUEUE_ATTRS {
+            if !writable {
+                continue;
+            }
+            if let Some(value) = resource.get_attr(attr_name)
+                && let Some(serialized) = pack_attr(value, *kind)
+            {
+                attr_map.insert(sdk_key.clone(), serialized);
             }
         }
 
-        // Tags are passed as a separate parameter.
         let tags = resource_tags_map(&resource);
 
         let mut req = self.sqs_client.create_queue().queue_name(&queue_name);
@@ -182,15 +516,24 @@ impl AwsProvider {
         from: &State,
         to: Resource,
     ) -> ProviderResult<State> {
-        // Build the partial map of attributes that actually changed.
+        // Build a partial map of attributes whose value changed.
+        // Create-only attributes (FifoQueue / FifoThroughputLimit /
+        // DeduplicationScope) are dropped — schema marks them
+        // create_only, but defend in depth.
         let mut attr_map: HashMap<QueueAttributeName, String> = HashMap::new();
-        for (attr_name, sdk_key) in WRITABLE_INT_ATTRS {
+        for (attr_name, sdk_key, kind, writable) in QUEUE_ATTRS {
+            if !writable || is_create_only(sdk_key) {
+                continue;
+            }
             let desired = to.get_attr(attr_name);
             let current = from.attributes.get(*attr_name);
-            if let Some(Value::Concrete(ConcreteValue::Int(n))) = desired
-                && current != desired
+            if desired == current {
+                continue;
+            }
+            if let Some(value) = desired
+                && let Some(serialized) = pack_attr(value, *kind)
             {
-                attr_map.insert(sdk_key.clone(), n.to_string());
+                attr_map.insert(sdk_key.clone(), serialized);
             }
         }
 
@@ -306,8 +649,7 @@ impl AwsProvider {
 }
 
 /// Extract a `tags = { ... }` block from the resource, dropping any
-/// non-string values. Returns `None` when no tags are set so callers
-/// can leave the SDK builder untouched.
+/// non-string values. Returns `None` when no tags are set.
 fn resource_tags_map(resource: &Resource) -> Option<HashMap<String, String>> {
     let Some(Value::Concrete(ConcreteValue::Map(tag_map))) = resource.get_attr("tags") else {
         return None;


### PR DESCRIPTION
## Summary

Expands `aws.sqs.Queue` from v1's minimum surface (`visibility_timeout` / `message_retention_period` / `delay_seconds` / `maximum_message_size`) to the **full `QueueAttributeName` set** — every variant except the `All` meta marker. Same PR also makes the S3 BucketNotificationConfiguration acceptance fixture self-contained, which unblocked the discovery of two IAM policy idempotency bugs that are fixed alongside.

Per `feedback_resource_unit_complete_attrs.md`: a resource ships once, with every attribute. The earlier "v1 minimum" split (#285) was the failure mode this rule was written to prevent.

## Closes / refs

- Closes #280
- Closes #278
- Refs #287 (`redrive_allow_policy.redrive_permission` idempotency — held back as `dlq.crn`, deferred for deep-debug)

## SQS Queue: new attributes

Writable / mutable:
- `policy` — IAM policy document (Struct)
- `redrive_policy` — `{dead_letter_target_arn, max_receive_count}` (Struct)
- `redrive_allow_policy` — `{redrive_permission, source_queue_arns?}` (Struct)
- `receive_message_wait_time_seconds` (Int, long polling)
- `kms_master_key_id` (kms_key_id)
- `kms_data_key_reuse_period_seconds` (Int)
- `sqs_managed_sse_enabled` (Bool)
- `content_based_deduplication` (Bool, FIFO-only)

Create-only:
- `fifo_queue` (Bool)
- `deduplication_scope` (String)
- `fifo_throughput_limit` (String)

Read-only (5):
- `approximate_number_of_messages`
- `approximate_number_of_messages_delayed`
- `approximate_number_of_messages_not_visible`
- `created_timestamp`
- `last_modified_timestamp`

Create-only enforcement: `FifoQueue`, `FifoThroughputLimit`, `DeduplicationScope` go through `create_only_overrides` so the codegen marks them immutable. The hand-written service drops them from the `SetQueueAttributes` update path via `is_create_only`.

## Schema (carina-aws-types)

New `AttributeType` builders:
- `sqs_redrive_policy()` — `{dead_letter_target_arn: arn, max_receive_count: Int}`
- `sqs_redrive_allow_policy()` — `{redrive_permission: StringEnum, source_queue_arns?: List<arn>}`
- `sqs_redrive_permission()` — StringEnum `allowAll` / `denyAll` / `byQueue` with snake_case DSL aliases (`allow_all` / `deny_all` / `by_queue`)

## Service implementation (services/sqs/queue.rs)

- `AttrKind` extended: `Int` / `Bool` / `String` / `IamPolicy` / `RedrivePolicyStruct` / `RedriveAllowPolicyStruct`
- `QUEUE_ATTRS` table: `(snake_case_name, sdk_key, kind, is_writable)` covering all 22 variants except `All`
- `pack_attr` / `unpack_attr` per kind, with JSON converters for the three Struct-typed attributes
- `read_sqs_queue` requests `QueueAttributeName::All` (FIFO-only attrs would otherwise reject on standard queues with `InvalidAttributeName`)
- `is_create_only` drops the three immutable FIFO knobs from the update path

## IAM policy converter idempotency fixes (services/iam/role.rs)

Surfaced by the `Policy` attribute on SQS Queue, but the bugs were latent in the iam/role converter and affect every consumer:

1. `Effect: "Allow"` (AWS canonical) ↔ `effect = allow` (DSL snake_case alias) — emit `EnumIdentifier` carrying the alias on read.
2. `Principal: {"AWS": "*"}` (AWS returns scalar for single-element principals) ↔ schema declares `aws: List<String>` — normalize scalar → singleton list on read.
3. `Action` / `NotAction` / `Resource` / `NotResource` — same scalar→list normalization.
4. `scalar_to_json` was silently dropping `EnumIdentifier(_)` values via its `_ => Null` catch-all. Once the read side started emitting `EnumIdentifier` for `effect`, the write side was dropping the field entirely on round-trip. Added an explicit arm that maps the snake_case alias back to the AWS canonical PascalCase (`allow → Allow`, `deny → Deny`), with trailing-segment strip so namespaced carriers (`aws.x.Effect.allow`) also round-trip correctly.

`json_to_policy_doc` and `policy_doc_to_json` promoted to `pub(crate)` so the SQS service can reuse them. This sharing is intentionally a stop-gap — #286 tracks extracting these helpers to a shared module.

## Acceptance fixtures

- `acceptance-tests/sqs_queue/basic.crn` — extended with `policy` + `receive_message_wait_time_seconds` + `sqs_managed_sse_enabled`
- `acceptance-tests/sqs_queue/fifo.crn` — new: FIFO queue with content-based dedup + scope + throughput limit
- `acceptance-tests/s3_bucket_notification_configuration/basic.crn` — provisioned queue inline (closes #278; no longer depends on an out-of-band queue)

`dlq.crn` (redrive_policy + redrive_allow_policy) is **not** included — see #287 for the alias-mismatch deep-debug that needs to happen first.

## Test plan

- [x] `cargo nextest run --workspace` — 359 pass
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --release --target wasm32-wasip2 -p carina-provider-aws`
- [x] `bash scripts/check-examples.sh`
- [x] schema regen (expected diff)
- [x] acceptance `sqs_queue/basic.crn` (full: apply + plan-verify + destroy)
- [x] acceptance `sqs_queue/fifo.crn` (full)
- [x] acceptance `s3_bucket_notification_configuration/basic.crn` (full)
- [ ] `dlq.crn` deferred to #287
