### PR TITLE
Expose CloudFront's fixed hosted zone ID as namespaced constant

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -460,6 +460,15 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         .copied()
         .collect();
 
+    // Build per-(parent_struct, member) type override map (aws#302).
+    // Distinguishes struct fields by parent struct shape so the same
+    // member name can resolve to different types in different contexts.
+    let struct_field_type_overrides: HashMap<(&str, &str), &str> = res
+        .struct_field_type_overrides
+        .iter()
+        .map(|(p, m, t)| ((*p, *m), *t))
+        .collect();
+
     // Build enum alias map: attr_snake_name -> [(canonical, alias)]
     let mut enum_alias_map: HashMap<&str, Vec<(&str, &str)>> = HashMap::new();
     for (attr, alias, canonical) in &res.enum_aliases {
@@ -711,6 +720,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
                 all_ranged_ints: &mut all_ranged_ints,
                 current_root_attr: Some(name.as_str()),
                 deferred_populate_struct_fields: &deferred_populate_struct_fields,
+                struct_field_type_overrides: &struct_field_type_overrides,
             },
             &member_ref.target,
             name,
@@ -786,6 +796,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
                 all_ranged_ints: &mut all_ranged_ints,
                 current_root_attr: Some(name.as_str()),
                 deferred_populate_struct_fields: &deferred_populate_struct_fields,
+                struct_field_type_overrides: &struct_field_type_overrides,
             },
             &member_ref.target,
             name,
@@ -1203,6 +1214,12 @@ struct TypeResolutionContext<'a> {
     /// `generate_struct_type` checks `(current_root_attr, member)`
     /// against this set when emitting each field. carina#3034.
     deferred_populate_struct_fields: &'a HashSet<(&'a str, &'a str)>,
+    /// `(parent_struct, member) -> type_code` overrides for struct
+    /// fields, keyed by the immediate parent struct shape name (not the
+    /// top-level attribute). Lets a member like `HostedZoneId` resolve
+    /// to one type inside `AliasTarget` and another at the top level.
+    /// Carries `ResourceDef.struct_field_type_overrides` (aws#302).
+    struct_field_type_overrides: &'a HashMap<(&'a str, &'a str), &'a str>,
 }
 
 /// Resolve a Smithy type to a Carina type code string.
@@ -1359,7 +1376,20 @@ fn generate_struct_type(
         let snake_name = field_name.to_snake_case();
         let is_required = SmithyModel::is_required(member_ref);
 
-        let (field_type, enum_info) = resolve_type(ctx, &member_ref.target, field_name);
+        // Check `(parent_struct, member)` type override first — distinguishes
+        // a member name shared across structs (e.g. `HostedZoneId` in
+        // `AliasTarget` vs `RecordSet`). Falls through to the default
+        // resolve_type path when no per-parent override is registered.
+        let override_type = ctx
+            .struct_field_type_overrides
+            .get(&(struct_name, field_name.as_str()))
+            .copied();
+
+        let (field_type, enum_info) = if let Some(t) = override_type {
+            (t.to_string(), None)
+        } else {
+            resolve_type(ctx, &member_ref.target, field_name)
+        };
 
         // If enum detected, use shared schema enum type.
         let field_type = if let Some(ei) = enum_info {
@@ -2845,6 +2875,11 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
 
     let exclude: HashSet<&str> = res.exclude_fields.iter().copied().collect();
     let type_overrides: HashMap<&str, &str> = res.type_overrides.iter().copied().collect();
+    let struct_field_type_overrides: HashMap<(&str, &str), &str> = res
+        .struct_field_type_overrides
+        .iter()
+        .map(|(p, m, t)| ((*p, *m), *t))
+        .collect();
     let required_overrides: HashSet<&str> = res.required_overrides.iter().copied().collect();
     let read_only_overrides: HashSet<&str> = res.read_only_overrides.iter().copied().collect();
     let extra_read_only: HashSet<&str> = res.extra_read_only.iter().copied().collect();
@@ -3023,6 +3058,8 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
             name,
             &namespace,
             &type_overrides,
+            &struct_field_type_overrides,
+            None,
             &mut all_enums,
             &mut struct_defs,
         );
@@ -3074,6 +3111,8 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
             name,
             &namespace,
             &type_overrides,
+            &struct_field_type_overrides,
+            None,
             &mut all_enums,
             &mut struct_defs,
         );
