### PR TITLE
fix: poll for DVO.resource_record after RequestCertificate (closes #298)

### DIFF
--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -110,6 +110,42 @@ impl AwsProvider {
                 .for_resource(id.clone())
         })?;
 
+        let validation_method = resource
+            .get_attr("validation_method")
+            .and_then(extract_string)
+            .and_then(parse_validation_method);
+
+        // DNS validation populates DomainValidationOptions[].ResourceRecord
+        // asynchronously after RequestCertificate. Wait so the post-create
+        // read-back carries the records downstream resources reference.
+        // carina-rs/carina-provider-aws#298.
+        if matches!(validation_method, Some(ValidationMethod::Dns)) {
+            let cert = wait_for_dvo_populated(
+                &id,
+                || async {
+                    self.acm_client
+                        .describe_certificate()
+                        .certificate_arn(arn)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            ProviderError::api_error(sdk_error_message(
+                                "DescribeCertificate failed",
+                                &e,
+                            ))
+                            .for_resource(id.clone())
+                        })
+                        .map(|out| out.certificate().cloned())
+                },
+                6,
+                std::time::Duration::from_secs(5),
+            )
+            .await?;
+            return self
+                .read_acm_certificate_from_detail(&id, arn, Some(&cert))
+                .await;
+        }
+
         // Read back so the State carries every server-side attribute the
         // user might wait on (`status`, `domain_validation_options`, ...).
         self.read_acm_certificate(&id, Some(arn)).await
@@ -134,7 +170,23 @@ impl AwsProvider {
                 ProviderError::api_error(sdk_error_message("DescribeCertificate failed", &e))
                     .for_resource(id.clone())
             })?;
-        let Some(cert) = output.certificate() else {
+        self.read_acm_certificate_from_detail(id, arn, output.certificate())
+            .await
+    }
+
+    /// Build State for an ACM certificate from an already-fetched
+    /// `CertificateDetail`. Skips the `DescribeCertificate` call that
+    /// `read_acm_certificate` would otherwise make, letting callers
+    /// reuse a `DescribeCertificate` response they already have (the
+    /// create path's DVO-poll loop). Still calls `ListTagsForCertificate`
+    /// since that's a separate API.
+    pub(crate) async fn read_acm_certificate_from_detail(
+        &self,
+        id: &ResourceId,
+        arn: &str,
+        cert: Option<&aws_sdk_acm::types::CertificateDetail>,
+    ) -> ProviderResult<State> {
+        let Some(cert) = cert else {
             return Ok(State::not_found(id.clone()));
         };
 
@@ -341,5 +393,269 @@ impl AwsProvider {
                     .for_resource(id)
             })?;
         Ok(())
