### PR TITLE
fix: make AwsNormalizer async to follow ProviderNormalizer trait change (carina#3112)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=741f7afc#741f7afc1c366ab41fdc614f77a7582954885390"
+source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
 dependencies = [
  "argon2",
  "futures",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=741f7afc#741f7afc1c366ab41fdc614f77a7582954885390"
+source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=741f7afc#741f7afc1c366ab41fdc614f77a7582954885390"
+source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "741f7afc" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "741f7afc" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "741f7afc" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "741f7afc" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -324,7 +324,13 @@ impl CarinaProvider for AwsProcessProvider {
             .iter()
             .map(convert::proto_to_core_resource)
             .collect();
-        self.normalizer.normalize_desired(&mut core_resources);
+        // Guest-side: drive the now-async normalizer on the guest's own
+        // outermost runtime — the same pattern the `Provider` CRUD
+        // methods use here (`self.runtime.block_on(...)`). Not a nested
+        // runtime: the host drives the WASM call, the guest drives its
+        // internal async with this runtime (carina#3112 design Non-goal).
+        self.runtime
+            .block_on(self.normalizer.normalize_desired(&mut core_resources));
         core_resources
             .iter()
             .map(convert::core_to_proto_resource)
@@ -349,8 +355,11 @@ impl CarinaProvider for AwsProcessProvider {
         for s in proto_schemas {
             registry.insert("aws", convert::proto_to_core_schema(s));
         }
-        self.normalizer
-            .merge_default_tags(&mut core_resources, &core_tags, &registry);
+        self.runtime.block_on(self.normalizer.merge_default_tags(
+            &mut core_resources,
+            &core_tags,
+            &registry,
+        ));
         *resources = core_resources
             .iter()
             .map(convert::core_to_proto_resource)

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use indexmap::IndexMap;
 
-use carina_core::provider::{self, ProviderNormalizer};
-use carina_core::resource::{ConcreteValue, Resource, Value};
+use carina_core::provider::{self, BoxFuture, ProviderNormalizer, SavedAttrs, ready_noop};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::{AttributeType, SchemaRegistry};
 
 /// Schema extension for the AWS provider.
@@ -14,18 +14,41 @@ use carina_core::schema::{AttributeType, SchemaRegistry};
 pub struct AwsNormalizer;
 
 impl ProviderNormalizer for AwsNormalizer {
-    fn normalize_desired(&self, resources: &mut [Resource]) {
-        resolve_enum_identifiers(resources);
-        crate::services::route53::record_set::normalize_record_set_dns_names(resources);
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+        // Bodies are pure (enum resolution, dns-name strip — no I/O);
+        // the trait is async only so the WASM host impl can `.await`
+        // the guest directly (carina#3112). Wrapping the existing sync
+        // logic in a ready future is sufficient here.
+        Box::pin(async move {
+            resolve_enum_identifiers(resources);
+            crate::services::route53::record_set::normalize_record_set_dns_names(resources);
+        })
     }
 
-    fn merge_default_tags(
-        &self,
-        resources: &mut [Resource],
-        default_tags: &IndexMap<String, Value>,
-        registry: &SchemaRegistry,
-    ) {
-        provider::merge_default_tags_for_provider("aws", resources, default_tags, registry);
+    fn normalize_state<'a>(
+        &'a self,
+        _current_states: &'a mut HashMap<ResourceId, State>,
+    ) -> BoxFuture<'a, ()> {
+        ready_noop()
+    }
+
+    fn hydrate_read_state<'a>(
+        &'a self,
+        _current_states: &'a mut HashMap<ResourceId, State>,
+        _saved_attrs: &'a SavedAttrs,
+    ) -> BoxFuture<'a, ()> {
+        ready_noop()
+    }
+
+    fn merge_default_tags<'a>(
+        &'a self,
+        resources: &'a mut [Resource],
+        default_tags: &'a IndexMap<String, Value>,
+        registry: &'a SchemaRegistry,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            provider::merge_default_tags_for_provider("aws", resources, default_tags, registry);
+        })
     }
 }
 
@@ -929,8 +952,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_aws_normalizer_strips_record_set_trailing_dot() {
+    #[tokio::test]
+    async fn test_aws_normalizer_strips_record_set_trailing_dot() {
         // Regression for aws#300: when `route53.RecordSet.name` is fed by
         // another resource's read (e.g. `cert.domain_validation_options[0]
         // .resource_record.name`), the AWS API returns the FQDN with a
@@ -942,7 +965,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("_abc.example.com.".to_string())),
         );
         let mut resources = vec![resource];
-        AwsNormalizer.normalize_desired(&mut resources);
+        AwsNormalizer.normalize_desired(&mut resources).await;
         assert_eq!(
             resources[0].get_attr("name"),
             Some(&Value::Concrete(ConcreteValue::String(


### PR DESCRIPTION
## Why

carina#3112 / carina-rs/carina#3114 (merged) made `carina_core::provider::ProviderNormalizer` an **async trait** (methods return `BoxFuture<'a, ()>`) to remove a nested-`block_on` self-deadlock in the WASM host. `AwsNormalizer` implements that trait — without this change carina-provider-aws no longer builds against carina-core.

## What

- `AwsNormalizer`'s four methods become `fn name<'a>(...) -> BoxFuture<'a, ()>`.
  - `normalize_desired` / `merge_default_tags`: bodies are pure (enum resolution, route53 dns-name strip, default-tag merge — no I/O), so the existing sync logic is wrapped in `Box::pin(async move { ... })`. No logic change.
  - `normalize_state` / `hydrate_read_state`: were the old trait's default no-ops; now return the shared `ready_noop()` helper — same behavior, made explicit (the trait no longer has default bodies, by design — same discipline as carina-provider-awscc#192).
- Guest-side (`main.rs`): the WASM guest's sync `normalize_desired` / `merge_default_tags` drive the now-async normalizer via `self.runtime.block_on(...)` — the same pattern the guest's `Provider` CRUD methods already use. Not a nested runtime: the host drives the WASM call, the guest drives its internal async with its own runtime (per the carina#3112 design Non-goal).
- carina-core git pin bumped `741f7afc` → `7705f3c7` (the merged carina#3114 commit) in carina-provider-aws and carina-aws-types.

## Verify

- `cargo test`: all suites pass
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`: **green** (the WASM component registry actually loads)

## Context

Part of the carina#3112 cross-repo series: carina#3114 (core, merged) → **this PR (aws)** → carina-provider-awscc (next). The real-infra smoke (`carina apply registry/dev/registry` without the deadlock) is user-driven and runs once all three repos' mains are green.

Refs carina-rs/carina#3112

🤖 Generated with [Claude Code](https://claude.com/claude-code)