### PR TITLE
codegen: ACM Certificate.domain_validation_options uses read shape (closes #296)

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -442,6 +442,24 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     // Build extra read-only set
     let extra_read_only: HashSet<&str> = res.extra_read_only.iter().copied().collect();
 
+    // Build read-shape override set (carina-provider-aws#296). Names
+    // here force the codegen to use the read structure's member_ref
+    // for the attribute's type, even if the create input has a
+    // narrower shape under the same name. The attribute is also
+    // forced read-only — the rich response shape cannot be
+    // round-tripped back into the create input.
+    let read_shape_overrides: HashSet<&str> = res.read_shape_overrides.iter().copied().collect();
+
+    // Build deferred-populate StructField override set (carina#3034).
+    // Each tuple is (attr_pascal_name, member_pascal_name); used
+    // when only specific inner fields of a struct/list-of-struct
+    // attribute populate asynchronously, not the whole attribute.
+    let deferred_populate_struct_fields: HashSet<(&str, &str)> = res
+        .deferred_populate_struct_field_overrides
+        .iter()
+        .copied()
+        .collect();
+
     // Build enum alias map: attr_snake_name -> [(canonical, alias)]
     let mut enum_alias_map: HashMap<&str, Vec<(&str, &str)>> = HashMap::new();
     for (attr, alias, canonical) in &res.enum_aliases {
@@ -531,6 +549,13 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             }
             if name == "Tags" {
                 continue; // handled separately
+            }
+            // Skip names whose schema type should come from the read
+            // structure instead — they will be inserted into
+            // `read_only_fields` below from the read_structure's
+            // member_ref. carina-provider-aws#296.
+            if read_shape_overrides.contains(name.as_str()) {
+                continue;
             }
             writable_fields.insert(name.clone(), member_ref);
         }
@@ -684,6 +709,8 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
                 to_dsl_overrides: &to_dsl_overrides,
                 all_enums: &mut all_enums,
                 all_ranged_ints: &mut all_ranged_ints,
+                current_root_attr: Some(name.as_str()),
+                deferred_populate_struct_fields: &deferred_populate_struct_fields,
             },
             &member_ref.target,
             name,
@@ -757,6 +784,8 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
                 to_dsl_overrides: &to_dsl_overrides,
                 all_enums: &mut all_enums,
                 all_ranged_ints: &mut all_ranged_ints,
+                current_root_attr: Some(name.as_str()),
+                deferred_populate_struct_fields: &deferred_populate_struct_fields,
             },
             &member_ref.target,
             name,
@@ -1162,6 +1191,18 @@ struct TypeResolutionContext<'a> {
     to_dsl_overrides: &'a HashMap<&'a str, &'a str>,
     all_enums: &'a mut BTreeMap<String, EnumInfo>,
     all_ranged_ints: &'a mut BTreeMap<String, IntRange>,
+    /// Top-level attribute being resolved — set by callers in the
+    /// writable / read-only loops, used by `generate_struct_type` to
+    /// decide whether a nested StructField needs `.deferred_populate()`.
+    /// `None` for callers (e.g. inside enum collection passes) that
+    /// don't have an attribute context.
+    current_root_attr: Option<&'a str>,
+    /// `(attr_pascal_name, member_pascal_name)` pairs whose nested
+    /// StructField should be marked `.deferred_populate()`. Carries
+    /// `ResourceDef.deferred_populate_struct_field_overrides` —
+    /// `generate_struct_type` checks `(current_root_attr, member)`
+    /// against this set when emitting each field. carina#3034.
+    deferred_populate_struct_fields: &'a HashSet<(&'a str, &'a str)>,
 }
 
 /// Resolve a Smithy type to a Carina type code string.
