### PR TITLE
Support S3 lifecycle and replication rule filters

### DIFF
--- a/acceptance-tests/s3_bucket_lifecycle_configuration/with_filter.crn
+++ b/acceptance-tests/s3_bucket_lifecycle_configuration/with_filter.crn
@@ -1,0 +1,59 @@
+# S3 BucketLifecycleConfiguration - Filter test
+#
+# Tests: lifecycle rules scoped by `filter` — a prefix filter, a tag
+# filter, and an `and` filter combining a prefix with an object-size
+# bound. Verifies the provider serializes the Filter element correctly.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-lifecycle-filter-v1'
+}
+
+aws.s3.BucketLifecycleConfiguration {
+  bucket = bucket.bucket
+
+  rules = [
+    {
+      id     = 'logs-prefix'
+      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.enabled
+      filter = {
+        prefix = 'logs/'
+      }
+      expiration = {
+        days = 90
+      }
+    },
+    {
+      id     = 'archive-tagged'
+      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.enabled
+      filter = {
+        tag = {
+          key   = 'tier'
+          value = 'cold'
+        }
+      }
+      transitions = [
+        {
+          days          = 30
+          storage_class = aws.s3.BucketLifecycleConfiguration.TransitionStorageClass.glacier
+        },
+      ]
+    },
+    {
+      id     = 'large-data-objects'
+      status = aws.s3.BucketLifecycleConfiguration.LifecycleRuleStatus.enabled
+      filter = {
+        and = {
+          prefix                   = 'data/'
+          object_size_greater_than = 1048576
+        }
+      }
+      expiration = {
+        days = 365
+      }
+    },
+  ]
+}

--- a/acceptance-tests/s3_bucket_replication_configuration/with_filter.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/with_filter.crn
@@ -1,0 +1,64 @@
+# S3 BucketReplicationConfiguration - Filter test
+#
+# Tests: a replication rule scoped by a `filter` (prefix) with an
+# explicit `delete_marker_replication`. Verifies the provider serializes
+# the Filter and DeleteMarkerReplication elements correctly.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let source = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-repl-filter-src-v1'
+}
+
+aws.s3.BucketVersioning {
+  bucket = source.bucket
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
+}
+
+let dest = aws.s3.Bucket {
+  bucket = 'carina-acc-test-aws-s3-repl-filter-dst-v1'
+}
+
+aws.s3.BucketVersioning {
+  bucket = dest.bucket
+  status = aws.s3.BucketVersioning.VersioningStatus.enabled
+}
+
+let role = aws.iam.Role {
+  role_name = 'carina-acc-test-aws-s3-repl-filter-role-v1'
+
+  assume_role_policy_document = {
+    version = aws.iam.PolicyDocument.Version.2012_10_17
+    statement {
+      effect = aws.iam.PolicyDocument.Effect.allow
+      principal = {
+        service = 's3.amazonaws.com'
+      }
+      action = 'sts:AssumeRole'
+    }
+  }
+}
+
+aws.s3.BucketReplicationConfiguration {
+  bucket = source.bucket
+  role   = role.arn
+
+  rules = [
+    {
+      id       = 'replicate-docs'
+      status   = aws.s3.BucketReplicationConfiguration.ReplicationRuleStatus.enabled
+      priority = 1
+      filter = {
+        prefix = 'docs/'
+      }
+      delete_marker_replication = {
+        status = aws.s3.BucketReplicationConfiguration.DeleteMarkerReplicationStatus.enabled
+      }
+      destination = {
+        bucket = 'arn:aws:s3:::carina-acc-test-aws-s3-repl-filter-dst-v1'
+      }
+    },
+  ]
+}

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1591,16 +1591,76 @@ fn s3_replication_status() -> AttributeType {
     }
 }
 
