### PR TITLE
codegen: deferred_populate_overrides + ACM Certificate.status (refs carina#3034)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
+source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
 dependencies = [
  "argon2",
  "futures",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
+source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
+source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -133,6 +133,10 @@ struct AttrInfo {
     is_read_only: bool,
     /// Whether the field contributes to anonymous resource identity hashing
     is_identity: bool,
+    /// Whether the AWS API populates this field asynchronously after Create
+    /// (carina#3034). Validate-time check rejects chained references to
+    /// such a field unless the user has declared a `wait` block.
+    is_deferred_populate: bool,
     /// Description from Smithy docs
     description: Option<String>,
     /// Enum info if this attribute is an enum
@@ -429,6 +433,12 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     // Build identity override set
     let identity_overrides: HashSet<&str> = res.identity_overrides.iter().copied().collect();
 
+    // Build deferred-populate override set (carina#3034). Names are
+    // PascalCase, matched against `name` (Smithy member name) before
+    // it is snake_cased for the schema.
+    let deferred_populate_overrides: HashSet<&str> =
+        res.deferred_populate_overrides.iter().copied().collect();
+
     // Build extra read-only set
     let extra_read_only: HashSet<&str> = res.extra_read_only.iter().copied().collect();
 
@@ -680,6 +690,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         );
 
         let is_identity = identity_overrides.contains(name.as_str());
+        let is_deferred_populate = deferred_populate_overrides.contains(name.as_str());
 
         attrs.push(AttrInfo {
             snake_name,
@@ -689,6 +700,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_create_only,
             is_read_only,
             is_identity,
+            is_deferred_populate,
             description,
             enum_info,
         });
@@ -725,6 +737,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_create_only,
             is_read_only,
             is_identity: identity_overrides.contains(extra.name),
+            is_deferred_populate: deferred_populate_overrides.contains(extra.name),
             description: extra.description.map(|s| s.to_string()),
             enum_info: None,
         });
@@ -757,6 +770,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_create_only: false,
             is_read_only: true,
             is_identity: false,
+            is_deferred_populate: deferred_populate_overrides.contains(name.as_str()),
             description,
             enum_info,
         });
@@ -990,6 +1004,9 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         }
         if attr.is_identity {
             attr_code.push_str("\n\x20               .identity()");
+        }
+        if attr.is_deferred_populate {
+            attr_code.push_str("\n\x20               .deferred_populate()");
         }
 
         if let Some(ref desc) = attr.description {

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -88,6 +88,14 @@ pub struct ResourceDef {
     /// Fields to mark as identity (contribute to anonymous resource identifier hashing).
     /// Use for attributes that distinguish same-type resources sharing create-only values.
     pub identity_overrides: Vec<&'static str>,
+    /// Fields whose value the AWS API populates *asynchronously after Create
+    /// returns* — chained references to these from another resource will be
+    /// rejected at validate time unless the user has declared a `wait`
+    /// block on the binding (carina#3034). Examples: ACM `Status`
+    /// (PENDING_VALIDATION → ISSUED), CloudFront `DomainName`,
+    /// RDS `Endpoint`. Names are PascalCase, matching the rest of
+    /// `ResourceDef`'s `*_overrides` Vecs.
+    pub deferred_populate_overrides: Vec<&'static str>,
     /// Read-back projections for attributes that are not direct members of
     /// the read structure. The DSL attribute already lives in the schema
     /// (typically because the create input already contains it); this only
@@ -323,6 +331,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.subnet
@@ -358,6 +367,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             // private_dns_name_options_on_launch is a nested struct on the
             // read shape; collapse it into a single Value::Map attribute
             // so the DSL surface stays flat.
@@ -403,6 +413,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                 ),
             }],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.route_table