@@ -1354,6 +1395,13 @@ fn generate_struct_type(
         let mut field_code = format!("StructField::new(\"{}\", {})", snake_name, field_type);
         if is_required {
             field_code.push_str(".required()");
+        }
+        if let Some(root_attr) = ctx.current_root_attr
+            && ctx
+                .deferred_populate_struct_fields
+                .contains(&(root_attr, field_name.as_str()))
+        {
+            field_code.push_str(".deferred_populate()");
         }
         if let Some(desc) = SmithyModel::documentation(&member_ref.traits) {
             let escaped = escape_description(desc);

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -96,6 +96,42 @@ pub struct ResourceDef {
     /// RDS `Endpoint`. Names are PascalCase, matching the rest of
     /// `ResourceDef`'s `*_overrides` Vecs.
     pub deferred_populate_overrides: Vec<&'static str>,
+    /// Per-(field, member) overrides for `StructField.deferred_populate`
+    /// inside a top-level attribute. Used when only specific inner
+    /// fields of a struct/list-of-struct attribute populate
+    /// asynchronously, not the whole attribute (carina#3034).
+    ///
+    /// Each tuple is `(field_pascal_name, member_pascal_name)`. The
+    /// codegen looks up the rendered struct's StructField list and
+    /// adds `.deferred_populate()` to the matching member.
+    ///
+    /// Example: ACM `Certificate.DomainValidationOptions[*].ResourceRecord`
+    /// is populated asynchronously after RequestCertificate; the user
+    /// dereferences `cert.domain_validation_options[0].resource_record`
+    /// in a `route53.RecordSet` and needs validate to flag it without
+    /// a `wait`.
+    pub deferred_populate_struct_field_overrides: Vec<(&'static str, &'static str)>,
+    /// Fields whose schema type should come from the *read structure*
+    /// rather than the create input — for attributes where the AWS
+    /// API's request shape differs from its response shape and only
+    /// the response shape is what downstream DSL chained accesses
+    /// reference (carina-provider-aws#296).
+    ///
+    /// Example: ACM `Certificate.DomainValidationOptions` is typed
+    /// `List<DomainValidationOption{domain_name, validation_domain}>`
+    /// in the create input but
+    /// `List<DomainValidation{domain_name, resource_record{name, type, value}, validation_status, ...}>`
+    /// in the read response (`CertificateDetail`). The read shape is
+    /// the one users want to chain into (the carina#3032 trigger
+    /// case). Without this override the codegen picks the create-side
+    /// shape, the read-side `resource_record_*` fields are missing
+    /// from the generated schema, and the type-narrowing pass cannot
+    /// see them.
+    ///
+    /// Implies the attribute is treated as read-only (the rich
+    /// read-side shape cannot be round-tripped back into the create
+    /// input). Names are PascalCase.
+    pub read_shape_overrides: Vec<&'static str>,
     /// Read-back projections for attributes that are not direct members of
     /// the read structure. The DSL attribute already lives in the schema
     /// (typically because the create input already contains it); this only
@@ -332,6 +368,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.subnet
@@ -368,6 +406,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             // private_dns_name_options_on_launch is a nested struct on the
             // read shape; collapse it into a single Value::Map attribute
             // so the DSL surface stays flat.
@@ -414,6 +454,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             }],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.route_table
@@ -441,6 +483,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.route
@@ -486,6 +530,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.security_group
@@ -513,6 +559,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.security_group_ingress
@@ -568,6 +616,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.security_group_egress
@@ -623,6 +673,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.egress_only_internet_gateway
@@ -650,6 +702,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             // VpcId lives on Attachments[0].VpcId in the read response;
             // there is no top-level VpcId getter on EgressOnlyInternetGateway.
             derived_attributes: vec![DerivedAttribute {
@@ -691,6 +745,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.flow_log
@@ -725,6 +781,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.nat_gateway
@@ -759,6 +817,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             // AllocationId lives on NatGatewayAddresses[0].AllocationId in the
             // read response; there is no top-level AllocationId getter on
             // NatGateway.
@@ -795,6 +855,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.transit_gateway
@@ -825,6 +887,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             // The TransitGatewayRequestOptions sub-struct on the response
             // is flattened into top-level attributes (matching the DSL
             // surface, which doesn't expose `options` as a nested struct).
@@ -898,6 +962,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.vpc_endpoint
@@ -935,6 +1001,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             // SecurityGroupIds is a write-side input
             // (CreateVpcEndpointRequest.SecurityGroupIds: List<String>) but
             // the read structure exposes it as Groups[*].GroupId on a
@@ -983,6 +1051,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // ec2.vpc_peering_connection
@@ -1010,6 +1080,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             // The peering response carries the requester / accepter VPCs
             // in two parallel `VpcPeeringConnectionVpcInfo` sub-structs;
             // the DSL surface flattens both, with the accepter-side
@@ -1070,6 +1142,8 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
     ]
@@ -1191,6 +1265,8 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // organizations.account
@@ -1223,6 +1299,8 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
     ]
@@ -1275,6 +1353,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketPolicy — attaches a resource-based policy to an existing
@@ -1319,6 +1399,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketVersioning — controls the versioning configuration of an
@@ -1387,6 +1469,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketAcl — sets the canned ACL on an existing S3 bucket.
@@ -1435,6 +1519,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             extra_attributes: vec![],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketOwnershipControls — sets the ObjectOwnership setting on
@@ -1484,6 +1570,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             }],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketServerSideEncryptionConfiguration — controls the SSE
@@ -1534,6 +1622,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             }],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketReplicationConfiguration — controls cross-region (or
@@ -1586,6 +1676,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketLifecycleConfiguration — controls object lifecycle rules
@@ -1631,6 +1723,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             }],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketWebsiteConfiguration — configures static-website hosting.
@@ -1695,6 +1789,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketCorsConfiguration — controls CORS rules on an existing
@@ -1738,6 +1834,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             }],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketNotificationConfiguration — wires bucket events to
@@ -1825,6 +1923,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketLogging — controls server-access logging on a bucket.
@@ -1886,6 +1986,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
         // s3.BucketPublicAccessBlock — controls the Public Access Block