+/// The `And` operator for a replication rule filter — combines a prefix
+/// with multiple tags. Required by S3 whenever a filter needs more than
+/// one condition.
+fn s3_replication_filter_and() -> AttributeType {
+    AttributeType::Struct {
+        name: "ReplicationRuleAndOperator".to_string(),
+        fields: vec![
+            StructField::new("prefix", AttributeType::String).with_provider_name("Prefix"),
+            StructField::new("tags", AttributeType::list(s3_filter_tag()))
+                .with_provider_name("Tags")
+                .with_block_name("tag"),
+        ],
+    }
+}
+
+/// Filter selecting which objects a replication rule applies to. A V2
+/// replication rule requires a `Filter` element; the provider emits an
+/// empty one automatically if this attribute is omitted.
+fn s3_replication_rule_filter() -> AttributeType {
+    AttributeType::Struct {
+        name: "ReplicationRuleFilter".to_string(),
+        fields: vec![
+            StructField::new("prefix", AttributeType::String).with_provider_name("Prefix"),
+            StructField::new("tag", s3_filter_tag())
+                .with_provider_name("Tag")
+                .with_block_name("tag"),
+            StructField::new("and", s3_replication_filter_and())
+                .with_provider_name("And")
+                .with_block_name("and"),
+        ],
+    }
+}
+
+/// Whether delete markers are replicated. A V2 replication rule that
+/// carries a `Filter` must also declare `DeleteMarkerReplication`; the
+/// provider defaults it to `Disabled` when omitted.
+fn s3_delete_marker_replication() -> AttributeType {
+    AttributeType::Struct {
+        name: "DeleteMarkerReplication".to_string(),
+        fields: vec![
+            StructField::new(
+                "status",
+                AttributeType::StringEnum {
+                    name: "DeleteMarkerReplicationStatus".to_string(),
+                    values: vec!["Enabled".to_string(), "Disabled".to_string()],
+                    namespace: Some("aws.s3.BucketReplicationConfiguration".to_string()),
+                    dsl_aliases: dsl_aliases_for(&["Enabled", "Disabled"]),
+                },
+            )
+            .with_provider_name("Status")
+            .required(),
+        ],
+    }
+}
+
 fn s3_replication_rule() -> AttributeType {
     AttributeType::Struct {
         name: "ReplicationRule".to_string(),
         fields: vec![
             StructField::new("id", AttributeType::String).with_provider_name("ID"),
             StructField::new("priority", AttributeType::Int).with_provider_name("Priority"),
-            StructField::new("prefix", AttributeType::String).with_provider_name("Prefix"),
+            StructField::new("filter", s3_replication_rule_filter())
+                .with_provider_name("Filter")
+                .with_block_name("filter"),
             StructField::new("status", s3_replication_status())
                 .with_provider_name("Status")
                 .required(),
+            StructField::new("delete_marker_replication", s3_delete_marker_replication())
+                .with_provider_name("DeleteMarkerReplication")
+                .with_block_name("delete_marker_replication"),
             StructField::new("destination", s3_replication_destination())
                 .with_provider_name("Destination")
                 .with_block_name("destination")
@@ -1709,6 +1769,63 @@ fn s3_abort_multipart() -> AttributeType {
     }
 }
 
+/// A single object tag (`key` / `value`) used inside S3 lifecycle and
+/// replication rule filters.
+fn s3_filter_tag() -> AttributeType {
+    AttributeType::Struct {
+        name: "FilterTag".to_string(),
+        fields: vec![
+            StructField::new("key", AttributeType::String)
+                .with_provider_name("Key")
+                .required(),
+            StructField::new("value", AttributeType::String)
+                .with_provider_name("Value")
+                .required(),
+        ],
+    }
+}
+
+/// The `And` operator for a lifecycle rule filter — combines a prefix,
+/// multiple tags, and object-size bounds. Required by S3 whenever a
+/// filter needs more than one condition.
+fn s3_lifecycle_filter_and() -> AttributeType {
+    AttributeType::Struct {
+        name: "LifecycleRuleAndOperator".to_string(),
+        fields: vec![
+            StructField::new("prefix", AttributeType::String).with_provider_name("Prefix"),
+            StructField::new("tags", AttributeType::list(s3_filter_tag()))
+                .with_provider_name("Tags")
+                .with_block_name("tag"),
+            StructField::new("object_size_greater_than", AttributeType::Int)
+                .with_provider_name("ObjectSizeGreaterThan"),
+            StructField::new("object_size_less_than", AttributeType::Int)
+                .with_provider_name("ObjectSizeLessThan"),
+        ],
+    }
+}
+
+/// Filter selecting which objects a lifecycle rule applies to. When a
+/// rule needs no filter it still requires an empty `<Filter/>` element;
+/// the provider emits one automatically if this attribute is omitted.
+fn s3_lifecycle_rule_filter() -> AttributeType {
+    AttributeType::Struct {
+        name: "LifecycleRuleFilter".to_string(),
+        fields: vec![
+            StructField::new("prefix", AttributeType::String).with_provider_name("Prefix"),
+            StructField::new("tag", s3_filter_tag())
+                .with_provider_name("Tag")
+                .with_block_name("tag"),
+            StructField::new("object_size_greater_than", AttributeType::Int)
+                .with_provider_name("ObjectSizeGreaterThan"),
+            StructField::new("object_size_less_than", AttributeType::Int)
+                .with_provider_name("ObjectSizeLessThan"),
+            StructField::new("and", s3_lifecycle_filter_and())
+                .with_provider_name("And")
+                .with_block_name("and"),
+        ],
+    }
+}
+
 fn s3_lifecycle_rule() -> AttributeType {
     AttributeType::Struct {
         name: "LifecycleRule".to_string(),
@@ -1717,7 +1834,9 @@ fn s3_lifecycle_rule() -> AttributeType {
             StructField::new("status", s3_lifecycle_status())
                 .with_provider_name("Status")
                 .required(),
-            StructField::new("prefix", AttributeType::String).with_provider_name("Prefix"),
+            StructField::new("filter", s3_lifecycle_rule_filter())
+                .with_provider_name("Filter")
+                .with_block_name("filter"),
             StructField::new("expiration", s3_lifecycle_expiration())
                 .with_provider_name("Expiration")
                 .with_block_name("expiration"),

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::{
     AbortIncompleteMultipartUpload, BucketLifecycleConfiguration, ExpirationStatus,
-    LifecycleExpiration, LifecycleRule, NoncurrentVersionExpiration, NoncurrentVersionTransition,
-    Transition, TransitionStorageClass,
+    LifecycleExpiration, LifecycleRule, LifecycleRuleAndOperator, LifecycleRuleFilter,
+    NoncurrentVersionExpiration, NoncurrentVersionTransition, Tag, Transition,
+    TransitionStorageClass,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
@@ -185,10 +186,14 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRu
     if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("id") {
         builder = builder.id(s);
     }
-    #[allow(deprecated)]
-    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("prefix") {
-        builder = builder.prefix(s);
-    }
+    // S3 requires every V2 lifecycle rule to carry a `Filter` element.
+    // Build one from the `filter` attribute, or fall back to an empty
+    // filter (matches all objects) so the request is not rejected with
+    // `MalformedXML`.
+    builder = builder.filter(match map.get("filter") {
+        Some(v) => build_filter(id, v)?,
+        None => LifecycleRuleFilter::builder().build(),
+    });
     if let Some(v) = map.get("expiration") {
         builder = builder.expiration(build_expiration(id, v)?);
     }
@@ -219,6 +224,87 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRu
         ProviderError::api_error(sdk_error_message("Failed to build LifecycleRule", &e))
             .for_resource(id.clone())
     })
+}
+
+/// Build a single S3 object tag from a `{ key, value }` map.
+fn build_filter_tag(id: &ResourceId, value: &Value) -> ProviderResult<Tag> {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
+        return Err(
+            ProviderError::invalid_input("filter tag must be a map").for_resource(id.clone())
+        );
+    };
+    let key = match map.get("key") {
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+        _ => {
+            return Err(
+                ProviderError::invalid_input("filter tag.key is required").for_resource(id.clone())
+            );
+        }
+    };
+    let val = match map.get("value") {
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+        _ => {
+            return Err(ProviderError::invalid_input("filter tag.value is required")
+                .for_resource(id.clone()));
+        }
+    };
+    Tag::builder().key(key).value(val).build().map_err(|e| {
+        ProviderError::api_error(sdk_error_message("Failed to build filter tag", &e))
+            .for_resource(id.clone())
+    })
+}
+
+/// Build a `LifecycleRuleAndOperator` (prefix + tags + size bounds).
+fn build_filter_and(id: &ResourceId, value: &Value) -> ProviderResult<LifecycleRuleAndOperator> {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
+        return Err(
+            ProviderError::invalid_input("filter.and must be a map").for_resource(id.clone())
+        );
+    };
+    let mut builder = LifecycleRuleAndOperator::builder();
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("prefix") {
+        builder = builder.prefix(s);
+    }
+    if let Some(Value::Concrete(ConcreteValue::List(items))) = map.get("tags") {
+        let tags: Vec<Tag> = items
+            .iter()
+            .map(|v| build_filter_tag(id, v))
+            .collect::<ProviderResult<Vec<_>>>()?;
+        builder = builder.set_tags(Some(tags));
+    }
+    if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("object_size_greater_than") {
+        builder = builder.object_size_greater_than(*n);
+    }
+    if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("object_size_less_than") {
+        builder = builder.object_size_less_than(*n);
+    }
+    Ok(builder.build())
+}
+
+/// Build a `LifecycleRuleFilter` from the DSL `filter` map. S3 allows at
+/// most one of `prefix` / `tag` / size bound / `and` to be set; the
+/// schema validates the shape, so this just forwards whatever is present.
+fn build_filter(id: &ResourceId, value: &Value) -> ProviderResult<LifecycleRuleFilter> {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
+        return Err(ProviderError::invalid_input("filter must be a map").for_resource(id.clone()));
+    };
+    let mut builder = LifecycleRuleFilter::builder();
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("prefix") {
+        builder = builder.prefix(s);
+    }
+    if let Some(v) = map.get("tag") {
+        builder = builder.tag(build_filter_tag(id, v)?);
+    }
+    if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("object_size_greater_than") {
+        builder = builder.object_size_greater_than(*n);
+    }
+    if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("object_size_less_than") {
+        builder = builder.object_size_less_than(*n);
+    }
+    if let Some(v) = map.get("and") {
+        builder = builder.and(build_filter_and(id, v)?);
+    }
+    Ok(builder.build())
 }
 
 fn build_expiration(id: &ResourceId, value: &Value) -> ProviderResult<LifecycleExpiration> {
@@ -341,14 +427,13 @@ fn rule_to_value(rule: &LifecycleRule) -> Value {
         "status".to_string(),
         Value::Concrete(ConcreteValue::String(rule.status().as_str().to_string())),
     );
-    #[allow(deprecated)]
-    if let Some(s) = rule.prefix()
-        && !s.is_empty()
+    // Only surface a non-empty filter. S3 returns an empty `<Filter/>`
+    // for match-all rules; reflecting that as an empty map would diff
+    // against a DSL config that simply omits `filter`.
+    if let Some(filter) = rule.filter()
+        && let Some(filter_value) = filter_to_value(filter)
     {
-        map.insert(
-            "prefix".to_string(),
-            Value::Concrete(ConcreteValue::String(s.to_string())),
-        );
+        map.insert("filter".to_string(), filter_value);
     }
     if let Some(exp) = rule.expiration() {
         let mut e = IndexMap::new();
@@ -428,6 +513,97 @@ fn rule_to_value(rule: &LifecycleRule) -> Value {
     Value::Concrete(ConcreteValue::Map(map))
 }
 
+/// Convert an S3 `Tag` into a `{ key, value }` map value.
+fn tag_to_value(tag: &Tag) -> Value {
+    let mut m = IndexMap::new();
+    m.insert(
+        "key".to_string(),
+        Value::Concrete(ConcreteValue::String(tag.key().to_string())),
+    );
+    m.insert(
+        "value".to_string(),
+        Value::Concrete(ConcreteValue::String(tag.value().to_string())),
+    );
+    Value::Concrete(ConcreteValue::Map(m))
+}
+
+/// Convert a `LifecycleRuleAndOperator` into a map value, or `None` when
+/// every field is empty.
+fn filter_and_to_value(and: &LifecycleRuleAndOperator) -> Option<Value> {
+    let mut m = IndexMap::new();
+    if let Some(p) = and.prefix()
+        && !p.is_empty()
+    {
+        m.insert(
+            "prefix".to_string(),
+            Value::Concrete(ConcreteValue::String(p.to_string())),
+        );
+    }
+    let tags = and.tags();
+    if !tags.is_empty() {
+        m.insert(
+            "tags".to_string(),
+            Value::Concrete(ConcreteValue::List(tags.iter().map(tag_to_value).collect())),
+        );
+    }
+    if let Some(n) = and.object_size_greater_than() {
+        m.insert(
+            "object_size_greater_than".to_string(),
+            Value::Concrete(ConcreteValue::Int(n)),
+        );
+    }
+    if let Some(n) = and.object_size_less_than() {
+        m.insert(
+            "object_size_less_than".to_string(),
+            Value::Concrete(ConcreteValue::Int(n)),
+        );
+    }
+    if m.is_empty() {
+        None
+    } else {
+        Some(Value::Concrete(ConcreteValue::Map(m)))
+    }
+}
+
+/// Convert a `LifecycleRuleFilter` into a map value, or `None` when the
+/// filter is empty (a match-all `<Filter/>`).
+fn filter_to_value(filter: &LifecycleRuleFilter) -> Option<Value> {
+    let mut m = IndexMap::new();
+    if let Some(p) = filter.prefix()
+        && !p.is_empty()
+    {
+        m.insert(
+            "prefix".to_string(),
+            Value::Concrete(ConcreteValue::String(p.to_string())),
+        );
+    }
+    if let Some(tag) = filter.tag() {
+        m.insert("tag".to_string(), tag_to_value(tag));
+    }
+    if let Some(n) = filter.object_size_greater_than() {
+        m.insert(
+            "object_size_greater_than".to_string(),
+            Value::Concrete(ConcreteValue::Int(n)),
+        );
+    }
+    if let Some(n) = filter.object_size_less_than() {
+        m.insert(
+            "object_size_less_than".to_string(),
+            Value::Concrete(ConcreteValue::Int(n)),
+        );
+    }
+    if let Some(and) = filter.and()
+        && let Some(and_value) = filter_and_to_value(and)
+    {
+        m.insert("and".to_string(), and_value);
+    }
+    if m.is_empty() {
+        None
+    } else {
+        Some(Value::Concrete(ConcreteValue::Map(m)))
+    }
+}
+
 fn transition_to_value(t: &Transition) -> Value {
     let mut m = IndexMap::new();
     if let Some(d) = t.days() {
@@ -466,4 +642,134 @@ fn ncv_transition_to_value(t: &NoncurrentVersionTransition) -> Value {
         );
     }
     Value::Concrete(ConcreteValue::Map(m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rid() -> ResourceId {
+        ResourceId::new("s3.bucket_lifecycle_configuration", "test")
+    }
+
+    fn str_val(s: &str) -> Value {
+        Value::Concrete(ConcreteValue::String(s.to_string()))
+    }
+
+    fn map_val(pairs: Vec<(&str, Value)>) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert(k.to_string(), v);
+        }
+        Value::Concrete(ConcreteValue::Map(m))
+    }
+
+    #[test]
+    fn rule_without_filter_gets_empty_filter() {
+        // Reproduces carina-rs/carina-provider-aws#273: a rule with no
+        // `filter` must still emit a `Filter` element, otherwise S3
+        // rejects the request with `MalformedXML`.
+        let rule_value = map_val(vec![
+            ("id", str_val("expire-all")),
+            ("status", str_val("Enabled")),
+            (
+                "expiration",
+                map_val(vec![("days", Value::Concrete(ConcreteValue::Int(365)))]),
+            ),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        assert!(
+            rule.filter().is_some(),
+            "a lifecycle rule must always carry a Filter element"
+        );
+    }
+
+    #[test]
+    fn rule_with_prefix_filter() {
+        let rule_value = map_val(vec![
+            ("status", str_val("Enabled")),
+            ("filter", map_val(vec![("prefix", str_val("logs/"))])),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let filter = rule.filter().expect("filter set");
+        assert_eq!(filter.prefix(), Some("logs/"));
+    }
+
+    #[test]
+    fn rule_with_tag_filter() {
+        let rule_value = map_val(vec![
+            ("status", str_val("Enabled")),
+            (
+                "filter",
+                map_val(vec![(
+                    "tag",
+                    map_val(vec![("key", str_val("env")), ("value", str_val("dev"))]),
+                )]),
+            ),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let tag = rule.filter().and_then(|f| f.tag()).expect("tag set");
+        assert_eq!(tag.key(), "env");
+        assert_eq!(tag.value(), "dev");
+    }
+
+    #[test]
+    fn rule_with_and_filter() {
+        let rule_value = map_val(vec![
+            ("status", str_val("Enabled")),
+            (
+                "filter",
+                map_val(vec![(
+                    "and",
+                    map_val(vec![
+                        ("prefix", str_val("data/")),
+                        (
+                            "object_size_greater_than",
+                            Value::Concrete(ConcreteValue::Int(1024)),
+                        ),
+                        (
+                            "tags",
+                            Value::Concrete(ConcreteValue::List(vec![map_val(vec![
+                                ("key", str_val("tier")),
+                                ("value", str_val("cold")),
+                            ])])),
+                        ),
+                    ]),
+                )]),
+            ),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let and = rule.filter().and_then(|f| f.and()).expect("and set");
+        assert_eq!(and.prefix(), Some("data/"));
+        assert_eq!(and.object_size_greater_than(), Some(1024));
+        assert_eq!(and.tags().len(), 1);
+    }
+
+    #[test]
+    fn empty_filter_is_not_surfaced_on_read() {
+        // S3 returns an empty <Filter/> for match-all rules; reading it
+        // back as an empty map would diff against a DSL that omits it.
+        let empty = LifecycleRuleFilter::builder().build();
+        assert!(filter_to_value(&empty).is_none());
+    }
+
+    #[test]
+    fn prefix_filter_round_trips() {
+        let built = build_rule(
+            &rid(),
+            &map_val(vec![
+                ("status", str_val("Enabled")),
+                ("filter", map_val(vec![("prefix", str_val("logs/"))])),
+            ]),
+        )
+        .unwrap();
+        let value = rule_to_value(&built);
+        let Value::Concrete(ConcreteValue::Map(m)) = value else {
+            panic!("expected map");
+        };
+        let Some(Value::Concrete(ConcreteValue::Map(filter))) = m.get("filter") else {
+            panic!("filter should round-trip");
+        };
+        assert_eq!(filter.get("prefix"), Some(&str_val("logs/")));
+    }
 }

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use aws_sdk_s3::types::{
-    Destination, ReplicationConfiguration, ReplicationRule, ReplicationRuleStatus, StorageClass,
+    DeleteMarkerReplication, DeleteMarkerReplicationStatus, Destination, ReplicationConfiguration,
+    ReplicationRule, ReplicationRuleAndOperator, ReplicationRuleFilter, ReplicationRuleStatus,
+    StorageClass, Tag,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
@@ -190,8 +192,39 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<Replication
         }
     };
 
+    // S3 requires every V2 replication rule to carry a `Filter`. Build
+    // one from the `filter` attribute, or fall back to an empty filter
+    // (matches all objects) so the request is not rejected with
+    // `MalformedXML`.
+    let filter = match map.get("filter") {
+        Some(v) => build_filter(id, v)?,
+        None => ReplicationRuleFilter::builder().build(),
+    };
+    // A `Filter`-based rule must also declare `DeleteMarkerReplication`.
+    // Default to `Disabled` when the DSL omits it.
+    let delete_marker_status = match map.get("delete_marker_replication") {
+        Some(Value::Concrete(ConcreteValue::Map(dm))) => match dm.get("status") {
+            Some(Value::Concrete(ConcreteValue::String(s))) => {
+                DeleteMarkerReplicationStatus::from(s.as_str())
+            }
+            _ => {
+                return Err(ProviderError::invalid_input(
+                    "delete_marker_replication.status is required",
+                )
+                .for_resource(id.clone()));
+            }
+        },
+        _ => DeleteMarkerReplicationStatus::Disabled,
+    };
+
     let mut builder = ReplicationRule::builder()
         .status(ReplicationRuleStatus::from(status_str.as_str()))
+        .filter(filter)
+        .delete_marker_replication(
+            DeleteMarkerReplication::builder()
+                .status(delete_marker_status)
+                .build(),
+        )
         .destination(destination);
 
     if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("id") {
@@ -200,17 +233,78 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<Replication
     if let Some(Value::Concrete(ConcreteValue::Int(n))) = map.get("priority") {
         builder = builder.priority(*n as i32);
     }
-    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("prefix") {
-        #[allow(deprecated)]
-        {
-            builder = builder.prefix(s);
-        }
-    }
 
     builder.build().map_err(|e| {
         ProviderError::api_error(sdk_error_message("Failed to build ReplicationRule", &e))
             .for_resource(id.clone())
     })
+}
+
+/// Build a single S3 object tag from a `{ key, value }` map.
+fn build_filter_tag(id: &ResourceId, value: &Value) -> ProviderResult<Tag> {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
+        return Err(
+            ProviderError::invalid_input("filter tag must be a map").for_resource(id.clone())
+        );
+    };
+    let key = match map.get("key") {
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+        _ => {
+            return Err(
+                ProviderError::invalid_input("filter tag.key is required").for_resource(id.clone())
+            );
+        }
+    };
+    let val = match map.get("value") {
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+        _ => {
+            return Err(ProviderError::invalid_input("filter tag.value is required")
+                .for_resource(id.clone()));
+        }
+    };
+    Tag::builder().key(key).value(val).build().map_err(|e| {
+        ProviderError::api_error(sdk_error_message("Failed to build filter tag", &e))
+            .for_resource(id.clone())
+    })
+}
+
+/// Build a `ReplicationRuleAndOperator` (prefix + tags).
+fn build_filter_and(id: &ResourceId, value: &Value) -> ProviderResult<ReplicationRuleAndOperator> {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
+        return Err(
+            ProviderError::invalid_input("filter.and must be a map").for_resource(id.clone())
+        );
+    };
+    let mut builder = ReplicationRuleAndOperator::builder();
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("prefix") {
+        builder = builder.prefix(s);
+    }
+    if let Some(Value::Concrete(ConcreteValue::List(items))) = map.get("tags") {
+        let tags: Vec<Tag> = items
+            .iter()
+            .map(|v| build_filter_tag(id, v))
+            .collect::<ProviderResult<Vec<_>>>()?;
+        builder = builder.set_tags(Some(tags));
+    }
+    Ok(builder.build())
+}
+
+/// Build a `ReplicationRuleFilter` from the DSL `filter` map.
+fn build_filter(id: &ResourceId, value: &Value) -> ProviderResult<ReplicationRuleFilter> {
+    let Value::Concrete(ConcreteValue::Map(map)) = value else {
+        return Err(ProviderError::invalid_input("filter must be a map").for_resource(id.clone()));
+    };
+    let mut builder = ReplicationRuleFilter::builder();
+    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("prefix") {
+        builder = builder.prefix(s);
+    }
+    if let Some(v) = map.get("tag") {
+        builder = builder.tag(build_filter_tag(id, v)?);
+    }
+    if let Some(v) = map.get("and") {
+        builder = builder.and(build_filter_and(id, v)?);
+    }
+    Ok(builder.build())
 }
 
 fn build_destination(id: &ResourceId, value: &Value) -> ProviderResult<Destination> {
@@ -257,19 +351,35 @@ fn rule_to_value(rule: &ReplicationRule) -> Value {
             Value::Concrete(ConcreteValue::Int(p as i64)),
         );
     }
-    #[allow(deprecated)]
-    if let Some(s) = rule.prefix()
-        && !s.is_empty()
+    // Only surface a non-empty filter. S3 returns an empty `<Filter/>`
+    // for match-all rules; reflecting that as an empty map would diff
+    // against a DSL config that simply omits `filter`.
+    if let Some(filter) = rule.filter()
+        && let Some(filter_value) = filter_to_value(filter)
     {
-        map.insert(
-            "prefix".to_string(),
-            Value::Concrete(ConcreteValue::String(s.to_string())),
-        );
+        map.insert("filter".to_string(), filter_value);
     }
     map.insert(
         "status".to_string(),
         Value::Concrete(ConcreteValue::String(rule.status().as_str().to_string())),
     );
+    // Only surface delete_marker_replication when it is Enabled. The
+    // provider defaults it to Disabled, so reflecting Disabled would
+    // diff against a DSL config that omits it.
+    if let Some(dm) = rule.delete_marker_replication()
+        && let Some(status) = dm.status()
+        && *status == DeleteMarkerReplicationStatus::Enabled
+    {
+        let mut m = IndexMap::new();
+        m.insert(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String(status.as_str().to_string())),
+        );
+        map.insert(
+            "delete_marker_replication".to_string(),
+            Value::Concrete(ConcreteValue::Map(m)),
+        );
+    }
     if let Some(dest) = rule.destination() {
         let mut d = IndexMap::new();
         d.insert(
@@ -294,4 +404,215 @@ fn rule_to_value(rule: &ReplicationRule) -> Value {
         );
     }
     Value::Concrete(ConcreteValue::Map(map))
+}
+
+/// Convert an S3 `Tag` into a `{ key, value }` map value.
+fn tag_to_value(tag: &Tag) -> Value {
+    let mut m = IndexMap::new();
+    m.insert(
+        "key".to_string(),
+        Value::Concrete(ConcreteValue::String(tag.key().to_string())),
+    );
+    m.insert(
+        "value".to_string(),
+        Value::Concrete(ConcreteValue::String(tag.value().to_string())),
+    );
+    Value::Concrete(ConcreteValue::Map(m))
+}
+
+/// Convert a `ReplicationRuleAndOperator` into a map value, or `None`
+/// when every field is empty.
+fn filter_and_to_value(and: &ReplicationRuleAndOperator) -> Option<Value> {
+    let mut m = IndexMap::new();
+    if let Some(p) = and.prefix()
+        && !p.is_empty()
+    {
+        m.insert(
+            "prefix".to_string(),
+            Value::Concrete(ConcreteValue::String(p.to_string())),
+        );
+    }
+    let tags = and.tags();
+    if !tags.is_empty() {
+        m.insert(
+            "tags".to_string(),
+            Value::Concrete(ConcreteValue::List(tags.iter().map(tag_to_value).collect())),
+        );
+    }
+    if m.is_empty() {
+        None
+    } else {
+        Some(Value::Concrete(ConcreteValue::Map(m)))
+    }
+}
+
+/// Convert a `ReplicationRuleFilter` into a map value, or `None` when the
+/// filter is empty (a match-all `<Filter/>`).
+fn filter_to_value(filter: &ReplicationRuleFilter) -> Option<Value> {
+    let mut m = IndexMap::new();
+    if let Some(p) = filter.prefix()
+        && !p.is_empty()
+    {
+        m.insert(
+            "prefix".to_string(),
+            Value::Concrete(ConcreteValue::String(p.to_string())),
+        );
+    }
+    if let Some(tag) = filter.tag() {
+        m.insert("tag".to_string(), tag_to_value(tag));
+    }
+    if let Some(and) = filter.and()
+        && let Some(and_value) = filter_and_to_value(and)
+    {
+        m.insert("and".to_string(), and_value);
+    }
+    if m.is_empty() {
+        None
+    } else {
+        Some(Value::Concrete(ConcreteValue::Map(m)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rid() -> ResourceId {
+        ResourceId::new("s3.bucket_replication_configuration", "test")
+    }
+
+    fn str_val(s: &str) -> Value {
+        Value::Concrete(ConcreteValue::String(s.to_string()))
+    }
+
+    fn map_val(pairs: Vec<(&str, Value)>) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert(k.to_string(), v);
+        }
+        Value::Concrete(ConcreteValue::Map(m))
+    }
+
+    fn dest() -> Value {
+        map_val(vec![("bucket", str_val("arn:aws:s3:::dest-bucket"))])
+    }
+
+    #[test]
+    fn rule_without_filter_gets_empty_filter() {
+        // Reproduces carina-rs/carina-provider-aws#273: a V2 replication
+        // rule with no `filter` must still emit a `Filter` element,
+        // otherwise S3 rejects the request with `MalformedXML`.
+        let rule_value = map_val(vec![
+            ("id", str_val("replicate-all")),
+            ("status", str_val("Enabled")),
+            ("destination", dest()),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        assert!(
+            rule.filter().is_some(),
+            "a replication rule must always carry a Filter element"
+        );
+    }
+
+    #[test]
+    fn rule_without_delete_marker_replication_defaults_to_disabled() {
+        // A Filter-based replication rule must also declare
+        // DeleteMarkerReplication; default it to Disabled.
+        let rule_value = map_val(vec![
+            ("status", str_val("Enabled")),
+            ("destination", dest()),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let status = rule
+            .delete_marker_replication()
+            .and_then(|d| d.status())
+            .expect("delete_marker_replication set");
+        assert_eq!(*status, DeleteMarkerReplicationStatus::Disabled);
+    }
+
+    #[test]
+    fn rule_with_explicit_delete_marker_replication() {
+        let rule_value = map_val(vec![
+            ("status", str_val("Enabled")),
+            ("destination", dest()),
+            (
+                "delete_marker_replication",
+                map_val(vec![("status", str_val("Enabled"))]),
+            ),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let status = rule
+            .delete_marker_replication()
+            .and_then(|d| d.status())
+            .expect("delete_marker_replication set");
+        assert_eq!(*status, DeleteMarkerReplicationStatus::Enabled);
+    }
+
+    #[test]
+    fn rule_with_prefix_filter() {
+        let rule_value = map_val(vec![
+            ("status", str_val("Enabled")),
+            ("destination", dest()),
+            ("filter", map_val(vec![("prefix", str_val("docs/"))])),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        assert_eq!(rule.filter().and_then(|f| f.prefix()), Some("docs/"));
+    }
+
+    #[test]
+    fn rule_with_and_filter() {
+        let rule_value = map_val(vec![
+            ("status", str_val("Enabled")),
+            ("destination", dest()),
+            (
+                "filter",
+                map_val(vec![(
+                    "and",
+                    map_val(vec![
+                        ("prefix", str_val("data/")),
+                        (
+                            "tags",
+                            Value::Concrete(ConcreteValue::List(vec![map_val(vec![
+                                ("key", str_val("replicate")),
+                                ("value", str_val("yes")),
+                            ])])),
+                        ),
+                    ]),
+                )]),
+            ),
+        ]);
+        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let and = rule.filter().and_then(|f| f.and()).expect("and set");
+        assert_eq!(and.prefix(), Some("data/"));
+        assert_eq!(and.tags().len(), 1);
+    }
+
+    #[test]
+    fn empty_filter_is_not_surfaced_on_read() {
+        let empty = ReplicationRuleFilter::builder().build();
+        assert!(filter_to_value(&empty).is_none());
+    }
+
+    #[test]
+    fn disabled_delete_marker_not_surfaced_on_read() {
+        // The provider defaults delete_marker_replication to Disabled;
+        // reflecting Disabled on read would diff against a DSL that
+        // omits it. Only Enabled should round-trip.
+        let built = build_rule(
+            &rid(),
+            &map_val(vec![
+                ("status", str_val("Enabled")),
+                ("destination", dest()),
+            ]),
+        )
+        .unwrap();
+        let value = rule_to_value(&built);
+        let Value::Concrete(ConcreteValue::Map(m)) = value else {
+            panic!("expected map");
+        };
+        assert!(
+            !m.contains_key("delete_marker_replication"),
+            "Disabled delete_marker_replication must not be surfaced"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Add full `filter` support to `aws.s3.BucketLifecycleConfiguration` and `aws.s3.BucketReplicationConfiguration`.

## Root cause

S3 V2 lifecycle and replication configurations require **every rule** to carry a `Filter` element. The provider's `build_rule` set neither `Filter` nor the deprecated `Prefix`, so `PutBucketLifecycleConfiguration` and `PutBucketReplication` were rejected with `MalformedXML`. The SDK's `LifecycleRule` / `ReplicationRule` builders treat `filter` as optional, so the broken request compiled fine and only failed at the AWS API.

## Changes

This is the *complete* fix — full filter support, not just an empty-filter patch:

- **carina-aws-types**: define `LifecycleRuleFilter` and `ReplicationRuleFilter` Struct types (`prefix` / `tag` / object-size bounds / `and` operator) plus `DeleteMarkerReplication`, and add a `filter` field to both rule types. Drop the deprecated `prefix` rule field — S3 V2 rejects `Prefix` alongside `Filter`, and `filter.prefix` covers the same case.
- **bucket_lifecycle / bucket_replication**: parse the `filter` attribute into the SDK filter types; when the DSL omits `filter`, emit an empty `Filter` (match-all) so the request is no longer malformed. A replication rule with a `Filter` must also declare `DeleteMarkerReplication` — default it to `Disabled`. Read paths surface a filter only when non-empty, so a match-all rule does not diff against a DSL config that omits `filter`.
- **Tests**: unit tests for the empty-filter default, prefix/tag/and filters, the `DeleteMarkerReplication` default, and read round-trips.
- **Fixtures**: `with_filter.crn` acceptance fixtures exercising prefix, tag, and `and` filters for both resources.

The LSP picks up the new `filter` Struct automatically — completion and diagnostics recurse over `carina-aws-types` Struct definitions. Schema/provider/docs codegen produces no diff: lifecycle/replication rule types are `type_overrides` that reference the hand-written `carina-aws-types` helpers, so regenerating only re-emits the same `super::bucket_lifecycle_rules()` call.

## Test plan

- [x] `cargo nextest run -p carina-provider-aws -p carina-aws-types` — 363 passed (12 new filter tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --doc`, `cargo fmt --check`, `scripts/check-carina-pin.sh`, `scripts/check-examples.sh` — pass
- [x] `carina validate` on `basic.crn` and `with_filter.crn` for both resources — pass
- [ ] `acceptance-tests/run-tests.sh full` — `s3_bucket_lifecycle_configuration` and `s3_bucket_replication_configuration` apply succeeds

Closes #273
Closes #277