@@ -3195,6 +3234,8 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
                     field_name,
                     &namespace,
                     &type_overrides,
+                    &struct_field_type_overrides,
+                    Some(struct_name.as_str()),
                     &mut all_enums,
                     &mut BTreeMap::new(),
                 );
@@ -3467,16 +3508,30 @@ fn generate_markdown_data_source(
 }
 
 /// Determine the display string for a type in markdown docs.
-#[allow(clippy::only_used_in_recursion)]
+///
+/// `parent_struct` is `Some(struct_name)` when this is called for a
+/// member of a struct-fields table (so per-`(parent, member)` overrides
+/// can fire), and `None` for top-level attributes and list-element
+/// recursion where no parent struct is in scope.
+#[allow(clippy::only_used_in_recursion, clippy::too_many_arguments)]
 fn type_display_string_md<'a>(
     model: &'a SmithyModel,
     target: &str,
     field_name: &str,
     namespace: &str,
     type_overrides: &HashMap<&str, &str>,
+    struct_field_type_overrides: &HashMap<(&str, &str), &str>,
+    parent_struct: Option<&str>,
     all_enums: &mut BTreeMap<String, EnumInfo>,
     struct_defs: &mut BTreeMap<String, Vec<(String, &'a carina_smithy::ShapeRef)>>,
 ) -> String {
+    // Per-(parent_struct, member) override wins over per-member and Smithy
+    // default. Distinguishes a member name shared across structs (aws#302).
+    if let Some(parent) = parent_struct
+        && let Some(&override_type) = struct_field_type_overrides.get(&(parent, field_name))
+    {
+        return type_code_to_display(override_type);
+    }
     // Check type overrides
     if let Some(&override_type) = type_overrides.get(field_name) {
         return type_code_to_display(override_type);
@@ -3553,6 +3608,8 @@ fn type_display_string_md<'a>(
                     field_name,
                     namespace,
                     type_overrides,
+                    struct_field_type_overrides,
+                    parent_struct,
                     all_enums,
                     struct_defs,
                 );

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -111,6 +111,21 @@ pub struct ResourceDef {
     /// in a `route53.RecordSet` and needs validate to flag it without
     /// a `wait`.
     pub deferred_populate_struct_field_overrides: Vec<(&'static str, &'static str)>,
+    /// Per-(parent_struct, member) type overrides for `StructField.field_type`.
+    /// Distinguishes a struct field by the *parent* struct shape, so a
+    /// member name that appears in multiple structs gets the right type
+    /// in each context.
+    ///
+    /// Each tuple is `(parent_struct_pascal_name, member_pascal_name,
+    /// type_code)`. `type_code` is a Rust expression that evaluates to
+    /// an `AttributeType` — typically a call into `super::types::…`.
+    ///
+    /// Example: route53 `AliasTarget.HostedZoneId` accepts the
+    /// `aws.cloudfront.HostedZoneId.global` namespaced constant
+    /// (resolving to `Z2FDTNDATAQYW2`), while the top-level
+    /// `RecordSet.HostedZoneId` is the user-supplied Route 53 zone ID
+    /// and stays plain String (aws#302).
+    pub struct_field_type_overrides: Vec<(&'static str, &'static str, &'static str)>,
     /// Fields whose schema type should come from the *read structure*
     /// rather than the create input — for attributes where the AWS
     /// API's request shape differs from its response shape and only
@@ -369,6 +384,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -407,6 +423,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             // private_dns_name_options_on_launch is a nested struct on the
             // read shape; collapse it into a single Value::Map attribute
@@ -455,6 +472,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -484,6 +502,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -531,6 +550,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -560,6 +580,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -617,6 +638,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -674,6 +696,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -703,6 +726,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             // VpcId lives on Attachments[0].VpcId in the read response;
             // there is no top-level VpcId getter on EgressOnlyInternetGateway.
@@ -746,6 +770,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -782,6 +807,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -818,6 +844,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             // AllocationId lives on NatGatewayAddresses[0].AllocationId in the
             // read response; there is no top-level AllocationId getter on
@@ -856,6 +883,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -888,6 +916,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             // The TransitGatewayRequestOptions sub-struct on the response
             // is flattened into top-level attributes (matching the DSL
@@ -963,6 +992,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1002,6 +1032,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             // SecurityGroupIds is a write-side input
             // (CreateVpcEndpointRequest.SecurityGroupIds: List<String>) but
@@ -1052,6 +1083,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1081,6 +1113,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             // The peering response carries the requester / accepter VPCs
             // in two parallel `VpcPeeringConnectionVpcInfo` sub-structs;
@@ -1143,6 +1176,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1266,6 +1300,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1300,6 +1335,7 @@ pub fn organizations_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1354,6 +1390,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1400,6 +1437,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1470,6 +1508,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1520,6 +1559,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1571,6 +1611,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1623,6 +1664,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1677,6 +1719,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1724,6 +1767,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1790,6 +1834,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1835,6 +1880,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1924,6 +1970,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -1987,6 +2034,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -2072,6 +2120,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -2231,6 +2280,7 @@ pub fn acm_resources() -> Vec<ResourceDef> {
             "DomainValidationOptions",
             "ResourceRecord",
         )],
+        struct_field_type_overrides: vec![],
         // ACM's `DomainValidationOptions` is one of the rare AWS
         // attributes whose request shape is meaningfully narrower
         // than its response shape. The create input takes a list of
@@ -2300,6 +2350,15 @@ pub fn route53_resources() -> Vec<ResourceDef> {
             identity_overrides: vec!["Type"],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],
+            // `AliasTarget.HostedZoneId` accepts the `aws.cloudfront.HostedZoneId.global`
+            // namespaced constant (resolved to `Z2FDTNDATAQYW2`) in addition to literal
+            // Route 53 hosted-zone IDs. The top-level `RecordSet.HostedZoneId` (the
+            // user's own Route 53 zone) is intentionally left as plain String (aws#302).
+            struct_field_type_overrides: vec![(
+                "AliasTarget",
+                "HostedZoneId",
+                "super::cloudfront_hosted_zone_id()",
+            )],
             read_shape_overrides: vec![],
             derived_attributes: vec![],
         },
@@ -2380,6 +2439,7 @@ pub fn iam_resources() -> Vec<ResourceDef> {
         identity_overrides: vec![],
         deferred_populate_overrides: vec![],
         deferred_populate_struct_field_overrides: vec![],
+        struct_field_type_overrides: vec![],
         read_shape_overrides: vec![],
         derived_attributes: vec![],
     }]