@@ -1969,6 +2071,8 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
     ]
@@ -2112,16 +2216,31 @@ pub fn acm_resources() -> Vec<ResourceDef> {
         // synchronizing `wait` block hit the carina#3032 failure
         // mode at apply time. carina#3034 marks this here so
         // validate flags it before apply.
-        //
-        // `domain_validation_options[*].resource_record_*` are also
-        // populated asynchronously, but the codegen schema currently
-        // models DVO with the request-side struct fields only
-        // (`domain_name` + `validation_domain`), missing the
-        // read-side `resource_record` substruct. Once that codegen
-        // bug is fixed, mark the inner field with `.deferred_populate()`
-        // via this list — it is the same mechanism, just one level
-        // deeper into the schema.
         deferred_populate_overrides: vec!["Status"],
+        // The ACM read-back populates `DomainValidationOptions[*]
+        // .ResourceRecord` only after the validation step has computed
+        // the CNAME — so a downstream RecordSet that reads
+        // `cert.domain_validation_options[0].resource_record` directly
+        // hits the carina#3032 failure mode just like `Status`. Mark
+        // the inner StructField asynchronous so validate flags it.
+        // Requires `read_shape_overrides` below to surface the
+        // `ResourceRecord` field from the read structure in the first
+        // place — the request-shape `DomainValidationOption` does not
+        // have it.
+        deferred_populate_struct_field_overrides: vec![(
+            "DomainValidationOptions",
+            "ResourceRecord",
+        )],
+        // ACM's `DomainValidationOptions` is one of the rare AWS
+        // attributes whose request shape is meaningfully narrower
+        // than its response shape. The create input takes a list of
+        // `(domain_name, validation_domain)` tuples (used only when
+        // overriding the email validation domain); the read response
+        // returns a list of richer entries with `resource_record`
+        // (the CNAME the user must publish), `validation_status`,
+        // etc. — the part downstream resources actually want to
+        // chain into. carina-rs/carina#3032 trigger lives here.
+        read_shape_overrides: vec!["DomainValidationOptions"],
         derived_attributes: vec![],
     }]
 }
@@ -2180,6 +2299,8 @@ pub fn route53_resources() -> Vec<ResourceDef> {
             }],
             identity_overrides: vec!["Type"],
             deferred_populate_overrides: vec![],
+            deferred_populate_struct_field_overrides: vec![],
+            read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
     ]
@@ -2258,6 +2379,8 @@ pub fn iam_resources() -> Vec<ResourceDef> {
         extra_attributes: vec![],
         identity_overrides: vec![],
         deferred_populate_overrides: vec![],
+        deferred_populate_struct_field_overrides: vec![],
+        read_shape_overrides: vec![],
         derived_attributes: vec![],
     }]
 }
@@ -2304,6 +2427,8 @@ pub fn logs_resources() -> Vec<ResourceDef> {
         }],
         identity_overrides: vec![],
         deferred_populate_overrides: vec![],
+        deferred_populate_struct_field_overrides: vec![],
+        read_shape_overrides: vec![],
         derived_attributes: vec![],
     }]
 }
