### PR TITLE
fix: wire namespace on iam_policy_effect/version StringEnums (closes #311)

### DIFF
--- a/acceptance-tests/ec2_flow_log/basic.crn
+++ b/acceptance-tests/ec2_flow_log/basic.crn
@@ -28,9 +28,9 @@ let flow_log_role = aws.iam.Role {
   role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
-    version = 2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = allow
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/iam_role/basic.crn
+++ b/acceptance-tests/iam_role/basic.crn
@@ -9,9 +9,9 @@ provider aws {
 aws.iam.Role {
   role_name = 'carina-acceptance-test-role'
   assume_role_policy_document = {
-    version = 2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = allow
+      effect = aws.iam.PolicyDocument.Effect.allow
       principal = {
         service = 'ec2.amazonaws.com'
       }

--- a/acceptance-tests/s3_bucket_notification_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_notification_configuration/basic.crn
@@ -16,11 +16,11 @@ let queue = aws.sqs.Queue {
   queue_name = 'carina-acc-test-aws-s3-bucket-notification-queue'
 
   policy = {
-    version = 2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement = [
       {
         sid = 'AllowS3SendMessage'
-        effect = allow
+        effect = aws.iam.PolicyDocument.Effect.allow
         principal = {
           service = ['s3.amazonaws.com']
         }

--- a/acceptance-tests/s3_bucket_policy/basic.crn
+++ b/acceptance-tests/s3_bucket_policy/basic.crn
@@ -16,10 +16,10 @@ aws.s3.BucketPolicy {
   bucket = bucket.bucket
 
   policy = {
-    version = 2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
       sid    = 'DenyInsecureTransport'
-      effect = deny
+      effect = aws.iam.PolicyDocument.Effect.deny
       principal = {
         aws = '*'
       }

--- a/acceptance-tests/s3_bucket_replication_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/basic.crn
@@ -30,9 +30,9 @@ let role = aws.iam.Role {
   role_name = 'carina-acc-test-aws-s3-repl-role-v1'
 
   assume_role_policy_document = {
-    version = 2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = allow
+      effect = aws.iam.PolicyDocument.Effect.allow
       principal = {
         service = 's3.amazonaws.com'
       }

--- a/acceptance-tests/sqs_queue/basic.crn
+++ b/acceptance-tests/sqs_queue/basic.crn
@@ -17,11 +17,11 @@ aws.sqs.Queue {
   sqs_managed_sse_enabled             = true
 
   policy = {
-    version = 2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement = [
       {
         sid    = 'AllowSelf'
-        effect = allow
+        effect = aws.iam.PolicyDocument.Effect.allow
         principal = {
           aws = ['*']
         }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1325,11 +1325,16 @@ fn string_or_principal_struct() -> AttributeType {
 /// their snake_case DSL aliases `allow` / `deny`, so users can write
 /// `effect = allow` as a bare identifier — matching the bare-identifier
 /// convention used by every other enum field in the same `.crn` file.
+/// The namespace also makes the fully-qualified form
+/// `aws.iam.PolicyDocument.Effect.allow` parse and resolve: the
+/// resolver's canonical shape is `<namespace>.<type_name>.<value>`, so
+/// `type_name` is the trailing `Effect` segment and `namespace` is
+/// `aws.iam.PolicyDocument`.
 fn iam_policy_effect() -> AttributeType {
     AttributeType::StringEnum {
-        name: "IamPolicyEffect".to_string(),
+        name: "Effect".to_string(),
         values: vec!["Allow".to_string(), "Deny".to_string()],
-        namespace: None,
+        namespace: Some("aws.iam.PolicyDocument".to_string()),
         dsl_aliases: dsl_aliases_for(&["Allow", "Deny"]),
     }
 }
@@ -1338,13 +1343,17 @@ fn iam_policy_effect() -> AttributeType {
 /// (AWS canonical) with snake_case DSL aliases `2012_10_17` / `2008_10_17`,
 /// so users can write `version = 2012_10_17` as a bare identifier —
 /// matching the bare-identifier convention `effect = allow` uses in the
-/// same `.crn` block. The numeric-tail bare form is parseable thanks to
-/// `carina-rs/carina#3051`'s `namespaced_id` grammar extension.
+/// same `.crn` block. The fully-qualified form
+/// `aws.iam.PolicyDocument.Version.2012_10_17` parses via `namespaced_id` +
+/// the numeric-tail extension from `carina-rs/carina#3051` and resolves
+/// through this namespace: the resolver's canonical shape is
+/// `<namespace>.<type_name>.<value>`, so `type_name` is the trailing
+/// `Version` segment and `namespace` is `aws.iam.PolicyDocument`.
 fn iam_policy_version() -> AttributeType {
     AttributeType::StringEnum {
-        name: "IamPolicyVersion".to_string(),
+        name: "Version".to_string(),
         values: vec!["2012-10-17".to_string(), "2008-10-17".to_string()],
-        namespace: None,
+        namespace: Some("aws.iam.PolicyDocument".to_string()),
         dsl_aliases: dsl_aliases_for(&["2012-10-17", "2008-10-17"]),
     }
 }
@@ -3248,11 +3257,12 @@ mod tests {
             AttributeType::StringEnum {
                 name,
                 values,
+                namespace,
                 dsl_aliases,
-                ..
             } => {
-                assert_eq!(name, "IamPolicyEffect");
+                assert_eq!(name, "Effect");
                 assert_eq!(values, vec!["Allow".to_string(), "Deny".to_string()]);
+                assert_eq!(namespace, Some("aws.iam.PolicyDocument".to_string()));
                 assert_eq!(
                     dsl_aliases,
                     vec![
@@ -3272,14 +3282,15 @@ mod tests {
             AttributeType::StringEnum {
                 name,
                 values,
+                namespace,
                 dsl_aliases,
-                ..
             } => {
-                assert_eq!(name, "IamPolicyVersion");
+                assert_eq!(name, "Version");
                 assert_eq!(
                     values,
                     vec!["2012-10-17".to_string(), "2008-10-17".to_string()]
                 );
+                assert_eq!(namespace, Some("aws.iam.PolicyDocument".to_string()));
                 assert_eq!(
                     dsl_aliases,
                     vec![


### PR DESCRIPTION
## Summary

Follow-up to #303 / #309 / #310. #309/#310 converted `iam_policy_effect()` and `iam_policy_version()` to `StringEnum` with `namespace: None`, which left **no working DSL spelling**:

- **Bare** (`effect = allow`, `version = 2012_10_17`) — rejected by the parser. `numeric_tail` is only valid as a tail of `namespaced_id`, not as a standalone primary expression.
- **Namespaced** (`aws.iam.PolicyDocument.Version.2012_10_17`) — rejected by the resolver: no namespace to descend.
- **Quoted** (`'2012-10-17'`) — rejected by `carina#2986` Phase 4 (StringEnum refuses string literals).

`carina-rs/infra` (PR #58) is blocked on this.

## Fix

The resolver's canonical shape is `<namespace>.<type_name>.<value>` (`carina-core` `validate_enum_namespace`), so the **trailing path segment is the StringEnum's `name`**, not part of the namespace. The issue's literal suggestion (`namespace: "...Version"`, `name: "IamPolicyVersion"`) would have required `aws.iam.PolicyDocument.Version.IamPolicyVersion.2012_10_17`. To make the *intended* form resolve:

| fn | `name` | `namespace` |
|----|--------|-------------|
| `iam_policy_effect()`  | `IamPolicyEffect` → `Effect`   | `None` → `Some("aws.iam.PolicyDocument")` |
| `iam_policy_version()` | `IamPolicyVersion` → `Version` | `None` → `Some("aws.iam.PolicyDocument")` |

`name` is only consumed at the definition site and in error messages; no SDK/JSON serialization depends on it (StringEnum serializes via `values`/`dsl_aliases`), so the rename is safe.

The 6 acceptance fixtures that used the now-unparseable bare form are migrated to the namespaced form.

## Verification

- `cargo test -p carina-aws-types` — 85 passed (both `iam_policy_*_is_string_enum` tests extended to assert `name` + `namespace`).
- `cargo clippy`/`cargo fmt --check` — clean.
- **End-to-end smoke** with a freshly built WASM provider on current carina `main` (includes #3051's numeric-tail grammar):
  - `version = aws.iam.PolicyDocument.Version.2012_10_17` + `effect = aws.iam.PolicyDocument.Effect.deny` → `carina validate` ✓
  - Bare `version = 2012_10_17` → confirmed still a hard parse error (expected; option 2 not chosen).
  - Migrated `s3_bucket_policy` / `iam_role` / `sqs_queue` fixtures → `carina init` + `carina validate` ✓

## Test plan

- [ ] CI green
- [ ] `carina-rs/infra` PR #58 unblocked (user-driven real-infra smoke)

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)