### PR TITLE
acceptance-tests: rename lifecycle to directives (ec2_vpc_step2)

### DIFF
--- a/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -12,7 +12,7 @@ aws.ec2.Vpc {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  lifecycle {
+  directives {
     create_before_destroy = true
   }
 


### PR DESCRIPTION
## Summary

Rename the meta-argument block in `acceptance-tests/create_before_destroy/ec2_vpc_step2.crn` from `lifecycle { ... }` to `directives { ... }`. This fixture was missed in the carina#2826 sweep (merged 2026-05-09).

Audited the rest of `acceptance-tests/`, `examples/`, and `docs/` for stale `lifecycle { ... }` blocks — none remain.

## Closes

- Closes #270

## Test plan

- [x] `carina fmt --check acceptance-tests/create_before_destroy` — passes
- [ ] Full acceptance run on `create_before_destroy/` — deferred to user
