### PR TITLE
feat: convert iam_policy_effect to StringEnum (effect half of #303)

### DIFF
--- a/acceptance-tests/ec2_flow_log/basic.crn
+++ b/acceptance-tests/ec2_flow_log/basic.crn
@@ -30,7 +30,7 @@ let flow_log_role = aws.iam.Role {
   assume_role_policy_document = {
     version = '2012-10-17'
     statement {
-      effect = 'Allow'
+      effect = allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/iam_role/basic.crn
+++ b/acceptance-tests/iam_role/basic.crn
@@ -11,7 +11,7 @@ aws.iam.Role {
   assume_role_policy_document = {
     version = '2012-10-17'
     statement {
-      effect = 'Allow'
+      effect = allow
       principal = {
         service = 'ec2.amazonaws.com'
       }

--- a/acceptance-tests/s3_bucket_policy/basic.crn
+++ b/acceptance-tests/s3_bucket_policy/basic.crn
@@ -19,7 +19,7 @@ aws.s3.BucketPolicy {
     version = '2012-10-17'
     statement {
       sid    = 'DenyInsecureTransport'
-      effect = 'Deny'
+      effect = deny
       principal = {
         aws = '*'
       }

--- a/acceptance-tests/s3_bucket_replication_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/basic.crn
@@ -32,7 +32,7 @@ let role = aws.iam.Role {
   assume_role_policy_document = {
     version = '2012-10-17'
     statement {
-      effect = 'Allow'
+      effect = allow
       principal = {
         service = 's3.amazonaws.com'
       }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1321,29 +1321,16 @@ fn string_or_principal_struct() -> AttributeType {
     ])
 }
 
-/// IAM Policy Effect enum type
-/// Only allows "Allow" or "Deny"
+/// IAM Policy Effect enum type. Allows `Allow` / `Deny` (AWS canonical) and
+/// their snake_case DSL aliases `allow` / `deny`, so users can write
+/// `effect = allow` as a bare identifier — matching the bare-identifier
+/// convention used by every other enum field in the same `.crn` file.
 fn iam_policy_effect() -> AttributeType {
-    AttributeType::Custom {
-        semantic_name: Some("IamPolicyEffect".to_string()),
-        pattern: Some("^(Allow|Deny)$".to_string()),
-        length: None,
-        base: Box::new(AttributeType::String),
-        validate: legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                match s.as_str() {
-                    "Allow" | "Deny" => Ok(()),
-                    _ => Err(format!(
-                        "Invalid IAM policy effect: \"{}\". Must be \"Allow\" or \"Deny\"",
-                        s
-                    )),
-                }
-            } else {
-                Err(format!("Expected string, got {:?}", value))
-            }
-        }),
+    AttributeType::StringEnum {
+        name: "IamPolicyEffect".to_string(),
+        values: vec!["Allow".to_string(), "Deny".to_string()],
         namespace: None,
-        to_dsl: None,
+        dsl_aliases: dsl_aliases_for(&["Allow", "Deny"]),
     }
 }
 
@@ -2699,7 +2686,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "allow".to_string(),
+                                    )),
                                 ),
                                 (
                                     "action".to_string(),
@@ -2746,7 +2735,7 @@ mod tests {
                     ConcreteValue::Map(
                         vec![(
                             "effect".to_string(),
-                            Value::Concrete(ConcreteValue::String("Grant".to_string())),
+                            Value::Concrete(ConcreteValue::EnumIdentifier("grant".to_string())),
                         )]
                         .into_iter()
                         .collect(),
@@ -2775,7 +2764,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Deny".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "deny".to_string(),
+                                    )),
                                 ),
                                 (
                                     "action".to_string(),
@@ -2815,7 +2806,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "allow".to_string(),
+                                    )),
                                 ),
                                 (
                                     "principal".to_string(),
@@ -2870,7 +2863,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "allow".to_string(),
+                                    )),
                                 ),
                                 (
                                     "principal".to_string(),
@@ -3255,5 +3250,29 @@ mod tests {
             .collect(),
         ));
         assert!(validate_condition_operators(&doc).is_ok());
+    }
+
+    #[test]
+    fn iam_policy_effect_is_string_enum() {
+        let effect = super::iam_policy_effect();
+        match effect {
+            AttributeType::StringEnum {
+                name,
+                values,
+                dsl_aliases,
+                ..
+            } => {
+                assert_eq!(name, "IamPolicyEffect");
+                assert_eq!(values, vec!["Allow".to_string(), "Deny".to_string()]);
+                assert_eq!(
+                    dsl_aliases,
+                    vec![
+                        ("Allow".to_string(), "allow".to_string()),
+                        ("Deny".to_string(), "deny".to_string()),
+                    ]
+                );
+            }
+            other => panic!("expected StringEnum, got {:?}", other),
+        }
     }
 }

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -786,6 +786,9 @@ mod tests {
             Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
         );
         let mut stmt = IndexMap::new();