@@ -429,6 +440,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.route
@@ -473,6 +485,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.security_group
@@ -499,6 +512,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.security_group_ingress
@@ -553,6 +567,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.security_group_egress
@@ -607,6 +622,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.egress_only_internet_gateway
@@ -633,6 +649,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             // VpcId lives on Attachments[0].VpcId in the read response;
             // there is no top-level VpcId getter on EgressOnlyInternetGateway.
             derived_attributes: vec![DerivedAttribute {
@@ -673,6 +690,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.flow_log
@@ -706,6 +724,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.nat_gateway
@@ -739,6 +758,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             // AllocationId lives on NatGatewayAddresses[0].AllocationId in the
             // read response; there is no top-level AllocationId getter on
             // NatGateway.
@@ -774,6 +794,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.transit_gateway
@@ -803,6 +824,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             // The TransitGatewayRequestOptions sub-struct on the response
             // is flattened into top-level attributes (matching the DSL
             // surface, which doesn't expose `options` as a nested struct).
@@ -875,6 +897,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.vpc_endpoint
@@ -911,6 +934,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             // SecurityGroupIds is a write-side input
             // (CreateVpcEndpointRequest.SecurityGroupIds: List<String>) but
             // the read structure exposes it as Groups[*].GroupId on a
@@ -958,6 +982,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.vpc_peering_connection
@@ -984,6 +1009,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             // The peering response carries the requester / accepter VPCs
             // in two parallel `VpcPeeringConnectionVpcInfo` sub-structs;
             // the DSL surface flattens both, with the accepter-side
@@ -1043,6 +1069,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
     ]
@@ -1163,6 +1190,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // organizations.account
@@ -1194,6 +1222,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
     ]
@@ -1245,6 +1274,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketPolicy — attaches a resource-based policy to an existing
@@ -1288,6 +1318,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketVersioning — controls the versioning configuration of an
@@ -1355,6 +1386,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketAcl — sets the canned ACL on an existing S3 bucket.
@@ -1402,6 +1434,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             read_only_overrides: vec![],
             extra_attributes: vec![],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketOwnershipControls — sets the ObjectOwnership setting on
@@ -1450,6 +1483,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 ),
             }],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketServerSideEncryptionConfiguration — controls the SSE
@@ -1499,6 +1533,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 description: Some("List of server-side encryption rules to apply to the bucket."),
             }],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketReplicationConfiguration — controls cross-region (or
@@ -1550,6 +1585,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketLifecycleConfiguration — controls object lifecycle rules
@@ -1594,6 +1630,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 description: Some("Lifecycle rules to apply to the bucket."),
             }],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketWebsiteConfiguration — configures static-website hosting.
@@ -1657,6 +1694,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketCorsConfiguration — controls CORS rules on an existing
@@ -1699,6 +1737,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 description: Some("CORS rules to apply to the bucket."),
             }],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketNotificationConfiguration — wires bucket events to
@@ -1785,6 +1824,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketLogging — controls server-access logging on a bucket.
@@ -1845,6 +1885,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketPublicAccessBlock — controls the Public Access Block
@@ -1927,6 +1968,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 },
             ],
             identity_overrides: vec![],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
     ]
@@ -2064,6 +2106,22 @@ pub fn acm_resources() -> Vec<ResourceDef> {
         read_only_overrides: vec![],
         extra_attributes: vec![],
         identity_overrides: vec![],
+        // ACM transitions Status PENDING_VALIDATION → ISSUED
+        // asynchronously after RequestCertificate returns. Downstream
+        // resources that read `cert.status` directly without a
+        // synchronizing `wait` block hit the carina#3032 failure
+        // mode at apply time. carina#3034 marks this here so
+        // validate flags it before apply.
+        //
+        // `domain_validation_options[*].resource_record_*` are also
+        // populated asynchronously, but the codegen schema currently
+        // models DVO with the request-side struct fields only
+        // (`domain_name` + `validation_domain`), missing the
+        // read-side `resource_record` substruct. Once that codegen
+        // bug is fixed, mark the inner field with `.deferred_populate()`
+        // via this list — it is the same mechanism, just one level
+        // deeper into the schema.
+        deferred_populate_overrides: vec!["Status"],
         derived_attributes: vec![],
     }]
 }
@@ -2121,6 +2179,7 @@ pub fn route53_resources() -> Vec<ResourceDef> {
                 description: Some("The ID of the hosted zone that contains this record set."),
             }],
             identity_overrides: vec!["Type"],
+            deferred_populate_overrides: vec![],
             derived_attributes: vec![],
         },
     ]
@@ -2198,6 +2257,7 @@ pub fn iam_resources() -> Vec<ResourceDef> {
         read_only_overrides: vec![],
         extra_attributes: vec![],
         identity_overrides: vec![],
+        deferred_populate_overrides: vec![],
         derived_attributes: vec![],
     }]
 }
@@ -2243,6 +2303,7 @@ pub fn logs_resources() -> Vec<ResourceDef> {
             ),
         }],
         identity_overrides: vec![],