+    }
+}
+
+/// Poll a fetch closure that returns an ACM `CertificateDetail`
+/// until every `domain_validation_options[]` entry has its
+/// `resource_record` populated, or the attempt budget is exhausted.
+/// Returns the last fetched `CertificateDetail` so callers can build
+/// state from it without a redundant `DescribeCertificate`.
+///
+/// AWS populates the DNS validation record asynchronously after
+/// `RequestCertificate` returns. Without this loop the post-create
+/// read-back races AWS and may surface a state where
+/// `domain_validation_options` is empty or has entries lacking
+/// `resource_record`, leaving downstream chained references like
+/// `cert.domain_validation_options[0].resource_record.name`
+/// unresolvable.
+///
+/// `max_attempts` × `interval` bounds the total wait. The fetch
+/// closure is invoked up to `max_attempts` times, with `interval`
+/// between attempts (no sleep before the first attempt or after the
+/// last). On timeout, returns a `ProviderError::timeout` naming the
+/// resource so the operator can decide between retry and an AWS
+/// support escalation.
+pub(crate) async fn wait_for_dvo_populated<F, Fut>(
+    id: &ResourceId,
+    mut fetch: F,
+    max_attempts: u32,
+    interval: std::time::Duration,
+) -> ProviderResult<aws_sdk_acm::types::CertificateDetail>
+where
+    F: FnMut() -> Fut,
+    Fut:
+        std::future::Future<Output = ProviderResult<Option<aws_sdk_acm::types::CertificateDetail>>>,
+{
+    for attempt in 0..max_attempts {
+        if let Some(cert) = fetch().await? {
+            let dvs = cert.domain_validation_options();
+            if !dvs.is_empty() && dvs.iter().all(|dv| dv.resource_record().is_some()) {
+                return Ok(cert);
+            }
+        }
+        if attempt + 1 < max_attempts {
+            tokio::time::sleep(interval).await;
+        }
+    }
+    Err(ProviderError::timeout(format!(
+        "ACM did not populate domain_validation_options[].resource_record within \
+         {} attempts (~{:?}); the certificate exists but cannot be referenced by \
+         downstream resources yet. Retry the apply, or check the ACM console \
+         for the cert ARN.",
+        max_attempts,
+        interval.saturating_mul(max_attempts),
+    ))
+    .for_resource(id.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_acm::types::{CertificateDetail, DomainValidation, RecordType, ResourceRecord};
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    fn id() -> ResourceId {
+        ResourceId::with_provider("aws", "acm.Certificate", "test-cert")
+    }
+
+    fn dv_without_rr(domain: &str) -> DomainValidation {
+        DomainValidation::builder()
+            .domain_name(domain)
+            .build()
+            .expect("builder")
+    }
+
+    fn dv_with_rr(domain: &str) -> DomainValidation {
+        let rr = ResourceRecord::builder()
+            .name("_abc.example.com.")
+            .r#type(RecordType::Cname)
+            .value("_xyz.acm-validations.aws.")
+            .build()
+            .expect("rr builder");
+        DomainValidation::builder()
+            .domain_name(domain)
+            .resource_record(rr)
+            .build()
+            .expect("dv builder")
+    }
+
+    fn cert_with(dvs: Vec<DomainValidation>) -> CertificateDetail {
+        let mut b = CertificateDetail::builder().domain_name("example.com");
+        for dv in dvs {
+            b = b.domain_validation_options(dv);
+        }
+        b.build()
+    }
+
+    #[tokio::test]
+    async fn wait_for_dvo_returns_immediately_when_first_fetch_is_populated() {
+        let calls = Mutex::new(0u32);
+        let result = wait_for_dvo_populated(
+            &id(),
+            || async {
+                *calls.lock().unwrap() += 1;
+                Ok(Some(cert_with(vec![dv_with_rr("example.com")])))
+            },
+            6,
+            Duration::from_millis(0),
+        )
+        .await;
+        let cert = result.expect("expected Ok");
+        assert_eq!(*calls.lock().unwrap(), 1, "should not retry after success");
+        let dvs = cert.domain_validation_options();
+        assert_eq!(dvs.len(), 1);
+        assert!(dvs[0].resource_record().is_some());
+    }
+
+    #[tokio::test]
+    async fn wait_for_dvo_retries_until_resource_record_appears() {
+        let calls = Mutex::new(0u32);
+        let result = wait_for_dvo_populated(
+            &id(),
+            || async {
+                let mut c = calls.lock().unwrap();
+                *c += 1;
+                let attempt = *c;
+                drop(c);
+                if attempt < 3 {
+                    Ok(Some(cert_with(vec![dv_without_rr("example.com")])))
+                } else {
+                    Ok(Some(cert_with(vec![dv_with_rr("example.com")])))
+                }
+            },
+            6,
+            Duration::from_millis(0),
+        )
+        .await;
+        let cert = result.expect("expected Ok");
+        assert_eq!(
+            *calls.lock().unwrap(),
+            3,
+            "should poll until populated, not over-poll",
+        );
+        assert!(
+            cert.domain_validation_options()
+                .iter()
+                .all(|dv| dv.resource_record().is_some()),
+            "returned CertificateDetail must carry the populated DVO",
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_dvo_requires_every_entry_to_have_resource_record() {
+        let calls = Mutex::new(0u32);
+        let result = wait_for_dvo_populated(
+            &id(),
+            || async {
+                let mut c = calls.lock().unwrap();
+                *c += 1;
+                let attempt = *c;
+                drop(c);
+                if attempt < 2 {
+                    Ok(Some(cert_with(vec![
+                        dv_with_rr("example.com"),
+                        dv_without_rr("alt.example.com"),
+                    ])))
+                } else {
+                    Ok(Some(cert_with(vec![
+                        dv_with_rr("example.com"),
+                        dv_with_rr("alt.example.com"),
+                    ])))
+                }
+            },
+            6,
+            Duration::from_millis(0),
+        )
+        .await;
+        let cert = result.expect("expected Ok");
+        assert_eq!(*calls.lock().unwrap(), 2);
+        assert_eq!(cert.domain_validation_options().len(), 2);
+        assert!(
+            cert.domain_validation_options()
+                .iter()
+                .all(|dv| dv.resource_record().is_some()),
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_dvo_times_out_after_max_attempts() {
+        let calls = Mutex::new(0u32);
+        let result = wait_for_dvo_populated(
+            &id(),
+            || async {
+                *calls.lock().unwrap() += 1;
+                Ok(Some(cert_with(vec![dv_without_rr("example.com")])))
+            },
+            4,
+            Duration::from_millis(0),
+        )
+        .await;
+        let err = result.expect_err("expected timeout error");
+        assert_eq!(
+            *calls.lock().unwrap(),
+            4,
+            "fetched exactly max_attempts times"
+        );
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("domain_validation_options"),
+            "error message must name the attribute; got: {msg}",
+        );
+        assert!(
+            msg.contains("4 attempts"),
+            "error must report the attempt budget; got: {msg}",
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_dvo_treats_empty_list_as_pending() {
+        let calls = Mutex::new(0u32);
+        let result = wait_for_dvo_populated(
+            &id(),
+            || async {
+                let mut c = calls.lock().unwrap();
+                *c += 1;
+                let attempt = *c;
+                drop(c);
+                if attempt < 2 {
+                    Ok(None)
+                } else {
+                    Ok(Some(cert_with(vec![dv_with_rr("example.com")])))
+                }
+            },
+            6,
+            Duration::from_millis(0),
+        )
+        .await;
+        let cert = result.expect("expected Ok");
+        assert_eq!(*calls.lock().unwrap(), 2);
+        assert!(
+            cert.domain_validation_options()
+                .iter()
+                .all(|dv| dv.resource_record().is_some()),
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_dvo_propagates_fetch_errors_immediately() {
+        let calls = Mutex::new(0u32);
+        let result = wait_for_dvo_populated(
+            &id(),
+            || async {
+                *calls.lock().unwrap() += 1;
+                Err(ProviderError::api_error("DescribeCertificate boom"))
+            },
+            6,
+            Duration::from_millis(0),
+        )
+        .await;
+        assert!(result.is_err(), "expected propagated error");
+        assert_eq!(
+            *calls.lock().unwrap(),
+            1,
+            "should not retry after a non-empty fetch error",
+        );
     }
 }


### PR DESCRIPTION
## Summary

`create_acm_certificate` now polls `DescribeCertificate` until every `domain_validation_options[].resource_record` is populated before returning state, when `validation_method = DNS`.

Before: `RequestCertificate` returns, the immediate read-back races AWS's async population, and the returned state often omits `domain_validation_options` or has entries missing `resource_record`. Downstream chained references like `cert.domain_validation_options[0].resource_record.name` then fail at apply time with carina-core's "has not been published yet" error (carina-rs/carina#3046).

After: state always carries the populated DVO when this function returns successfully, or fails fast with a clear timeout error pointing at the cert ARN.

## Why not the SDK waiter?

`aws-sdk-acm` ships a `certificate_validated` waiter, but it waits on `ValidationStatus == SUCCESS` — i.e. after the validation DNS record has been published and AWS has verified it. The validation record itself must be readable *during* `PENDING_VALIDATION` for the user to publish it. The SDK waiter is the wrong timing and is not used.

## Implementation

- **`wait_for_dvo_populated<F, Fut>(id, fetch, max_attempts, interval)`** — closure-based helper that calls `fetch` (returning `ProviderResult<Option<CertificateDetail>>`) up to `max_attempts` times with `interval` between attempts, stopping when every DV entry has `resource_record` set. Returns the final `CertificateDetail` so the caller can build state without a second DescribeCertificate. On timeout, returns a `ProviderError::timeout` naming the attribute and the budget.
- **`create_acm_certificate`** — when `validation_method == DNS`, polls 6 × 5s = 30s, then threads the polled `CertificateDetail` into the new detail-base entry below to avoid the redundant API call. Email-validation and unspecified methods continue through the existing path unchanged.
- **`read_acm_certificate_from_detail(id, arn, Option<&CertificateDetail>)`** — new entry that builds state from an already-fetched detail. `read_acm_certificate` (ARN-base) now delegates to it. The split is necessary to reuse the poll's last detail; existing callers (`update_acm_certificate`, normal read path) are unchanged.

Per-iteration delay is 5s, matching the established `wait_for_ec2_state` pattern in `helpers.rs`. 6 attempts × 5s gives a 30s overall budget, which is comfortably above the observed sub-1s — few-seconds populate window for DNS validation but well below AWS's per-account API throttle thresholds.

## Tests

Six unit tests on the helper, all using closure mocks (no AWS calls):

- `wait_for_dvo_returns_immediately_when_first_fetch_is_populated`
- `wait_for_dvo_retries_until_resource_record_appears`
- `wait_for_dvo_requires_every_entry_to_have_resource_record`
- `wait_for_dvo_times_out_after_max_attempts`
- `wait_for_dvo_treats_empty_list_as_pending`
- `wait_for_dvo_propagates_fetch_errors_immediately`

Each retry-success test additionally asserts the returned `CertificateDetail` carries the populated DVO, so a regression that returned the wrong cert from the polling loop would be caught.

## Test plan

- [x] `cargo nextest run -p carina-provider-aws` — 214 tests pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — pass
- [x] `bash scripts/check-examples.sh` — pass
- [x] 5-round self-review — R1: added DVO-populated assertions to retry/timeout/empty tests; R2: corrected timeout error formula to `interval * max_attempts` (honest 30s budget); R3-5 clean
- [ ] Real-infra T6c smoke (carina-rs/infra registry ACM usecase) — user-driven; pending after merge

## Related

- carina-rs/carina#3046 — original symptom report (will close once this lands)
- carina-rs/carina#3042 — fixed the typo subcase
- carina-rs/carina#3048 — added the carina-core regression test pinning the chained-access positive path

Closes #298