@@ -2428,6 +2488,7 @@ pub fn logs_resources() -> Vec<ResourceDef> {
         identity_overrides: vec![],
         deferred_populate_overrides: vec![],
         deferred_populate_struct_field_overrides: vec![],
+        struct_field_type_overrides: vec![],
         read_shape_overrides: vec![],
         derived_attributes: vec![],
     }]
@@ -2685,6 +2746,7 @@ pub fn sqs_resources() -> Vec<ResourceDef> {
         identity_overrides: vec![],
         deferred_populate_overrides: vec![],
         deferred_populate_struct_field_overrides: vec![],
+        struct_field_type_overrides: vec![],
         read_shape_overrides: vec![],
         derived_attributes: vec![],
     }]

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -514,6 +514,144 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_enum_identifiers_cloudfront_hosted_zone_id_in_alias_target() {
+        // Regression for aws#302: `aws.cloudfront.HostedZoneId.global` written
+        // at value position of `alias_target.hosted_zone_id` (a Struct field)
+        // must resolve to the AWS-published constant `Z2FDTNDATAQYW2` before
+        // the value reaches the SDK builder. The receiving Struct field is
+        // schema-typed as a CloudFront-namespaced StringEnum, so the normalizer
+        // descends into the struct and rewrites via `DslMap::api_for`.
+        use indexmap::IndexMap;
+        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-cf-alias");
+        let mut alias_target = IndexMap::new();
+        alias_target.insert(
+            "dns_name".to_string(),
+            Value::Concrete(ConcreteValue::String("d1234.cloudfront.net".to_string())),
+        );
+        alias_target.insert(
+            "evaluate_target_health".to_string(),
+            Value::Concrete(ConcreteValue::Bool(false)),
+        );
+        alias_target.insert(
+            "hosted_zone_id".to_string(),
+            Value::Concrete(ConcreteValue::String(
+                "aws.cloudfront.HostedZoneId.global".to_string(),
+            )),
+        );
+        resource.set_attr(
+            "alias_target".to_string(),
+            Value::Concrete(ConcreteValue::Map(alias_target)),
+        );
+        let mut resources = vec![resource];
+        resolve_enum_identifiers(&mut resources);
+        let Some(Value::Concrete(ConcreteValue::Map(at))) = resources[0].get_attr("alias_target")
+        else {
+            panic!("expected alias_target Map");
+        };
+        assert_eq!(
+            at.get("hosted_zone_id"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Z2FDTNDATAQYW2".to_string()
+            )))
+        );
+    }
+
+    /// Variants of the aws#302 input shape — literal AWS spelling,
+    /// TypeName shorthand, and the negative case where the *top-level*
+    /// `RecordSet.hosted_zone_id` (user's own Route 53 zone) must NOT
+    /// be coerced through the CloudFront alias table.
+    #[test]
+    fn test_resolve_enum_identifiers_cloudfront_hosted_zone_id_input_shapes() {
+        use indexmap::IndexMap;
+        let make_resource = |hzid: &str| {
+            let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test");
+            let mut at = IndexMap::new();
+            at.insert(
+                "dns_name".to_string(),
+                Value::Concrete(ConcreteValue::String("d1.cloudfront.net".to_string())),
+            );
+            at.insert(
+                "evaluate_target_health".to_string(),
+                Value::Concrete(ConcreteValue::Bool(false)),
+            );
+            at.insert(
+                "hosted_zone_id".to_string(),
+                Value::Concrete(ConcreteValue::String(hzid.to_string())),
+            );
+            resource.set_attr(
+                "alias_target".to_string(),
+                Value::Concrete(ConcreteValue::Map(at)),
+            );
+            resource
+        };
+
+        // Literal `Z2FDTNDATAQYW2` (the AWS-published spelling) — the
+        // StringEnum's `values` list accepts it directly without alias
+        // rewriting.
+        let mut resources = vec![make_resource("Z2FDTNDATAQYW2")];
+        resolve_enum_identifiers(&mut resources);
+        let Some(Value::Concrete(ConcreteValue::Map(at))) = resources[0].get_attr("alias_target")
+        else {
+            panic!("expected alias_target Map");
+        };
+        assert_eq!(
+            at.get("hosted_zone_id"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Z2FDTNDATAQYW2".to_string()
+            )))
+        );
+
+        // TypeName shorthand `HostedZoneId.global` — resolves through
+        // Pass 1's `TypeName.value` arm.
+        let mut resources = vec![make_resource("HostedZoneId.global")];
+        resolve_enum_identifiers(&mut resources);
+        let Some(Value::Concrete(ConcreteValue::Map(at))) = resources[0].get_attr("alias_target")
+        else {
+            panic!("expected alias_target Map");
+        };
+        assert_eq!(
+            at.get("hosted_zone_id"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Z2FDTNDATAQYW2".to_string()
+            )))
+        );
+
+        // Bare DSL alias `global` — `resolve_enum_value_recursive`
+        // expands a bare identifier to `aws.cloudfront.HostedZoneId.global`
+        // (Pass 1), and Pass 2 then rewrites the trailing alias through
+        // `DslMap::api_for` to land on `Z2FDTNDATAQYW2`.
+        let mut resources = vec![make_resource("global")];
+        resolve_enum_identifiers(&mut resources);
+        let Some(Value::Concrete(ConcreteValue::Map(at))) = resources[0].get_attr("alias_target")
+        else {
+            panic!("expected alias_target Map");
+        };
+        assert_eq!(
+            at.get("hosted_zone_id"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Z2FDTNDATAQYW2".to_string()
+            )))
+        );
+
+        // Negative: top-level `RecordSet.hosted_zone_id` is the user's
+        // own Route 53 zone (plain String in the schema) — a literal
+        // hosted-zone ID like `Z1XYZABC123` must NOT be rewritten.
+        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-toplevel");
+        resource.set_attr(
+            "hosted_zone_id".to_string(),
+            Value::Concrete(ConcreteValue::String("Z1XYZABC123".to_string())),
+        );
+        let mut resources = vec![resource];
+        resolve_enum_identifiers(&mut resources);
+        assert_eq!(
+            resources[0].get_attr("hosted_zone_id"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Z1XYZABC123".to_string()
+            )))
+        );
+    }
+
+    #[test]
     fn test_resolve_enum_identifiers_ec2_vpc_instance_tenancy() {
         let mut resource = Resource::with_provider("aws", "ec2.Vpc", "test-vpc");
         resource.set_attr(

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -42,7 +42,7 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
                     fields: vec![
                     StructField::new("dns_name", AttributeType::String).required().with_description("Alias resource record sets only: The value that you specify depends on where you want to route queries: Amazon API Gateway custom regional APIs and ed...").with_provider_name("DNSName"),
                     StructField::new("evaluate_target_health", AttributeType::Bool).required().with_description("Applies only to alias, failover alias, geolocation alias, latency alias, and weighted alias resource record sets: When EvaluateTargetHealth is true, a...").with_provider_name("EvaluateTargetHealth"),
-                    StructField::new("hosted_zone_id", AttributeType::String).required().with_description("Alias resource records sets only: The value used depends on where you want to route traffic: Amazon API Gateway custom regional APIs and edge-optimize...").with_provider_name("HostedZoneId")
+                    StructField::new("hosted_zone_id", super::cloudfront_hosted_zone_id()).required().with_description("Alias resource records sets only: The value used depends on where you want to route traffic: Amazon API Gateway custom regional APIs and edge-optimize...").with_provider_name("HostedZoneId")
                     ],
                 })
                 .with_description("Alias resource record sets only: Information about the Amazon Web Services resource, such as a CloudFront distribution or an Amazon S3 bucket, that yo...")

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -25,6 +25,32 @@ pub struct AwsSchemaConfig {
     pub schema: ResourceSchema,
 }
 