+        deferred_populate_overrides: vec![],
         derived_attributes: vec![],
     }]
 }
@@ -2497,6 +2558,7 @@ pub fn sqs_resources() -> Vec<ResourceDef> {
             },
         ],
         identity_overrides: vec![],
+        deferred_populate_overrides: vec![],
         derived_attributes: vec![],
     }]
 }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -256,6 +256,13 @@ fn proto_to_core_struct_field(f: &ProtoStructField) -> CoreStructField {
         description: f.description.clone(),
         provider_name: f.provider_name.clone(),
         block_name: f.block_name.clone(),
+        // The WIT contract does not transmit `deferred_populate`
+        // (carina#3034). The annotation lives entirely in the host-
+        // side schema (set by codegen output in
+        // `carina-provider-aws/src/schemas/generated/`), which is
+        // loaded directly via `SchemaRegistry` rather than crossing
+        // the WASM boundary.
+        deferred_populate: false,
     }
 }
 
@@ -274,6 +281,8 @@ fn _proto_to_core_attribute_schema(a: &ProtoAttributeSchema) -> CoreAttributeSch
         block_name: a.block_name.clone(),
         write_only: a.write_only,
         identity: a.identity,
+        // See `proto_to_core_struct_field` for the rationale.
+        deferred_populate: false,
     }
 }
 

--- a/carina-provider-aws/src/schemas/generated/acm/certificate.rs
+++ b/carina-provider-aws/src/schemas/generated/acm/certificate.rs
@@ -282,6 +282,7 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
                 dsl_aliases: vec![("EXPIRED".to_string(), "expired".to_string()), ("FAILED".to_string(), "failed".to_string()), ("INACTIVE".to_string(), "inactive".to_string()), ("ISSUED".to_string(), "issued".to_string()), ("PENDING_VALIDATION".to_string(), "pending_validation".to_string()), ("REVOKED".to_string(), "revoked".to_string()), ("VALIDATION_TIMED_OUT".to_string(), "validation_timed_out".to_string())],
             })
                 .read_only()
+                .deferred_populate()
                 .with_description("The status of the certificate. A certificate enters status PENDING_VALIDATION upon being requested, unless it fails for any of the reasons given in th... (read-only)")
                 .with_provider_name("Status"),
         )


### PR DESCRIPTION
## Summary

Plumbs the new `AttributeSchema::deferred_populate()` / `StructField::deferred_populate()` builders (carina#3034 core impl, carina-rs/carina#3036) through the codegen pipeline, and applies the annotation to ACM `Certificate.status` — the first attribute marked deferred-populate in this provider. Refs carina-rs/carina#3034.

## Codegen mechanism

- `ResourceDef.deferred_populate_overrides: Vec<&'static str>` — PascalCase attribute names matching the rest of the `*_overrides` Vecs.
- `AttrInfo.is_deferred_populate: bool` — set by membership in the override Vec.
- Codegen template emits `.deferred_populate()` next to `.identity()` so the rendered schema marks the asynchronously-populated attribute.

## ACM Certificate.status

ACM transitions `Status` PENDING_VALIDATION → ISSUED asynchronously after `RequestCertificate` returns. Downstream resources reading `cert.status` directly without a synchronizing `wait` block hit the carina-rs/carina#3032 failure mode at apply time. With this annotation, `carina validate` rejects the chained reference at parse time and points the user at `wait cert`.

## DVO follow-up

`domain_validation_options[*].resource_record_*` are also populated asynchronously and are the more common carina#3032 trigger, but the codegen schema currently models DVO with the request-side struct fields only (`domain_name` + `validation_domain`), missing the read-side `resource_record` substruct. Once that codegen schema bug is fixed (separate follow-up — the core mechanism is the same), mark the inner field via this list. Tracking comment left inline in `acm_resources()`.

## carina-core dep bump

- `86eaa70a` → `455e6fa1` (post-carina-rs/carina#3036 main).

## convert.rs

Defaults `deferred_populate: false` when lowering proto schemas across the WASM boundary — the annotation lives entirely in the host-side schema (carina-rs/carina#3035 §"WIT contract").

## Test plan

- [x] `cargo nextest run` — 375/375 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — ok
- [x] Generated diff inspected: single `+ .deferred_populate()` on ACM Certificate `status` (no other regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
