### PR TITLE
chore: bump carina-core pin to da711925 (closes #323)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=7f4c2145#7f4c214519722f9482ea0b8b043367f1ea26c2f4"
+source = "git+https://github.com/carina-rs/carina?rev=da711925#da7119259be0da4a26745f945d84a4fee242581b"
 dependencies = [
  "argon2",
  "futures",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=7f4c2145#7f4c214519722f9482ea0b8b043367f1ea26c2f4"
+source = "git+https://github.com/carina-rs/carina?rev=da711925#da7119259be0da4a26745f945d84a4fee242581b"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=7f4c2145#7f4c214519722f9482ea0b8b043367f1ea26c2f4"
+source = "git+https://github.com/carina-rs/carina?rev=da711925#da7119259be0da4a26745f945d84a4fee242581b"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "7f4c2145" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "da711925" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "7f4c2145" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "da711925" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "7f4c2145" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "7f4c2145" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "da711925" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "da711925" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }


### PR DESCRIPTION
Closes #323

`carina-provider-aws` pinned a pre-#3055 `carina-core` (`7f4c2145`). The never-converging `~ effect: "allow" → "Allow"` / `~ version: "2012_10_17" → "2012-10-17"` plan diff on `aws.s3.BucketPolicy` (and any IAM-policy-shaped attribute) was the schema-blind carina-core detail-row renderer (carina#3073), not a provider gap. carina-provider-aws#327's per-provider `normalize_state` workaround was closed in favor of that core root fix, which is now merged (carina PR #3076, `da711925`).

This bumps all four carina pins (`carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` in `carina-provider-aws/Cargo.toml`; `carina-core` in `carina-aws-types/Cargo.toml` — kept in lockstep so a mismatch does not load two `carina-core` crates) from `7f4c2145` to `da711925`, picking up the carina#3073 fix plus the intervening #3055 / #3060 / #3063 / #3069 / #3070 work. Pure pin bump — no source or codegen change.

## Verification (full `7f4c2145` → `da711925` range API-compatible)

- `cargo build` clean (carina-core recompiled at the new rev)
- `cargo test --workspace` — all suites pass, 0 failed
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` clean
- `git diff --stat` = Cargo.toml/Cargo.lock only (no codegen drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