+/// CloudFront's fixed Route 53 hosted zone ID, surfaced as a namespaced
+/// constant.
+///
+/// AWS publishes `Z2FDTNDATAQYW2` as the global hosted zone ID for every
+/// CloudFront distribution — it never varies by region or account.
+/// Users were hard-coding the magic string in their `.crn` files; this
+/// type lets them write `aws.cloudfront.HostedZoneId.global` instead,
+/// which the normalizer resolves to the literal value before reaching
+/// the SDK (aws#302).
+///
+/// Accepts:
+/// - Namespaced identifier: `aws.cloudfront.HostedZoneId.global`
+/// - Literal AWS spelling: `Z2FDTNDATAQYW2`
+///
+/// Any other value is a type error — `alias_target.hosted_zone_id`
+/// expects an AWS-published constant for the alias target's service,
+/// not an arbitrary string.
+pub fn cloudfront_hosted_zone_id() -> AttributeType {
+    AttributeType::StringEnum {
+        name: "HostedZoneId".to_string(),
+        values: vec!["Z2FDTNDATAQYW2".to_string()],
+        namespace: Some("aws.cloudfront".to_string()),
+        dsl_aliases: vec![("Z2FDTNDATAQYW2".to_string(), "global".to_string())],
+    }
+}
+
 /// AWS region type with custom validation
 /// Accepts:
 /// - DSL format: aws.Region.ap_northeast_1