+        // `effect` is a StringEnum; the canonical post-read shape is
+        // `EnumIdentifier("allow")`, which `scalar_to_json` maps back to the
+        // PascalCase wire form (`"Allow"`).
         stmt.insert(
             "effect".to_string(),
             Value::Concrete(ConcreteValue::String("Allow".to_string())),


### PR DESCRIPTION
## Summary

Convert `iam_policy_effect()` from `AttributeType::Custom { pattern: ^(Allow|Deny)$ }` to `AttributeType::StringEnum` with `dsl_aliases: [(Allow,allow),(Deny,deny)]`. DSL surface becomes `effect = allow` / `effect = deny` (bare identifier), matching every other enum in the same `.crn` file. Typos get did-you-mean diagnostics for free.

Sweep 4 acceptance fixtures: `effect = 'Allow' | 'Deny'` → bare `allow` / `deny`. (Two fixtures already used bare form.)

**Refs #303** (not closes). This PR delivers the `effect` half only.

## Scope split: why version stays Custom

`iam_policy_version()` stays as `AttributeType::Custom` in this PR. Its values (`2012-10-17`, `2008-10-17`) cannot be expressed as bare DSL identifiers under the current pest grammar (`namespaced_id = identifier ~ ("." ~ (identifier | ASCII_DIGIT+))+` — last segment must be `[A-Za-z]...` or pure `[0-9]+`, so `2012_10_17` does not parse). Converting `version` to StringEnum without a parser extension would force every existing `version = '2012-10-17'` line to break with `StringLiteralExpectedEnum` (carina#2986 Phase 4 rejects quoted-string input on StringEnum) with no migration target — users cannot write `version = ...` in *any* form post-conversion.

The version half is tracked upstream at **`carina-rs/carina#3051`** ("parser: extend namespaced_id tail to accept dotted-numeric identifiers"). Once that lands, a follow-up PR completes #303.

## Breaking changes

- Existing `.crn` files with `effect = 'Allow' | 'Deny'` must migrate to bare `effect = allow | deny`. Project policy: **no backward compatibility**.
- `version = '2012-10-17'` lines are **unchanged** by this PR.

## Out of scope

- `version` → StringEnum (blocked on `carina-rs/carina#3051`).
- The companion codegen-side enum sweep on awscc is tracked at `carina-rs/carina-provider-awscc#245`. awscc's `carina-aws-types/` copy is intentionally independent.

## Test plan

- [x] `cargo nextest run` (397 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check-examples.sh`
- [x] `bash scripts/generate-schemas-smithy.sh && bash scripts/generate-provider.sh` produce no diff (CI Codegen Check)
- [x] New `iam_policy_effect_is_string_enum` test asserts the StringEnum shape (name, values, dsl_aliases)
- [x] Updated `validate_iam_policy_document_*` and `iam_policy_document_*_validates` tests use `ConcreteValue::EnumIdentifier("allow"/"deny")`
- [ ] Real-infra smoke (user-driven): apply against `carina-rs/infra` `usecases/registry/cloudfront.crn` after the consumer PR `carina-rs/infra#58` is updated to bare `effect = allow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)