### PR TITLE
s3.BucketAcl: infer canned ACL from grant list on read (closes #271)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=5bd1000e#5bd1000ebd45a69c4531422224fda8deaa2997cf"
+source = "git+https://github.com/carina-rs/carina?rev=568a52e6#568a52e6ad7433c92e3487ca2d89ba093f189fc5"
 dependencies = [
  "argon2",
  "futures",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=5bd1000e#5bd1000ebd45a69c4531422224fda8deaa2997cf"
+source = "git+https://github.com/carina-rs/carina?rev=568a52e6#568a52e6ad7433c92e3487ca2d89ba093f189fc5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=5bd1000e#5bd1000ebd45a69c4531422224fda8deaa2997cf"
+source = "git+https://github.com/carina-rs/carina?rev=568a52e6#568a52e6ad7433c92e3487ca2d89ba093f189fc5"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "5bd1000e" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "568a52e6" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "5bd1000e" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "568a52e6" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "5bd1000e" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "5bd1000e" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "568a52e6" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "568a52e6" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use aws_sdk_s3::types::BucketCannedAcl;
+use aws_sdk_s3::types::{BucketCannedAcl, Grant, Permission, Type as GranteeType};
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
@@ -9,14 +9,100 @@ use crate::AwsProvider;
 use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
+/// AWS group URIs used to identify canned-ACL grant patterns.
+const URI_ALL_USERS: &str = "http://acs.amazonaws.com/groups/global/AllUsers";
+const URI_AUTHENTICATED_USERS: &str = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
+
+/// Inspect the grant list returned by `GetBucketAcl` and infer which
+/// canned ACL produced it, if any. Returns the wire-form name
+/// (`"private"`, `"public-read"`, `"public-read-write"`,
+/// `"authenticated-read"`) the SDK accepts as input to
+/// `BucketCannedAcl::from`.
+///
+/// The four bucket-level canned ACLs Carina supports have fixed grant
+/// shapes:
+/// - `private`: owner FULL_CONTROL only.
+/// - `public-read`: owner FULL_CONTROL + AllUsers READ.
+/// - `public-read-write`: owner FULL_CONTROL + AllUsers READ + AllUsers WRITE.
+/// - `authenticated-read`: owner FULL_CONTROL + AuthenticatedUsers READ.
+///
+/// Returns `None` for any grant shape that does not match — for
+/// example, a custom grant set or a canned ACL Carina does not yet
+/// surface in the schema. Callers should leave the `acl` attribute
+/// absent in state in that case (state then disagrees with desired,
+/// surfacing a real diff, which is the correct behavior).
+fn infer_canned_acl_from_grants(grants: &[Grant], owner_id: Option<&str>) -> Option<&'static str> {
+    let owner_id = owner_id?;
+    // Bucket the grants by (grantee key, permission). Owner grants
+    // are keyed by canonical-user ID; group grants by URI.
+    let mut owner_perms: Vec<&Permission> = Vec::new();
+    let mut all_users_perms: Vec<&Permission> = Vec::new();
+    let mut auth_users_perms: Vec<&Permission> = Vec::new();
+    for grant in grants {
+        let Some(grantee) = grant.grantee() else {
+            continue;
+        };
+        let Some(perm) = grant.permission() else {
+            continue;
+        };
+        match (grantee.r#type(), grantee.id(), grantee.uri()) {
+            (GranteeType::CanonicalUser, Some(id), _) if id == owner_id => {
+                owner_perms.push(perm);
+            }
+            (GranteeType::CanonicalUser, _, _) => {
+                // Non-owner canonical user grant — not a canned shape.
+                return None;
+            }
+            (GranteeType::Group, _, Some(URI_ALL_USERS)) => all_users_perms.push(perm),
+            (GranteeType::Group, _, Some(URI_AUTHENTICATED_USERS)) => {
+                auth_users_perms.push(perm);
+            }
+            _ => return None,
+        }
+    }
+
+    let owner_has_full = owner_perms
+        .iter()
+        .any(|p| matches!(p, Permission::FullControl));
+    if !owner_has_full {
+        return None;
+    }
+
+    match (
+        all_users_perms.as_slice(),
+        auth_users_perms.as_slice(),
+        owner_perms.len(),
+    ) {
+        // private: owner FULL_CONTROL only.
+        ([], [], 1) => Some("private"),
+        // authenticated-read: owner FULL_CONTROL + AuthenticatedUsers READ.
+        ([], [Permission::Read], 1) => Some("authenticated-read"),
+        // public-read: owner FULL_CONTROL + AllUsers READ.
+        ([Permission::Read], [], 1) => Some("public-read"),
+        // public-read-write: owner FULL_CONTROL + AllUsers READ + AllUsers WRITE
+        // (order returned by S3 is not guaranteed).
+        (au, [], 1)
+            if au.len() == 2
+                && au.iter().any(|p| matches!(p, Permission::Read))
+                && au.iter().any(|p| matches!(p, Permission::Write)) =>
+        {
+            Some("public-read-write")
+        }
+        _ => None,
+    }
+}
+
 impl AwsProvider {
     /// Read an S3 BucketAcl.
     ///
-    /// AWS does not return a "canned ACL" name from `GetBucketAcl`; it
-    /// returns the underlying grant list. We do not attempt to round-trip
-    /// the canned-ACL name on read, only echo back the configured
-    /// `acl` attribute when the bucket exists. This is acceptable because
-    /// `acl` is a write-only setter from the API's perspective.
+    /// AWS does not return a canned-ACL name from `GetBucketAcl`; it
+    /// returns the underlying grant list. We infer which canned ACL
+    /// produced the grant shape (private / public-read / public-read-write
+    /// / authenticated-read) and write that into state so post-apply
+    /// `plan-verify` is idempotent. Custom grant sets that do not match
+    /// any canned shape leave `acl` absent in state — the resulting diff
+    /// is accurate (the bucket no longer matches the requested canned
+    /// ACL).
     pub(crate) async fn read_s3_bucket_acl(
         &self,
         id: &ResourceId,
@@ -29,12 +115,19 @@ impl AwsProvider {
         let result = self.s3_client.get_bucket_acl().bucket(bucket).send().await;
 
         match result {
-            Ok(_) => {
+            Ok(output) => {
                 let mut attributes = HashMap::new();
                 attributes.insert(
                     "bucket".to_string(),
                     Value::Concrete(ConcreteValue::String(bucket.to_string())),
                 );
+                let owner_id = output.owner().and_then(|o| o.id());
+                if let Some(canned) = infer_canned_acl_from_grants(output.grants(), owner_id) {
+                    attributes.insert(
+                        "acl".to_string(),
+                        Value::Concrete(ConcreteValue::String(canned.to_string())),
+                    );
+                }
                 Ok(State::existing(id.clone(), attributes).with_identifier(bucket.to_string()))
             }
             Err(e) => {
@@ -126,5 +219,112 @@ impl AwsProvider {
             ))
             .for_resource(id.clone())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_s3::types::Grantee;
+
+    fn owner_full_control(owner_id: &str) -> Grant {
+        Grant::builder()
+            .grantee(
+                Grantee::builder()
+                    .r#type(GranteeType::CanonicalUser)
+                    .id(owner_id)
+                    .build()
+                    .unwrap(),
+            )
+            .permission(Permission::FullControl)
+            .build()
+    }
+
+    fn group_grant(uri: &str, perm: Permission) -> Grant {
+        Grant::builder()
+            .grantee(
+                Grantee::builder()
+                    .r#type(GranteeType::Group)
+                    .uri(uri)
+                    .build()
+                    .unwrap(),
+            )
+            .permission(perm)
+            .build()
+    }
+
+    #[test]
+    fn infer_private_canned_acl() {
+        let grants = vec![owner_full_control("OWNER123")];
+        assert_eq!(
+            infer_canned_acl_from_grants(&grants, Some("OWNER123")),
+            Some("private")
+        );
+    }
+
+    #[test]
+    fn infer_public_read_canned_acl() {
+        let grants = vec![
+            owner_full_control("OWNER123"),
+            group_grant(URI_ALL_USERS, Permission::Read),
+        ];
+        assert_eq!(
+            infer_canned_acl_from_grants(&grants, Some("OWNER123")),
+            Some("public-read")
+        );
+    }
+
+    #[test]
+    fn infer_public_read_write_canned_acl() {
+        // S3 may return grants in any order.
+        let grants = vec![
+            owner_full_control("OWNER123"),
+            group_grant(URI_ALL_USERS, Permission::Write),
+            group_grant(URI_ALL_USERS, Permission::Read),
+        ];
+        assert_eq!(
+            infer_canned_acl_from_grants(&grants, Some("OWNER123")),
+            Some("public-read-write")
+        );
+    }
+
+    #[test]
+    fn infer_authenticated_read_canned_acl() {
+        let grants = vec![
+            owner_full_control("OWNER123"),
+            group_grant(URI_AUTHENTICATED_USERS, Permission::Read),
+        ];
+        assert_eq!(
+            infer_canned_acl_from_grants(&grants, Some("OWNER123")),
+            Some("authenticated-read")
+        );
+    }
+
+    #[test]
+    fn infer_returns_none_for_custom_grant() {
+        // A non-owner canonical user grant doesn't match any canned ACL.
+        let grants = vec![
+            owner_full_control("OWNER123"),
+            Grant::builder()
+                .grantee(
+                    Grantee::builder()
+                        .r#type(GranteeType::CanonicalUser)
+                        .id("ANOTHER_USER")
+                        .build()
+                        .unwrap(),
+                )
+                .permission(Permission::Read)
+                .build(),
+        ];
+        assert_eq!(
+            infer_canned_acl_from_grants(&grants, Some("OWNER123")),
+            None
+        );
+    }
+
+    #[test]
+    fn infer_returns_none_without_owner() {
+        let grants = vec![owner_full_control("OWNER123")];
+        assert_eq!(infer_canned_acl_from_grants(&grants, None), None);
     }
 }


### PR DESCRIPTION
## Summary

Pairs with carina-rs/carina#2997 (merged `568a52e6`) to fix the post-apply `plan-verify` idempotency failures on `aws.s3.BucketOwnershipControls` and `aws.s3.BucketAcl`.

### Why two PRs

The failure had two distinct root causes:

| Symptom | Root cause | Fix |
|---------|-----------|-----|
| `object_ownership: "bucket_owner_enforced" → "BucketOwnerEnforced"` | The differ compared the trailing enum segment with `eq_ignore_ascii_case` and never consulted `dsl_aliases`, so compound-word PascalCase (`BucketOwnerEnforced`) and snake_case (`bucket_owner_enforced`) didn't match. | carina-rs/carina#2997 |
| `acl: (none) → "private"` | `read_s3_bucket_acl` skipped writing `acl` into state at all — it assumed `acl` is "write-only" because `GetBucketAcl` returns grants, not a canned name. State stayed empty, desired had a value, differ saw a real diff. | this PR |

The carina-side fix also helps every other compound-word StringEnum in any provider, but the immediate user-visible bug was these two S3 sub-resources.

## Change in this PR

`carina-provider-aws/src/services/s3/bucket_acl.rs` now inspects the grant list returned by `GetBucketAcl` and infers which canned ACL produced it. The four bucket-level canned ACLs Carina supports have fixed grant shapes:

- `private`: owner FULL_CONTROL only.
- `public-read`: owner FULL_CONTROL + AllUsers READ.
- `public-read-write`: owner FULL_CONTROL + AllUsers READ + AllUsers WRITE.
- `authenticated-read`: owner FULL_CONTROL + AuthenticatedUsers READ.

If the grant set matches a canned shape, write that name into state. If it doesn't (custom grants, or a canned ACL Carina hasn't yet surfaced in the schema), leave `acl` absent — the resulting `plan` diff is accurate (the bucket genuinely no longer matches the requested canned ACL).

Also bumps the `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` git rev to `568a52e6` so the differ fix lands together.

## Closes

- Closes #271

## Test plan

- [x] `cargo nextest run --workspace` — 365 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --release --target wasm32-wasip2 -p carina-provider-aws`
- [x] Unit tests: 6 new tests in `services::s3::bucket_acl::tests` covering each canned ACL shape + non-matching cases
- [x] acceptance `s3_bucket_ownership_controls/basic.crn` (full: apply + plan-verify + destroy)
- [x] acceptance `s3_bucket_acl/basic.crn` (full)