### PR DESCRIPTION
## Summary

Surface CloudFront's fixed Route 53 hosted zone ID `Z2FDTNDATAQYW2` as the namespaced provider constant `aws.cloudfront.HostedZoneId.global`. Consumers wiring a Route 53 ALIAS record to a CloudFront distribution no longer hard-code the magic string.

```crn
alias_target = {
  dns_name               = distribution.domain_name
  hosted_zone_id         = aws.cloudfront.HostedZoneId.global   # resolves to Z2FDTNDATAQYW2 at plan time
  evaluate_target_health = false
}
```

## Design

The spelling chosen here differs slightly from the literal in the issue body (`aws.cloudfront.hosted_zone_id`) — that form does not parse as any existing `NamespacedId` shape (index 1 must be PascalCase). Instead this PR uses the existing 5-part `provider.service.TypeName.value` shape, which:

- fits the existing `NamespacedId` parser, validator, normalizer, and LSP completion pipelines with zero core-side changes
- gives the value a real "type" namespace (`HostedZoneId`), matching `aws.Region.*` and other namespaced-enum precedents
- extends cleanly to the candidates the issue lists for follow-up — ELB / S3 website / API Gateway etc. would each become `aws.<service>.HostedZoneId.<region_or_global>` entries

Hosted Zone IDs for AWS-published targets form a small enumerable set (one per service × region table, all in AWS docs), so modeling them as `StringEnum` values is semantically honest, not a virtual type.

