### PR TITLE
fix: canonicalize EnumIdentifier StringEnum leaves in aws normalizer

### DIFF
--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -99,9 +99,13 @@ pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
 /// Walk `value` against `attr_type` and rewrite every enum spelling to
 /// the AWS API-canonical form via `DslMap::api_for`.
 ///
-/// Input expectation: enum identifiers are already in fully-qualified
-/// DSL form (the output of `resolve_enum_value_recursive`), so the
-/// extraction is `extract_enum_value(s)` — strip the namespace prefix —
+/// Input shapes: enum leaves arrive either as fully-qualified DSL
+/// `String` (the output of `resolve_enum_value_recursive`) or as
+/// `EnumIdentifier` (DSL-source values that Pass-1 leaves untouched,
+/// e.g. nested IAM policy `version` / `effect` after the carina#3055
+/// state-lift). Both carry the same text payload; extraction is
+/// `extract_enum_value_with_values(s, values)` — strip the namespace
+/// prefix, recovering dotted enum values like the legacy `ipsec.1` —
 /// followed by `dsl_map.api_for(trailing)` to translate DSL → API.
 ///
 /// Returns `None` when nothing was rewritten, mirroring the
@@ -110,17 +114,31 @@ pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
 fn api_canonicalize_recursive(value: &Value, attr_type: &AttributeType) -> Option<Value> {
     // Leaf: StringEnum (with or without namespace). We canonicalize via
     // the alias table regardless of whether the input was namespaced —
-    // `extract_enum_value` handles both shapes.
-    if let Some((_, _, _, dsl_map)) = attr_type.string_enum_parts() {
-        let Value::Concrete(ConcreteValue::String(s)) = value else {
+    // `extract_enum_value_with_values` handles both shapes (including
+    // dotted enum values like the legacy `ipsec.1`).
+    //
+    // Both `String` and `EnumIdentifier` carry the same text payload; the
+    // shape distinction (carina#2986) is irrelevant once we are
+    // rewriting to the AWS wire form. Accepting `EnumIdentifier` here is
+    // the fix for aws#315: after the carina#3055 state-lift, nested
+    // StringEnum struct fields (IAM policy `version` / `effect`) arrive
+    // as `EnumIdentifier`, and a `String`-only guard silently skipped
+    // them, so the DSL spelling reached AWS and was rejected with
+    // `MalformedPolicy`.
+    if let Some((_, values, _, dsl_map)) = attr_type.string_enum_parts() {
+        let (Value::Concrete(ConcreteValue::String(s))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(s))) = value
+        else {
             return None;
         };
-        let dsl_trailing = carina_core::utils::extract_enum_value(s);
+        let valid: Vec<&str> = values.iter().map(String::as_str).collect();
+        let dsl_trailing = carina_core::utils::extract_enum_value_with_values(s, &valid);
         let api = dsl_map.api_for(dsl_trailing);
-        // No-op if the string is already API-canonical AND has no
-        // namespace prefix (i.e. `s == api`). Otherwise rewrite to the
-        // bare API spelling so SDK::from(...) accepts it.
-        if s == &api {
+        // No-op only when the value is already the bare API spelling AND
+        // arrived as a plain `String` (no namespace, no shape rewrite).
+        // An `EnumIdentifier` must still be lowered to `String` so the
+        // schema-blind downstream serializers see a plain string.
+        if matches!(value, Value::Concrete(ConcreteValue::String(_))) && s == &api {
             return None;
         }
         return Some(Value::Concrete(ConcreteValue::String(api)));
@@ -512,6 +530,77 @@ mod tests {
             Some(&Value::Concrete(ConcreteValue::String(
                 "EventTime".to_string()
             )))
+        );
+    }
+
+    /// Root-cause regression for aws#315: the IAM policy document is a
+    /// fully schema-typed `Struct` (`iam_policy_document()`) whose
+    /// `version` and nested `statement[].effect` are `StringEnum` fields.
+    /// After the carina#3055 state-lift these arrive as `EnumIdentifier`,
+    /// not `String`. The Pass-2 leaf guard previously matched only
+    /// `String`, so it silently skipped them and the DSL spelling
+    /// (`aws.iam.PolicyDocument.Version.2012_10_17`, `allow`) flowed
+    /// through to the AWS API, which rejected the PUT with
+    /// `MalformedPolicy`. The fix accepts `EnumIdentifier` at the
+    /// StringEnum leaf and lowers it to the AWS-canonical `String`
+    /// (`"2012-10-17"`, `"Allow"`) — generically, for every nested
+    /// StringEnum struct field, not just IAM policy.
+    #[test]
+    fn test_resolve_enum_identifiers_iam_policy_doc_enum_identifier_nested() {
+        use indexmap::IndexMap;
+        let mut stmt = IndexMap::new();
+        stmt.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
+        );
+        stmt.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::String("sts:AssumeRole".to_string())),
+        );
+        let mut policy = IndexMap::new();
+        policy.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::EnumIdentifier(
+                "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
+            )),
+        );
+        policy.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt),
+            )])),
+        );
+
+        let mut resource = Resource::with_provider("aws", "iam.Role", "test-role", None);
+        resource.set_attr(
+            "assume_role_policy_document".to_string(),
+            Value::Concrete(ConcreteValue::Map(policy)),
+        );
+        let mut resources = vec![resource];
+        resolve_enum_identifiers(&mut resources);
+
+        let Some(Value::Concrete(ConcreteValue::Map(pd))) =
+            resources[0].get_attr("assume_role_policy_document")
+        else {
+            panic!("expected assume_role_policy_document Map");
+        };
+        assert_eq!(
+            pd.get("version"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "2012-10-17".to_string()
+            ))),
+            "version must be lowered to AWS-canonical String"
+        );
+        let Some(Value::Concrete(ConcreteValue::List(stmts))) = pd.get("statement") else {
+            panic!("expected statement List");
+        };
+        let Some(Value::Concrete(ConcreteValue::Map(s0))) = stmts.first() else {
+            panic!("expected statement[0] Map");
+        };
+        assert_eq!(
+            s0.get("effect"),
+            Some(&Value::Concrete(ConcreteValue::String("Allow".to_string()))),
+            "effect must be lowered to AWS-canonical String"
         );
     }
 

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -538,12 +538,15 @@ fn scalar_to_json(value: &Value) -> serde_json::Value {
         Value::Concrete(ConcreteValue::Int(n)) => serde_json::Value::Number((*n).into()),
         Value::Concrete(ConcreteValue::Float(f)) => serde_json::json!(*f),
         Value::Concrete(ConcreteValue::Bool(b)) => serde_json::Value::Bool(*b),
-        // `effect` and `version` land here as `EnumIdentifier` after the
-        // read-side canonicalization (e.g. `EnumIdentifier("allow")`,
-        // `EnumIdentifier("2012_10_17")`). AWS's wire form uses the
-        // PascalCase / hyphenated canonical, so map the DSL snake/underscore
-        // alias back. Trailing-segment strip handles any namespaced form
-        // (`aws.iam.PolicyStatement.Effect.allow` → `allow`).
+        // `effect` / `version` are StringEnum struct fields, so the AWS
+        // normalizer's `api_canonicalize_recursive` pass rewrites them to
+        // the AWS wire form (`Allow`, `2012-10-17`) before this serializer
+        // ever runs — they arrive here as an already-canonical `String`.
+        // This arm is the defensive fallback for any `EnumIdentifier` that
+        // somehow reaches the serializer un-canonicalized (e.g. a future
+        // enum field not yet covered by the schema-typed normalizer pass):
+        // strip the namespace and map the DSL alias back so AWS still
+        // accepts it rather than rejecting with `MalformedPolicy`.
         Value::Concrete(ConcreteValue::EnumIdentifier(id)) => {
             let trailing = id.rsplit('.').next().unwrap_or(id.as_str());
             let canonical = match trailing {
@@ -836,6 +839,57 @@ mod tests {
         assert!(resolved.contains("\"Effect\""));
         assert!(resolved.contains("\"Action\""));
         assert!(!resolved.contains("\"version\""));
+    }
+
+    /// aws#315 defensive fallback: the schema-typed AWS normalizer
+    /// (`api_canonicalize_recursive`) is what actually canonicalizes
+    /// `version` / `effect` before this serializer runs — see the
+    /// end-to-end regression in `normalizer.rs`. But if an
+    /// `EnumIdentifier` reaches the serializer un-canonicalized (a future
+    /// enum field not yet covered by the normalizer pass), the
+    /// `scalar_to_json` fallback must still emit the AWS wire form so AWS
+    /// does not reject the PUT with `MalformedPolicy`. Both the namespaced
+    /// and the bare-alias `EnumIdentifier` shapes are covered here.
+    #[test]
+    fn resolve_iam_policy_attr_enum_identifier_fallback_is_aws_canonical() {
+        let mut policy = IndexMap::new();
+        policy.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::EnumIdentifier(
+                "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
+            )),
+        );
+        let mut stmt = IndexMap::new();
+        stmt.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
+        );
+        stmt.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
+        );
+        policy.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt),
+            )])),
+        );
+
+        let r = make_resource(Some(Value::Concrete(ConcreteValue::Map(policy))));
+        let resolved = resolve_iam_policy_attr(&r, "policy").expect("map → JSON");
+
+        assert!(
+            resolved.contains(r#""Version":"2012-10-17""#),
+            "version must be AWS-canonical, got: {resolved}"
+        );
+        assert!(
+            resolved.contains(r#""Effect":"Allow""#),
+            "effect must be AWS-canonical, got: {resolved}"
+        );
+        assert!(
+            !resolved.contains("2012_10_17") && !resolved.contains(r#""allow""#),
+            "DSL spelling must not reach AWS, got: {resolved}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #315.

IAM-shaped policy docs (`aws.s3.BucketPolicy.policy`, `aws.iam.Role.assume_role_policy_document`, `aws.sqs.Queue.policy` — all typed as `iam_policy_document()`) were sending the DSL spelling of `version` / `effect` to AWS verbatim, so every `carina-rs/infra` apply touching a migrated IAM policy doc failed with `MalformedPolicy: The policy must contain a valid version string`.

**Root cause:** the AWS normalizer's `api_canonicalize_recursive` Pass-2 leaf guard (`carina-provider-aws/src/normalizer.rs`) matched only `ConcreteValue::String`, silently skipping `ConcreteValue::EnumIdentifier`. The IAM policy document is a fully schema-typed `Struct` whose `version` and nested `statement[].effect` are `StringEnum` fields — Pass-2 *should* canonicalize them via `DslMap::api_for`. But after the carina#3055 state-lift these arrive as `EnumIdentifier`, not `String`, so the guard skipped them and the DSL spelling (`aws.iam.PolicyDocument.Version.2012_10_17`, `allow`) flowed through to AWS.

This was initially attempted as a per-site patch in the hand-written `scalar_to_json` serializer; that was discarded in favor of fixing the root primitive.

## Changes

- `normalizer.rs`: the StringEnum leaf guard now accepts both `String` and `EnumIdentifier`, uses `extract_enum_value_with_values` (dotted-value safe, e.g. legacy `ipsec.1`), and always lowers `EnumIdentifier` to the canonical `String`. The no-op short-circuit now fires only for an already-canonical plain `String`. Generic fix — covers every nested StringEnum struct field, not just IAM policy.
- `role.rs`: the `scalar_to_json` `EnumIdentifier` arm is retained as a documented defensive fallback for enum fields not yet covered by the schema-typed normalizer pass.
- Regression tests: end-to-end in `normalizer.rs` (`iam.Role.assume_role_policy_document` with nested `EnumIdentifier` `version`/`effect`), defensive-fallback in `role.rs`.

The awscc side has **no equivalent gap** (its `dsl_value_to_aws` is schema-type-driven and already handles `String | EnumIdentifier`); a cross-check regression test is added there in a separate test-only PR.

## Test plan

- [x] `cargo nextest run -p carina-provider-aws` — 231 passed
- [x] New normalizer test fails with the old `String`-only guard, passes with the fix (root-cause proven by revert-check)
- [x] `cargo test --doc`, `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`
- [ ] Real-infra smoke (`carina-rs/infra` apply on the three blocked resources) — user-driven

🤖 Generated with [Claude Code](https://claude.com/claude-code)