@@ -2559,6 +2684,8 @@ pub fn sqs_resources() -> Vec<ResourceDef> {
         ],
         identity_overrides: vec![],
         deferred_populate_overrides: vec![],
+        deferred_populate_struct_field_overrides: vec![],
+        read_shape_overrides: vec![],
         derived_attributes: vec![],
     }]
 }

--- a/carina-provider-aws/src/schemas/generated/acm/certificate.rs
+++ b/carina-provider-aws/src/schemas/generated/acm/certificate.rs
@@ -127,18 +127,6 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
                 .with_provider_name("DomainName"),
         )
         .attribute(
-            AttributeSchema::new("domain_validation_options", AttributeType::list(AttributeType::Struct {
-                    name: "DomainValidationOption".to_string(),
-                    fields: vec![
-                    StructField::new("domain_name", AttributeType::String).required().with_description("A fully qualified domain name (FQDN) in the certificate request.").with_provider_name("DomainName"),
-                    StructField::new("validation_domain", AttributeType::String).required().with_description("The domain name that you want ACM to use to send you validation emails. This domain name is the suffix of the email addresses that you want ACM to use...").with_provider_name("ValidationDomain")
-                    ],
-                }))
-                .create_only()
-                .with_description("The domain name that you want ACM to use to send you emails so that you can validate domain ownership.")
-                .with_provider_name("DomainValidationOptions"),
-        )
-        .attribute(
             AttributeSchema::new("idempotency_token", AttributeType::String)
                 .create_only()
                 .with_description("Customer chosen string that can be used to distinguish between calls to RequestCertificate. Idempotency tokens time out after one hour. Therefore, if ...")
@@ -199,6 +187,51 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
                 .read_only()
                 .with_description("The Amazon Resource Name (ARN) of the certificate. For more information about ARNs, see Amazon Resource Names (ARNs) in the Amazon Web Services Genera... (read-only)")
                 .with_provider_name("CertificateArn"),
+        )
+        .attribute(
+            AttributeSchema::new("domain_validation_options", AttributeType::list(AttributeType::Struct {
+                    name: "DomainValidation".to_string(),
+                    fields: vec![
+                    StructField::new("domain_name", AttributeType::String).required().with_description("A fully qualified domain name (FQDN) in the certificate. For example, www.example.com or example.com.").with_provider_name("DomainName"),
+                    StructField::new("http_redirect", AttributeType::Struct {
+                    name: "HttpRedirect".to_string(),
+                    fields: vec![
+                    StructField::new("redirect_from", AttributeType::String).with_description("The URL including the domain to be validated. The certificate authority sends GET requests here during validation.").with_provider_name("RedirectFrom"),
+                    StructField::new("redirect_to", AttributeType::String).with_description("The URL hosting the validation token. RedirectFrom must return this content or redirect here.").with_provider_name("RedirectTo")
+                    ],
+                }).with_description("Contains information for HTTP-based domain validation of certificates requested through Amazon CloudFront and issued by ACM. This field exists only wh...").with_provider_name("HttpRedirect"),
+                    StructField::new("resource_record", AttributeType::Struct {
+                    name: "ResourceRecord".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_description("The name of the DNS record to create in your domain. This is supplied by ACM.").with_provider_name("Name"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "Type".to_string(),
+                values: vec!["CNAME".to_string()],
+                namespace: Some("aws.acm.Certificate".to_string()),
+                dsl_aliases: vec![("CNAME".to_string(), "cname".to_string())],
+            }).required().with_description("The type of DNS record. Currently this can be CNAME.").with_provider_name("Type"),
+                    StructField::new("value", AttributeType::String).required().with_description("The value of the CNAME record to add to your DNS database. This is supplied by ACM.").with_provider_name("Value")
+                    ],
+                }).deferred_populate().with_description("Contains the CNAME record that you add to your DNS database for domain validation. For more information, see Use DNS to Validate Domain Ownership. The...").with_provider_name("ResourceRecord"),
+                    StructField::new("validation_domain", AttributeType::String).with_description("The domain name that ACM used to send domain validation emails.").with_provider_name("ValidationDomain"),
+                    StructField::new("validation_emails", AttributeType::list(types::email())).with_description("A list of email addresses that ACM used to send domain validation emails.").with_provider_name("ValidationEmails"),
+                    StructField::new("validation_method", AttributeType::StringEnum {
+                name: "ValidationMethod".to_string(),
+                values: vec!["DNS".to_string(), "EMAIL".to_string(), "HTTP".to_string()],
+                namespace: Some("aws.acm.Certificate".to_string()),
+                dsl_aliases: vec![("DNS".to_string(), "dns".to_string()), ("EMAIL".to_string(), "email".to_string()), ("HTTP".to_string(), "http".to_string())],
+            }).with_description("Specifies the domain validation method.").with_provider_name("ValidationMethod"),
+                    StructField::new("validation_status", AttributeType::StringEnum {
+                name: "ValidationStatus".to_string(),
+                values: vec!["FAILED".to_string(), "PENDING_VALIDATION".to_string(), "SUCCESS".to_string()],
+                namespace: Some("aws.acm.Certificate".to_string()),
+                dsl_aliases: vec![("FAILED".to_string(), "failed".to_string()), ("PENDING_VALIDATION".to_string(), "pending_validation".to_string()), ("SUCCESS".to_string(), "success".to_string())],
+            }).with_description("The validation status of the domain name. This can be one of the following values: PENDING_VALIDATION SUCCESS FAILED").with_provider_name("ValidationStatus")
+                    ],
+                }))
+                .read_only()
+                .with_description("Contains information about the initial validation of each domain name that occurs as a result of the RequestCertificate request. This field exists onl... (read-only)")
+                .with_provider_name("DomainValidationOptions"),
         )
         .attribute(
             AttributeSchema::new("renewal_eligibility", AttributeType::StringEnum {

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 
-use aws_sdk_acm::types::{DomainValidationOption, ValidationMethod};
+use aws_sdk_acm::types::ValidationMethod;
 use indexmap::IndexMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -90,32 +90,15 @@ impl AwsProvider {
             // narrowing has already validated it.
             req = req.key_algorithm(key_algorithm.into());
         }
-        // `domain_validation_options` (per-SAN validation domain
-        // override) is parsed from a list of structs.
-        if let Some(Value::Concrete(ConcreteValue::List(opts))) =
-            resource.get_attr("domain_validation_options")
-        {
-            for entry in opts {
-                if let Value::Concrete(ConcreteValue::Map(map)) = entry {
-                    let domain = map.get("domain_name").and_then(extract_string);
-                    let validation_domain = map.get("validation_domain").and_then(extract_string);
-                    if let (Some(d), Some(vd)) = (domain, validation_domain) {
-                        let opt = DomainValidationOption::builder()
-                            .domain_name(d)
-                            .validation_domain(vd)
-                            .build()
-                            .map_err(|e| {
-                                ProviderError::api_error(sdk_error_message(
-                                    "Invalid domain_validation_option",
-                                    &e,
-                                ))
-                                .for_resource(id.clone())
-                            })?;
-                        req = req.domain_validation_options(opt);
-                    }
-                }
-            }
-        }
+        // The previous request-side `domain_validation_options`
+        // (per-SAN email validation domain override) has been
+        // dropped: the codegen schema now models DVO as the
+        // *response* shape (with `resource_record`, `validation_status`,
+        // ...) rather than the request shape (just `domain_name` +
+        // `validation_domain`), so the user cannot set it from DSL
+        // anymore. The override was a rare-use email-validation
+        // feature; the common DNS-validation path is unaffected.
+        // carina-rs/carina-provider-aws#296.
 
         let output = req.send().await.map_err(|e| {
             ProviderError::api_error(sdk_error_message("RequestCertificate failed", &e))
@@ -208,6 +191,11 @@ impl AwsProvider {
         // construct's primary use case.
         let dvs = cert.domain_validation_options();
         if !dvs.is_empty() {
+            // Emit the nested `resource_record: { name, type, value }`
+            // shape that matches the codegen-generated schema (#296).
+            // The DSL chained access is
+            // `cert.domain_validation_options[0].resource_record.value`,
+            // not the older flat `resource_record_value`.
             let mut list: Vec<Value> = Vec::with_capacity(dvs.len());
             for dv in dvs {
                 let mut m: IndexMap<String, Value> = IndexMap::new();
@@ -216,17 +204,22 @@ impl AwsProvider {
                     Value::Concrete(ConcreteValue::String(dv.domain_name().to_string())),
                 );
                 if let Some(rr) = dv.resource_record() {
-                    m.insert(
-                        "resource_record_name".to_string(),
+                    let mut rr_map: IndexMap<String, Value> = IndexMap::new();
+                    rr_map.insert(
+                        "name".to_string(),
                         Value::Concrete(ConcreteValue::String(rr.name().to_string())),
                     );
-                    m.insert(
-                        "resource_record_type".to_string(),
+                    rr_map.insert(
+                        "type".to_string(),
                         Value::Concrete(ConcreteValue::String(rr.r#type().as_str().to_string())),
                     );
-                    m.insert(
-                        "resource_record_value".to_string(),
+                    rr_map.insert(
+                        "value".to_string(),
                         Value::Concrete(ConcreteValue::String(rr.value().to_string())),
+                    );
+                    m.insert(
+                        "resource_record".to_string(),
+                        Value::Concrete(ConcreteValue::Map(rr_map)),
                     );
                 }
                 if let Some(status) = dv.validation_status() {

--- a/examples/acm_certificate/main.crn
+++ b/examples/acm_certificate/main.crn
@@ -40,10 +40,10 @@ let cert = aws.acm.Certificate {
 # apply time after the cert resource finishes its create.
 let validation_record = aws.route53.RecordSet {
   hosted_zone_id   = 'Z123EXAMPLE'
-  name             = cert.domain_validation_options[0].resource_record_name
-  type             = cert.domain_validation_options[0].resource_record_type
+  name             = cert.domain_validation_options[0].resource_record.name
+  type             = cert.domain_validation_options[0].resource_record.type
   ttl              = 60
-  resource_records = [cert.domain_validation_options[0].resource_record_value]
+  resource_records = [cert.domain_validation_options[0].resource_record.value]
 }
 
 # Block downstream resources until the cert is ISSUED.


### PR DESCRIPTION
## Summary

Closes #296. Unblocks carina-rs/carina#3032.

The ACM Certificate codegen schema previously modeled `domain_validation_options` with the **create-input** struct (`DomainValidationOption{domain_name, validation_domain}`), which is a rare-use email-validation override. The **read response** uses a much richer struct (`DomainValidation{domain_name, resource_record, validation_status, validation_method, http_redirect, ...}`), and that is what users actually want to chain into for DNS validation:

```crn
resource_records = [cert.domain_validation_options[0].resource_record.value]
```

Without this fix, that chained access fails the type-narrowing pass because `resource_record` doesn't exist in the create-side struct, and `carina-rs/carina#3034` cannot mark `resource_record_*` as deferred-populate because the fields don't exist in the schema.

## Two new codegen mechanisms

1. **`read_shape_overrides: Vec<&'static str>`** — names listed here force the codegen to use the read structure's `member_ref` instead of the create input's. The attribute is then emitted as read-only.
2. **`deferred_populate_struct_field_overrides: Vec<(&str, &str)>`** — `(attr_pascal_name, member_pascal_name)` pairs that mark a nested StructField as `.deferred_populate()` (carina#3034). Used when only specific inner fields populate asynchronously, not the whole attribute.

Both are threaded into `TypeResolutionContext` so `generate_struct_type` can consult them when emitting StructFields.

## ACM Certificate.DomainValidationOptions

- `read_shape_overrides`: `["DomainValidationOptions"]` — schema switches to the `DomainValidation` struct from `CertificateDetail`.
- `deferred_populate_struct_field_overrides`: `[("DomainValidationOptions", "ResourceRecord")]` — the `resource_record` substruct is populated only after ACM has computed the validation CNAME.

Result: `cert.domain_validation_options[0].resource_record.value` is now a typed access in the schema, and a chained reference to it without a `wait cert` block is rejected at validate time by carina-rs/carina#3036's deferred-populate validation rule.

## Runtime change

`read_acm_certificate` now emits the nested `resource_record: { name, type, value }` shape matching the schema, instead of the older flattened `resource_record_name/_type/_value` keys. Updated `examples/acm_certificate/main.crn` to use the nested form.

The previous request-side `domain_validation_options` parser is removed — the schema is now read-only, so the user cannot supply DVO from DSL anymore. The dropped path was a rare email-validation override; the common DNS path is unaffected.

## Test plan

- [x] `cargo nextest run` — 375/375 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — ok
- [x] Generated diff inspected: DVO replaced with read shape, `resource_record` marked `.deferred_populate()`, top-level attribute marked `.read_only()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