## Mechanism

The destination field is `route53.RecordSet.AliasTarget.HostedZoneId` (a struct member), while the same `HostedZoneId` name also appears at the top level of `RecordSet` (user's own Route 53 zone — must remain plain String). The existing codegen `type_overrides` is keyed by member name only and can't distinguish these two contexts.

This PR adds a new `ResourceDef.struct_field_type_overrides: Vec<(parent_struct, member, type_code)>` that is keyed by `(parent_struct, member)`:

- `(AliasTarget, HostedZoneId) → super::cloudfront_hosted_zone_id()` — CloudFront-namespaced StringEnum
- Top-level `HostedZoneId` is untouched — stays plain String

Threaded through `TypeResolutionContext` into both `generate_struct_type` (rust schema output) and `type_display_string_md` (markdown docs output). Future per-parent overrides for ELB / S3-website etc. drop into the same mechanism.

The provider-side type builder `cloudfront_hosted_zone_id()` lives in `carina-provider-aws/src/schemas/types.rs` and returns a `StringEnum` with `values: ["Z2FDTNDATAQYW2"]`, `namespace: Some("aws.cloudfront")`, `dsl_aliases: [("Z2FDTNDATAQYW2", "global")]`. The existing two-pass normalizer (resolve to FQN → API-canonicalize via `DslMap::api_for`) rewrites `aws.cloudfront.HostedZoneId.global` → `Z2FDTNDATAQYW2` before reaching the SDK.

## Test plan

- [x] `cargo nextest run --workspace` — 222 tests pass
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-examples.sh` — green
- [x] `bash scripts/generate-schemas-smithy.sh` — regenerated `route53/record_set.rs`
- [x] `bash scripts/generate-docs.sh` — regenerated `route53/record_set.md` (AliasTarget table shows `CloudfrontHostedZoneId`)
- [x] New tests in `carina-provider-aws/src/normalizer.rs`:
  - `test_resolve_enum_identifiers_cloudfront_hosted_zone_id_in_alias_target` — namespaced form `aws.cloudfront.HostedZoneId.global` resolves to `Z2FDTNDATAQYW2`
  - `test_resolve_enum_identifiers_cloudfront_hosted_zone_id_input_shapes` — four input shapes (TypeName shorthand, literal AWS spelling, bare alias `global`) all resolve, top-level RecordSet.hosted_zone_id with arbitrary string stays unrewritten (proves the per-parent override doesn't bleed through)
- [ ] Real-infra smoke: user-driven via `carina-rs/infra` `usecases/registry/cloudfront.crn`

## Follow-ups (not in scope)

- Similar candidates from the issue body (ELB regional hosted zone IDs, S3 website endpoint zone IDs, VPC endpoint principals) — each is a per-region table; the same `struct_field_type_overrides` mechanism applies.
- `generated-docs` Enum Values section currently only surfaces top-level attribute enums, not struct-field-level ones — the AliasTarget table shows the type name correctly but doesn't link to a per-enum value listing. Cosmetic; can be addressed if/when ELB lands more entries.

Closes #302