### PR TITLE
fix: paginate route53 record-set read with exact (name,type) match (#333)

### DIFF
--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -43,6 +43,51 @@ fn strip_trailing_dot(name: &str) -> String {
     name.strip_suffix('.').unwrap_or(name).to_string()
 }
 
+/// Outcome of scanning one `ListResourceRecordSets` page for an exact
+/// `(name, type)` record. See [`scan_page_for_record`].
+enum PageScan<'a> {
+    /// Exact `(normalized name, type)` match found on this page.
+    Found(&'a ResourceRecordSet),
+    /// A record whose name differs from the target appeared. Because the
+    /// listing is cursor-started at the target name and ordered by name,
+    /// a different name means the target name's records are exhausted —
+    /// the record does not exist; stop without paging further.
+    StopNotFound,
+    /// Every record on this page is still at the target name but none
+    /// matched the type yet (the target name's records span a page
+    /// boundary). Follow pagination and scan the next page.
+    KeepPaging,
+}
+
+/// Scan one page of `list_resource_record_sets` results for the record
+/// matching `target_name` (already trailing-dot-normalized) and
+/// `target_type`.
+///
+/// `start_record_name` + `start_record_type` are pagination *cursors*,
+/// not filters: AWS returns records at or after that position, ordered
+/// by name then by a fixed per-name type rank. So a single record (the
+/// old `max_items(1)` approach) is only the target when the target type
+/// happens to sort first at its name; otherwise the page leads with a
+/// different-typed (or, across a boundary, same-typed-different) record.
+/// This walks every record on the page and classifies the page so the
+/// caller can match, page on, or stop early without scanning the whole
+/// zone (carina-rs/carina-provider-aws#333).
+fn scan_page_for_record<'a>(
+    records: &'a [ResourceRecordSet],
+    target_name: &str,
+    target_type: &str,
+) -> PageScan<'a> {
+    for rrs in records {
+        if rrs.name() != target_name {
+            return PageScan::StopNotFound;
+        }
+        if rrs.r#type().as_str() == target_type {
+            return PageScan::Found(rrs);
+        }
+    }
+    PageScan::KeepPaging
+}
+
 fn extract_string(value: &Value) -> Option<&str> {
     if let Value::Concrete(ConcreteValue::String(s)) = value {
         Some(s.as_str())
@@ -239,33 +284,52 @@ impl AwsProvider {
 
         let normalized_name = normalize_dns_name(name);
 
-        let result = self
-            .route53_client
-            .list_resource_record_sets()
-            .hosted_zone_id(zone_id)
-            .start_record_name(&normalized_name)
-            .start_record_type(RrType::from(record_type))
-            .max_items(1)
-            .send()
-            .await
-            .map_err(|e| {
+        // `start_record_*` are pagination cursors, not filters: AWS
+        // returns records at or after that (name, type) position, ordered
+        // by name then per-name type rank. Page from the cursor and scan
+        // for the exact (name, type); stop as soon as the listing moves
+        // past the target name. The previous `max_items(1)` approach only
+        // worked when the target type sorted first at its name and
+        // silently returned `not_found` otherwise (aws#333).
+        let mut start_name = Some(normalized_name.clone());
+        let mut start_type = Some(RrType::from(record_type));
+        let mut start_identifier: Option<String> = None;
+
+        loop {
+            let mut request = self
+                .route53_client
+                .list_resource_record_sets()
+                .hosted_zone_id(zone_id)
+                .set_start_record_name(start_name.take())
+                .set_start_record_type(start_type.take());
+            if let Some(sid) = start_identifier.take() {
+                request = request.start_record_identifier(sid);
+            }
+
+            let result = request.send().await.map_err(|e| {
                 ProviderError::api_error(sdk_error_message("Failed to list record sets", &e))
                     .for_resource(id.clone())
             })?;
 
-        for rrs in result.resource_record_sets() {
-            let rrs_name = rrs.name();
-            let rrs_type = rrs.r#type().as_str();
-
-            if rrs_name == normalized_name && rrs_type == record_type {
-                let attrs = extract_attributes(zone_id, rrs);
-                return Ok(
-                    State::existing(id.clone(), attrs).with_identifier(identifier.to_string())
-                );
+            match scan_page_for_record(result.resource_record_sets(), &normalized_name, record_type)
+            {
+                PageScan::Found(rrs) => {
+                    let attrs = extract_attributes(zone_id, rrs);
+                    return Ok(
+                        State::existing(id.clone(), attrs).with_identifier(identifier.to_string())
+                    );
+                }
+                PageScan::StopNotFound => return Ok(State::not_found(id.clone())),
+                PageScan::KeepPaging => {}
             }
-        }
 
-        Ok(State::not_found(id.clone()))
+            if !result.is_truncated() {
+                return Ok(State::not_found(id.clone()));
+            }
+            start_name = result.next_record_name().map(str::to_string);
+            start_type = result.next_record_type().cloned();
+            start_identifier = result.next_record_identifier().map(str::to_string);
+        }
     }
 
     pub(crate) async fn create_route53_record_set(
@@ -529,5 +593,78 @@ mod tests {
                 "foo.example.com.".to_string()
             )))
         );
+    }
+
+    /// Build a minimal SDK `ResourceRecordSet` (name + type) for scan tests.
+    fn rrs(name: &str, ty: &str) -> ResourceRecordSet {
+        ResourceRecordSet::builder()
+            .name(name)
+            .r#type(RrType::from(ty))
+            .build()
+            .expect("name and type set")
+    }
+
+    /// The carina#3306 / aws#333 failure shape: an AAAA record exists at a
+    /// name that also has A and NS records. Route53 orders A before NS
+    /// before AAAA at the same name, so a page started at the AAAA cursor
+    /// can still lead with the earlier-sorting types — the old
+    /// `max_items(1)` scan returned the wrong single record and reported
+    /// `not_found`. The page scan must find the AAAA.
+    #[test]
+    fn finds_target_type_that_does_not_sort_first_at_its_name() {
+        let page = vec![
+            rrs("registry-dev.carina-rs.dev.", "A"),
+            rrs("registry-dev.carina-rs.dev.", "NS"),
+            rrs("registry-dev.carina-rs.dev.", "AAAA"),
+        ];
+        match scan_page_for_record(&page, "registry-dev.carina-rs.dev.", "AAAA") {
+            PageScan::Found(found) => {
+                assert_eq!(found.name(), "registry-dev.carina-rs.dev.");
+                assert_eq!(found.r#type().as_str(), "AAAA");
+            }
+            _ => panic!("AAAA exists on the page and must be Found"),
+        }
+    }
+
+    /// A record absent from the zone: the listing started at the target
+    /// name's cursor returns records for the *next* name. A different name
+    /// means the target name is exhausted — stop, do not page the rest of
+    /// the zone.
+    #[test]
+    fn stops_without_paging_once_name_sorts_past_target() {
+        let page = vec![
+            rrs("other.carina-rs.dev.", "A"),
+            rrs("other.carina-rs.dev.", "AAAA"),
+        ];
+        assert!(matches!(
+            scan_page_for_record(&page, "registry-dev.carina-rs.dev.", "AAAA"),
+            PageScan::StopNotFound
+        ));
+    }
+
+    /// Every record on the page is still the target name but the target
+    /// type has not appeared yet (the name's records span a page
+    /// boundary): keep paging.
+    #[test]
+    fn keeps_paging_when_target_name_records_span_a_page() {
+        let page = vec![
+            rrs("registry-dev.carina-rs.dev.", "A"),
+            rrs("registry-dev.carina-rs.dev.", "NS"),
+        ];
+        assert!(matches!(
+            scan_page_for_record(&page, "registry-dev.carina-rs.dev.", "AAAA"),
+            PageScan::KeepPaging
+        ));
+    }
+
+    /// An empty page (no records at or after the cursor) is not a match
+    /// and nothing follows — treated as keep-paging; the caller's
+    /// `is_truncated` check ends the loop.
+    #[test]
+    fn empty_page_keeps_paging() {
+        assert!(matches!(
+            scan_page_for_record(&[], "registry-dev.carina-rs.dev.", "AAAA"),
+            PageScan::KeepPaging
+        ));
     }
 }

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -329,12 +329,19 @@ impl AwsProvider {
                 PageScan::KeepPaging => {}
             }
 
-            if !result.is_truncated() {
-                return Ok(State::not_found(id.clone()));
+            // Only a `next_record_name` lets the scan continue from where
+            // it left off. Treating "no next cursor" as not-found (rather
+            // than re-sending with `start_record_name = None`, which would
+            // silently restart the listing from the beginning of the zone)
+            // keeps the loop bounded to the target name's records.
+            match result.next_record_name() {
+                Some(next_name) if result.is_truncated() => {
+                    start_name = Some(next_name.to_string());
+                    start_type = result.next_record_type().cloned();
+                    start_identifier = result.next_record_identifier().map(str::to_string);
+                }
+                _ => return Ok(State::not_found(id.clone())),
             }
-            start_name = result.next_record_name().map(str::to_string);
-            start_type = result.next_record_type().cloned();
-            start_identifier = result.next_record_identifier().map(str::to_string);
         }
     }
 

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -72,6 +72,12 @@ enum PageScan<'a> {
 /// This walks every record on the page and classifies the page so the
 /// caller can match, page on, or stop early without scanning the whole
 /// zone (carina-rs/carina-provider-aws#333).
+///
+/// NOTE: the match is `(name, type)` only — the carina resource identity
+/// (`zone|name|type`, see `make_identifier`). Routing-policy record sets
+/// (weighted/latency/geo/failover) have multiple records with the same
+/// `(name, type)` distinguished by `SetIdentifier`; those are not
+/// modeled and the first such record is returned (aws#335).
 fn scan_page_for_record<'a>(
     records: &'a [ResourceRecordSet],
     target_name: &str,
@@ -604,7 +610,7 @@ mod tests {
             .expect("name and type set")
     }
 
-    /// The carina#3306 / aws#333 failure shape: an AAAA record exists at a
+    /// The carina#3106 / aws#333 failure shape: an AAAA record exists at a
     /// name that also has A and NS records. Route53 orders A before NS
     /// before AAAA at the same name, so a page started at the AAAA cursor
     /// can still lead with the earlier-sorting types — the old


### PR DESCRIPTION
Closes #333.

## Problem

`read_route53_record_set` used `start_record_name` + `start_record_type` + `max_items(1)`. Those are pagination **cursors, not filters**: AWS returns records at/after that position ordered by name then per-name type rank, and `max_items(1)` fetched a single record without paging. So for any record type that does not sort first at its name (e.g. AAAA when A/NS/SOA exist at the same name — the `carina-rs/infra` registry dual-stack ALIAS topology), the read returned `not_found` for a record that exists, breaking post-create/post-update read-back and drift detection (and contributing to the carina#3106 scenario).

## Fix

Replace `max_items(1)`+cursor-as-filter with a paginating loop driven by a pure `scan_page_for_record`:

- exact `(normalized name, type)` on a page → `Found`
- a record with a different name appeared (cursor starts at the target name; listing is name-ordered and same-name records are contiguous) → `StopNotFound`, return `not_found` **without paging the rest of the zone**
- whole page still the target name, type not yet seen → follow `next_record_name`/`next_record_type`/`next_record_identifier` and scan the next page

The pure scan fn is unit-tested without the SDK (the repo's established `iam/roles.rs::filter_page` pattern), including the aws#333 regression: AAAA after A/NS at the same name is now `Found`.

## Review

5-round self-review. Round 2 found and fixed a robustness gap: a truncated response with no `next_record_name` would have silently restarted the listing from the beginning of the zone — now guarded (no next-cursor ⇒ `not_found`, scan stays bounded to the target name's records). Rounds 1/3/4/5 clean; Round 1 verified `StopNotFound` soundness against Route53's documented name-primary contiguous ordering; Round 4 confirmed all three callers (create/update/delete read-back) benefit with no regression.

## Out of scope (filed as follow-ups)

- carina-rs/carina-provider-aws#335 — routing-policy (weighted/latency/geo/failover) record sets matched non-deterministically by `(name,type)` (pre-existing model limit; documented with a NOTE in `scan_page_for_record`)
- carina-rs/carina-provider-aws#336 — exact-byte name comparison breaks for octal-escaped names (wildcard / IDN) (pre-existing)

## Verification

- `cargo test -p carina-provider-aws --lib`: 229/229 pass (incl. 4 new scan tests)
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)
