### PR TITLE
factory: thread binding into create_provider/create_normalizer (carina#2191 Phase 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=568a52e6#568a52e6ad7433c92e3487ca2d89ba093f189fc5"
+source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
 dependencies = [
  "argon2",
  "futures",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=568a52e6#568a52e6ad7433c92e3487ca2d89ba093f189fc5"
+source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=568a52e6#568a52e6ad7433c92e3487ca2d89ba093f189fc5"
+source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "568a52e6" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "568a52e6" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "568a52e6" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "568a52e6" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -185,6 +185,7 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
         create_before_destroy: r.directives.create_before_destroy,
         prevent_destroy: r.directives.prevent_destroy,
         depends_on: Vec::new(),
+        provider_instance: None,
     };
     resource
 }

--- a/carina-provider-aws/src/factory.rs
+++ b/carina-provider-aws/src/factory.rs
@@ -88,11 +88,17 @@ impl ProviderFactory for AwsProviderFactory {
 
     fn create_provider(
         &self,
+        _binding: Option<&str>,
         attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<
         '_,
         carina_core::provider::ProviderResult<Box<dyn carina_core::provider::Provider>>,
     > {
+        // `_binding` is intentionally unused: the AWS factory does not
+        // cache instances, so each call already produces an
+        // independent `AwsProvider`. The host uses the binding name
+        // as a cache key in `WasmProviderFactory`; for in-process
+        // factories the constructed-fresh shape is enough.
         use crate::services::sts::account_guard::extract_string_list;
         let region = self.extract_region(attributes);
         let allowed = extract_string_list(attributes.get("allowed_account_ids"));
@@ -107,6 +113,7 @@ impl ProviderFactory for AwsProviderFactory {
 
     fn create_normalizer(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         Box::pin(async { Box::new(AwsNormalizer) as Box<dyn ProviderNormalizer> })

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -305,6 +305,7 @@ impl CarinaProvider for AwsProcessProvider {
             create_before_destroy: request.directives.create_before_destroy,
             prevent_destroy: request.directives.prevent_destroy,
             depends_on: Vec::new(),
+            provider_instance: None,
         };
         let core_request = CoreDeleteRequest {
             directives: core_directives,


### PR DESCRIPTION
## Summary

Adapts the AWS factory to the new `ProviderFactory::create_provider` /
`create_normalizer` signature introduced in carina-rs/carina#3018
(Phase 4 of carina#2191 — named provider instances).

- Bumps `carina-core` / `carina-plugin-sdk` /
  `carina-provider-protocol` git rev to the carina Phase 4 merge
  commit.
- Adds `binding: Option<&str>` parameter to `create_provider` and
  `create_normalizer`. The AWS factory constructs a fresh
  `AwsProvider` per call, so it ignores the binding — the cache key
  is only load-bearing for the WASM host. Documented in code.
- Adds `provider_instance: None` to local `Directives` constructions
  in `convert.rs` and `main.rs` (field was added on the carina side
  in carina-rs/carina#3016).

Refs carina-rs/carina#2191.

## Test plan

- [x] `cargo nextest run` — 375 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Real-infra T6c — gated on carina Phase 6 + awscc sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
