### PR TITLE
feat: convert iam_policy_version to StringEnum (closes #303)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
+source = "git+https://github.com/carina-rs/carina?rev=7f4c2145#7f4c214519722f9482ea0b8b043367f1ea26c2f4"
 dependencies = [
  "argon2",
  "futures",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
+source = "git+https://github.com/carina-rs/carina?rev=7f4c2145#7f4c214519722f9482ea0b8b043367f1ea26c2f4"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
+source = "git+https://github.com/carina-rs/carina?rev=7f4c2145#7f4c214519722f9482ea0b8b043367f1ea26c2f4"
 dependencies = [
  "serde",
  "serde_json",

--- a/acceptance-tests/ec2_flow_log/basic.crn
+++ b/acceptance-tests/ec2_flow_log/basic.crn
@@ -28,7 +28,7 @@ let flow_log_role = aws.iam.Role {
   role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = 2012_10_17
     statement {
       effect = allow
 

--- a/acceptance-tests/iam_role/basic.crn
+++ b/acceptance-tests/iam_role/basic.crn
@@ -9,7 +9,7 @@ provider aws {
 aws.iam.Role {
   role_name = 'carina-acceptance-test-role'
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = 2012_10_17
     statement {
       effect = allow
       principal = {

--- a/acceptance-tests/s3_bucket_notification_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_notification_configuration/basic.crn
@@ -16,7 +16,7 @@ let queue = aws.sqs.Queue {
   queue_name = 'carina-acc-test-aws-s3-bucket-notification-queue'
 
   policy = {
-    version = '2012-10-17'
+    version = 2012_10_17
     statement = [
       {
         sid = 'AllowS3SendMessage'

--- a/acceptance-tests/s3_bucket_policy/basic.crn
+++ b/acceptance-tests/s3_bucket_policy/basic.crn
@@ -16,7 +16,7 @@ aws.s3.BucketPolicy {
   bucket = bucket.bucket
 
   policy = {
-    version = '2012-10-17'
+    version = 2012_10_17
     statement {
       sid    = 'DenyInsecureTransport'
       effect = deny

--- a/acceptance-tests/s3_bucket_replication_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/basic.crn
@@ -30,7 +30,7 @@ let role = aws.iam.Role {
   role_name = 'carina-acc-test-aws-s3-repl-role-v1'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = 2012_10_17
     statement {
       effect = allow
       principal = {

--- a/acceptance-tests/sqs_queue/basic.crn
+++ b/acceptance-tests/sqs_queue/basic.crn
@@ -17,7 +17,7 @@ aws.sqs.Queue {
   sqs_managed_sse_enabled             = true
 
   policy = {
-    version = '2012-10-17'
+    version = 2012_10_17
     statement = [
       {
         sid    = 'AllowSelf'

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "7f4c2145" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1334,29 +1334,18 @@ fn iam_policy_effect() -> AttributeType {
     }
 }
 
-/// IAM Policy Document Version enum type
-/// Only allows "2012-10-17" or "2008-10-17"
+/// IAM Policy Document Version enum type. Allows `2012-10-17` / `2008-10-17`
+/// (AWS canonical) with snake_case DSL aliases `2012_10_17` / `2008_10_17`,
+/// so users can write `version = 2012_10_17` as a bare identifier —
+/// matching the bare-identifier convention `effect = allow` uses in the
+/// same `.crn` block. The numeric-tail bare form is parseable thanks to
+/// `carina-rs/carina#3051`'s `namespaced_id` grammar extension.
 fn iam_policy_version() -> AttributeType {
-    AttributeType::Custom {
-        semantic_name: Some("IamPolicyVersion".to_string()),
-        pattern: Some("^(2012-10-17|2008-10-17)$".to_string()),
-        length: None,
-        base: Box::new(AttributeType::String),
-        validate: legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                match s.as_str() {
-                    "2012-10-17" | "2008-10-17" => Ok(()),
-                    _ => Err(format!(
-                        "Invalid IAM policy version: \"{}\". Must be \"2012-10-17\" or \"2008-10-17\"",
-                        s
-                    )),
-                }
-            } else {
-                Err(format!("Expected string, got {:?}", value))
-            }
-        }),
+    AttributeType::StringEnum {
+        name: "IamPolicyVersion".to_string(),
+        values: vec!["2012-10-17".to_string(), "2008-10-17".to_string()],
         namespace: None,
-        to_dsl: None,
+        dsl_aliases: dsl_aliases_for(&["2012-10-17", "2008-10-17"]),
     }
 }
 
@@ -2677,7 +2666,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -2718,7 +2707,7 @@ mod tests {
         let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "version".to_string(),
-                Value::Concrete(ConcreteValue::String("2020-01-01".to_string())),
+                Value::Concrete(ConcreteValue::EnumIdentifier("2020_01_01".to_string())),
             )]
             .into_iter()
             .collect(),
@@ -2755,7 +2744,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -2797,7 +2786,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -2854,7 +2843,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -3269,6 +3258,33 @@ mod tests {
                     vec![
                         ("Allow".to_string(), "allow".to_string()),
                         ("Deny".to_string(), "deny".to_string()),
+                    ]
+                );
+            }
+            other => panic!("expected StringEnum, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn iam_policy_version_is_string_enum() {
+        let version = super::iam_policy_version();
+        match version {
+            AttributeType::StringEnum {
+                name,
+                values,
+                dsl_aliases,
+                ..
+            } => {
+                assert_eq!(name, "IamPolicyVersion");
+                assert_eq!(
+                    values,
+                    vec!["2012-10-17".to_string(), "2008-10-17".to_string()]
+                );
+                assert_eq!(
+                    dsl_aliases,
+                    vec![
+                        ("2012-10-17".to_string(), "2012_10_17".to_string()),
+                        ("2008-10-17".to_string(), "2008_10_17".to_string()),
                     ]
                 );
             }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "7f4c2145" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "7f4c2145" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "7f4c2145" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -34,7 +34,10 @@ pub fn core_to_proto_resource_id(id: &CoreResourceId) -> ProtoResourceId {
 }
 
 pub fn proto_to_core_resource_id(id: &ProtoResourceId) -> CoreResourceId {
-    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name)
+    // `ProtoResourceId` predates carina#3038's `provider_instance` field;
+    // the WIT wire format does not carry it. Pass `None` so the
+    // reconstructed `CoreResourceId` routes through the default provider.
+    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name, None)
 }
 
 // -- Value --
@@ -174,7 +177,8 @@ pub fn core_to_proto_directives(l: &CoreDirectives) -> ProtoDirectives {
 // -- proto_to_core_resource (reverse of core_to_proto_resource) --
 
 pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
-    let mut resource = CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name);
+    let mut resource =
+        CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name, None);
     resource.attributes = r
         .attributes
         .iter()

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -283,7 +283,7 @@ mod tests {
         use std::collections::HashMap;
 
         // from-state has two attrs; patch adds one, replaces one, removes one.
-        let id = ResourceId::with_provider("aws", "ec2.Vpc", "test");
+        let id = ResourceId::with_provider("aws", "ec2.Vpc", "test", None);
         let mut from_attrs: HashMap<String, Value> = HashMap::new();
         from_attrs.insert(
             "cidr_block".into(),

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -257,7 +257,7 @@ mod tests {
     // (e.g. `"aws.s3.BucketVersioning.VersioningStatus.enabled"`).
     #[test]
     fn test_resolve_enum_identifiers_namespaced_value() {
-        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test");
+        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test");
+        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
@@ -293,7 +293,8 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = Resource::with_provider("aws", "s3.BucketOwnershipControls", "test");
+        let mut resource =
+            Resource::with_provider("aws", "s3.BucketOwnershipControls", "test", None);
         resource.set_attr(
             "object_ownership".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -312,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_plain_string() {
-        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test");
+        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
@@ -329,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_aws() {
-        let mut resource = Resource::with_provider("awscc", "s3.BucketVersioning", "test");
+        let mut resource = Resource::with_provider("awscc", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
@@ -352,7 +353,8 @@ mod tests {
         // the API form, so `"-1"` round-trips to itself (it's already
         // API-canonical; pass-1 only namespaces it, pass-2 strips the
         // namespace and canonicalizes via api_for).
-        let mut resource = Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule");
+        let mut resource =
+            Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("-1".to_string())),
@@ -456,7 +458,7 @@ mod tests {
         // canonicalized to AWS API spelling `Enabled` before reaching
         // the provider's SDK::from() call. Without this, the SDK wraps
         // the unknown value and S3 returns MalformedXML.
-        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test");
+        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -479,7 +481,7 @@ mod tests {
         // in BucketLogging) must be canonicalized through the recursion,
         // not just the top-level attribute.
         use indexmap::IndexMap;
-        let mut resource = Resource::with_provider("aws", "s3.BucketLogging", "test");
+        let mut resource = Resource::with_provider("aws", "s3.BucketLogging", "test", None);
         let mut pp = IndexMap::new();
         pp.insert(
             "partition_date_source".to_string(),
@@ -522,7 +524,8 @@ mod tests {
         // schema-typed as a CloudFront-namespaced StringEnum, so the normalizer
         // descends into the struct and rewrites via `DslMap::api_for`.
         use indexmap::IndexMap;
-        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-cf-alias");
+        let mut resource =
+            Resource::with_provider("aws", "route53.RecordSet", "test-cf-alias", None);
         let mut alias_target = IndexMap::new();
         alias_target.insert(
             "dns_name".to_string(),
@@ -564,7 +567,7 @@ mod tests {
     fn test_resolve_enum_identifiers_cloudfront_hosted_zone_id_input_shapes() {
         use indexmap::IndexMap;
         let make_resource = |hzid: &str| {
-            let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test");
+            let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test", None);
             let mut at = IndexMap::new();
             at.insert(
                 "dns_name".to_string(),
@@ -636,7 +639,8 @@ mod tests {
         // Negative: top-level `RecordSet.hosted_zone_id` is the user's
         // own Route 53 zone (plain String in the schema) — a literal
         // hosted-zone ID like `Z1XYZABC123` must NOT be rewritten.
-        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-toplevel");
+        let mut resource =
+            Resource::with_provider("aws", "route53.RecordSet", "test-toplevel", None);
         resource.set_attr(
             "hosted_zone_id".to_string(),
             Value::Concrete(ConcreteValue::String("Z1XYZABC123".to_string())),
@@ -653,7 +657,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ec2_vpc_instance_tenancy() {
-        let mut resource = Resource::with_provider("aws", "ec2.Vpc", "test-vpc");
+        let mut resource = Resource::with_provider("aws", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -672,7 +676,8 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ec2_security_group_ingress_protocol() {
-        let mut resource = Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule");
+        let mut resource =
+            Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("IpProtocol.tcp".to_string())),
@@ -792,7 +797,7 @@ mod tests {
         // .resource_record.name`), the AWS API returns the FQDN with a
         // trailing dot. AwsNormalizer::normalize_desired must strip it so
         // the diff against the dot-stripped state row is stable.
-        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-rec");
+        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-rec", None);
         resource.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String("_abc.example.com.".to_string())),

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -590,7 +590,7 @@ mod tests {
     use std::time::Duration;
 
     fn id() -> ResourceId {
-        ResourceId::with_provider("aws", "acm.Certificate", "test-cert")
+        ResourceId::with_provider("aws", "acm.Certificate", "test-cert", None)
     }
 
     fn dv_without_rr(domain: &str) -> DomainValidation {

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -538,16 +538,19 @@ fn scalar_to_json(value: &Value) -> serde_json::Value {
         Value::Concrete(ConcreteValue::Int(n)) => serde_json::Value::Number((*n).into()),
         Value::Concrete(ConcreteValue::Float(f)) => serde_json::json!(*f),
         Value::Concrete(ConcreteValue::Bool(b)) => serde_json::Value::Bool(*b),
-        // `effect` lands here as `EnumIdentifier("allow"|"deny")` after
-        // the read-side canonicalization. AWS's wire form is the
-        // PascalCase canonical (`Allow` / `Deny`), so map the snake_case
-        // alias back. Trailing-segment strip handles any namespaced
-        // form too (`aws.iam.PolicyStatement.Effect.allow` → `allow`).
+        // `effect` and `version` land here as `EnumIdentifier` after the
+        // read-side canonicalization (e.g. `EnumIdentifier("allow")`,
+        // `EnumIdentifier("2012_10_17")`). AWS's wire form uses the
+        // PascalCase / hyphenated canonical, so map the DSL snake/underscore
+        // alias back. Trailing-segment strip handles any namespaced form
+        // (`aws.iam.PolicyStatement.Effect.allow` → `allow`).
         Value::Concrete(ConcreteValue::EnumIdentifier(id)) => {
             let trailing = id.rsplit('.').next().unwrap_or(id.as_str());
             let canonical = match trailing {
                 "allow" => "Allow",
                 "deny" => "Deny",
+                "2012_10_17" => "2012-10-17",
+                "2008_10_17" => "2008-10-17",
                 other => other,
             };
             serde_json::Value::String(canonical.to_string())
@@ -581,16 +584,21 @@ pub(crate) fn json_to_policy_doc(json: &serde_json::Value) -> Value {
             continue;
         }
         let snake_key = lookup_snake(POLICY_TOP_FIELDS, k).unwrap_or(k.as_str());
-        let value = if snake_key == "statement" {
-            match v {
+        let value = match snake_key {
+            "statement" => match v {
                 serde_json::Value::Array(items) => Value::Concrete(ConcreteValue::List(
                     items.iter().map(json_to_policy_statement).collect(),
                 )),
                 serde_json::Value::Object(_) => json_to_policy_statement(v),
                 _ => json_scalar_to_value(v),
-            }
-        } else {
-            json_scalar_or_passthrough_to_value(v)
+            },
+            // `version` is a StringEnum with `dsl_aliases: [("2012-10-17",
+            // "2012_10_17"), ("2008-10-17", "2008_10_17")]`. AWS returns the
+            // canonical hyphenated form ("2012-10-17"); the DSL surface is the
+            // underscore alias ("2012_10_17"). Emit `EnumIdentifier` directly
+            // with the DSL form so post-apply plan-verify compares equal.
+            "version" => json_version_to_enum_identifier(v),
+            _ => json_scalar_or_passthrough_to_value(v),
         };
         map.insert(snake_key.to_string(), value);
     }
@@ -642,6 +650,22 @@ fn json_effect_to_enum_identifier(v: &serde_json::Value) -> Value {
     let alias = match s {
         "Allow" => "allow",
         "Deny" => "deny",
+        _ => s,
+    };
+    Value::Concrete(ConcreteValue::EnumIdentifier(alias.to_string()))
+}
+
+/// AWS returns `Version: "2012-10-17"`; the DSL StringEnum surface uses
+/// the underscore alias (`2012_10_17` / `2008_10_17`). Emit
+/// `EnumIdentifier` carrying the alias so the read state matches what
+/// the DSL produces.
+fn json_version_to_enum_identifier(v: &serde_json::Value) -> Value {
+    let Some(s) = v.as_str() else {
+        return json_scalar_to_value(v);
+    };
+    let alias = match s {
+        "2012-10-17" => "2012_10_17",
+        "2008-10-17" => "2008_10_17",
         _ => s,
     };
     Value::Concrete(ConcreteValue::EnumIdentifier(alias.to_string()))
@@ -783,7 +807,7 @@ mod tests {
         let mut policy = IndexMap::new();
         policy.insert(
             "version".to_string(),
-            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+            Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
         );
         let mut stmt = IndexMap::new();
         // `effect` is a StringEnum; the canonical post-read shape is
@@ -895,7 +919,7 @@ mod tests {
         let mut doc = IndexMap::new();
         doc.insert(
             "version".to_string(),
-            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+            Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
         );
         doc.insert(
             "statement".to_string(),
@@ -1026,7 +1050,7 @@ mod tests {
         let mut doc = IndexMap::new();
         doc.insert(
             "version".to_string(),
-            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+            Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
         );
         doc.insert(
             "id".to_string(),
@@ -1139,7 +1163,7 @@ mod tests {
         let mut doc = IndexMap::new();
         doc.insert(
             "version".to_string(),
-            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+            Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
         );
         doc.insert(
             "statement".to_string(),
@@ -1194,7 +1218,7 @@ mod tests {
         let mut doc = IndexMap::new();
         doc.insert(
             "version".to_string(),
-            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+            Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
         );
         doc.insert(
             "statement".to_string(),

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -426,7 +426,7 @@ mod tests {
     use carina_core::resource::Resource;
 
     fn record_set(name: &str) -> Resource {
-        let mut r = Resource::with_provider("aws", "route53.RecordSet", "test-rec");
+        let mut r = Resource::with_provider("aws", "route53.RecordSet", "test-rec", None);
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String(name.to_string())),
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn ignores_non_route53_record_set_resources() {
-        let mut r = Resource::with_provider("aws", "s3.Bucket", "test");
+        let mut r = Resource::with_provider("aws", "s3.Bucket", "test", None);
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -515,7 +515,7 @@ mod tests {
 
     #[test]
     fn ignores_non_aws_provider() {
-        let mut r = Resource::with_provider("awscc", "route53.RecordSet", "test");
+        let mut r = Resource::with_provider("awscc", "route53.RecordSet", "test", None);
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String("foo.example.com.".to_string())),

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -1120,17 +1120,23 @@ fn test_extract_iam_role_attributes() {
         attributes.get("max_session_duration"),
         Some(&Value::Concrete(ConcreteValue::Int(7200)))
     );
-    // Verify that the assume_role_policy_document is converted to a Map with snake_case keys
+    // Verify that the assume_role_policy_document is converted to a Map
+    // with snake_case keys. `version` lands as `EnumIdentifier` carrying
+    // the underscore DSL alias (`2012_10_17`); the read-side helper maps
+    // AWS's canonical `"2012-10-17"` to the alias for plan-verify parity.
     let policy_doc = attributes
         .get("assume_role_policy_document")
         .expect("assume_role_policy_document should be present");
     if let Value::Concrete(ConcreteValue::Map(map)) = policy_doc {
         assert!(map.contains_key("version"), "should have 'version' key");
         assert!(map.contains_key("statement"), "should have 'statement' key");
-        if let Some(Value::Concrete(ConcreteValue::String(v))) = map.get("version") {
-            assert_eq!(v, "2012-10-17");
+        if let Some(Value::Concrete(ConcreteValue::EnumIdentifier(v))) = map.get("version") {
+            assert_eq!(v, "2012_10_17");
         } else {
-            panic!("Expected version to be String");
+            panic!(
+                "Expected version to be EnumIdentifier, got {:?}",
+                map.get("version")
+            );
         }
     } else {
         panic!("Expected Map, got {:?}", policy_doc);


### PR DESCRIPTION
## Summary

Completes the version half of #303. Convert `iam_policy_version()` from `AttributeType::Custom { pattern: ^(2012-10-17|2008-10-17)$ }` to `AttributeType::StringEnum` with `dsl_aliases: [("2012-10-17", "2012_10_17"), ("2008-10-17", "2008_10_17")]`.

DSL surface becomes `version = 2012_10_17` (bare identifier), matching the sibling `effect = allow` form delivered in #309. Closes the consistency gap that motivated #303 — IAM policy blocks now use bare identifiers for every enum field.

Sweep 6 acceptance fixtures: `version = '2012-10-17'` → `version = 2012_10_17`.

Closes #303.

## Implementation

- **Schema** (`carina-aws-types/src/lib.rs`): `iam_policy_version()` → StringEnum, mirroring `iam_policy_effect()`. The dsl_aliases helper auto-generates `("2012-10-17", "2012_10_17")` etc. from the canonical values.
- **Write path** (`carina-provider-aws/src/services/iam/role.rs::scalar_to_json`): extends the existing `EnumIdentifier → canonical` map with `2012_10_17 → 2012-10-17` and `2008_10_17 → 2008-10-17`. AWS receives the canonical hyphenated form on the wire.
- **Read path** (`json_to_policy_doc` + new `json_version_to_enum_identifier`): mirrors `json_effect_to_enum_identifier`. AWS `Version: "2012-10-17"` is read back as `EnumIdentifier("2012_10_17")` so post-apply plan-verify compares equal.

## Dependency bump

Bumps `carina-core` git rev from `455e6fa1` to `7f4c2145`:

- `7f4c2145` = `carina-rs/carina#3052` (namespaced_id parser extension, required to parse `2012_10_17` as a bare identifier). This is the headline prerequisite for #303's version half.
- The same rev window also landed `carina#3038`'s `make provider-instance-less ResourceId unrepresentable` refactor, which changed `ResourceId::with_provider` / `Resource::with_provider` from 3-arg to 4-arg (`Option<String>` for `provider_instance`). This PR adapts the affected call sites (`convert.rs`, test helpers in `helpers.rs` / `normalizer.rs` / `services/acm/certificate.rs` / `services/route53/record_set.rs`) by passing `None`. `ProtoResourceId` does not carry the field so the proto→core converters correctly default to `None`.

## Breaking

- `.crn` files with `version = '2012-10-17' | '2008-10-17'` must migrate to bare `version = 2012_10_17 | 2008_10_17`. Project policy: no backward compatibility.

## Test plan

- [x] `cargo nextest run` (398 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check-examples.sh`
- [x] `bash scripts/generate-schemas-smithy.sh && bash scripts/generate-provider.sh` produce no diff (CI Codegen Check)
- [x] New `iam_policy_version_is_string_enum` test asserts the StringEnum shape (name, values, dsl_aliases)
- [x] All `validate_iam_policy_document_*` / `iam_policy_document_*_validates` tests use `ConcreteValue::EnumIdentifier("2012_10_17")` for the version field
- [x] `test_extract_iam_role_attributes` in `tests.rs` updated to expect `EnumIdentifier("2012_10_17")` for read-back version
- [ ] Real-infra smoke (user-driven): apply against `carina-rs/infra` `usecases/registry/cloudfront.crn` after the consumer PR `carina-rs/infra#58` is updated to bare `version = 2012_10_17` + `effect = allow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)