### PR TITLE
Centralize AWS retry budget into a RetryPolicy type

### DIFF
--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -102,6 +102,52 @@ pub fn sdk_error_message(context: &str, err: &(impl std::error::Error + 'static)
     format!("{}: {}", context, DisplayErrorContext(err))
 }
 
+/// Exponential-backoff retry budget for [`retry_aws_operation`].
+///
+/// All AWS calls in this provider share a single policy
+/// ([`RetryPolicy::default`]) rather than per-call-site magic numbers,
+/// so the retry budget is tuned in one place. The fields are named so a
+/// call site reads as intent, not as two unlabeled integers.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetryPolicy {
+    /// Maximum number of attempts, including the first.
+    max_attempts: u32,
+    /// Delay before the first retry; doubles each subsequent attempt.
+    initial_delay_secs: u64,
+    /// Upper bound on any single backoff delay.
+    max_delay_secs: u64,
+}
+
+impl RetryPolicy {
+    /// Backoff delay before the given retry (`attempt` is 1-based: the
+    /// delay after the 1st failed attempt is `attempt == 1`).
+    fn delay_secs(&self, attempt: u32) -> u64 {
+        let raw = self
+            .initial_delay_secs
+            .saturating_mul(2u64.saturating_pow(attempt - 1));
+        std::cmp::min(raw, self.max_delay_secs)
+    }
+}
+
+impl Default for RetryPolicy {
+    /// 8 attempts, 5s initial backoff, 120s cap.
+    ///
+    /// Backoff schedule (7 retries): 5, 10, 20, 40, 80, 120, 120 — 395s
+    /// of cumulative sleep. S3 `OperationAborted` (CreateBucket /
+    /// DeleteBucket name races, clearing in ~60–90s) and `RequestTimeout`
+    /// recurring under load both need a budget well past the 75s of
+    /// sleep that the previous 5-attempt default gave (4 retries:
+    /// 5+10+20+40); 8 attempts cover them without pinning a single
+    /// operation for the ~10min an even larger budget would.
+    fn default() -> Self {
+        Self {
+            max_attempts: 8,
+            initial_delay_secs: 5,
+            max_delay_secs: 120,
+        }
+    }
+}
+
 /// Retry an AWS SDK operation with exponential backoff on transient errors.
 ///
 /// Whether an error is retried is decided by [`is_retryable_sdk_error`],
@@ -110,13 +156,12 @@ pub fn sdk_error_message(context: &str, err: &(impl std::error::Error + 'static)
 /// AWS docs call transient but the S3 SDK model does not flag.
 ///
 /// - `operation_name`: Human-readable name for log messages.
-/// - `max_attempts`: Maximum number of attempts (including the first).
-/// - `initial_delay_secs`: Delay before the first retry (doubles each attempt, capped at 120s).
+/// - `policy`: The [`RetryPolicy`] budget — production callers pass
+///   [`RetryPolicy::default()`].
 /// - `f`: A closure that returns a `Future` producing the SDK result.
 pub async fn retry_aws_operation<F, Fut, T, E, R>(
     operation_name: &str,
-    max_attempts: u32,
-    initial_delay_secs: u64,
+    policy: RetryPolicy,
     f: F,
 ) -> Result<T, SdkError<E, R>>
 where
@@ -130,13 +175,13 @@ where
         attempt += 1;
         match f().await {
             Ok(result) => return Ok(result),
-            Err(e) if attempt < max_attempts && is_retryable_sdk_error(&e) => {
-                let delay = std::cmp::min(initial_delay_secs * 2u64.pow(attempt - 1), 120);
+            Err(e) if attempt < policy.max_attempts && is_retryable_sdk_error(&e) => {
+                let delay = policy.delay_secs(attempt);
                 eprintln!(
                     "  Retrying {} (attempt {}/{}): {}",
                     operation_name,
                     attempt,
-                    max_attempts,
+                    policy.max_attempts,
                     DisplayErrorContext(&e)
                 );
                 sleep(Duration::from_secs(delay)).await;
@@ -588,10 +633,19 @@ mod tests {
         assert!(is_retryable_sdk_error(&timeout));
     }
 
+    /// Zero-delay policy so retry tests do not actually sleep.
+    fn test_policy(max_attempts: u32) -> RetryPolicy {
+        RetryPolicy {
+            max_attempts,
+            initial_delay_secs: 0,
+            max_delay_secs: 0,
+        }
+    }
+
     #[tokio::test]
     async fn retry_aws_operation_succeeds_first_try() {
         let result: Result<&str, SdkError<MockServiceError, HttpResponse>> =
-            retry_aws_operation("test op", 3, 0, || async { Ok("success") }).await;
+            retry_aws_operation("test op", test_policy(3), || async { Ok("success") }).await;
         assert_eq!(result.unwrap(), "success");
     }
 
@@ -602,7 +656,7 @@ mod tests {
         let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
         let counter = attempt_count.clone();
         let result: Result<&str, SdkError<MockServiceError, HttpResponse>> =
-            retry_aws_operation("delete bucket sub-resource", 3, 0, || {
+            retry_aws_operation("delete bucket sub-resource", test_policy(3), || {
                 let counter = counter.clone();
                 async move {
                     let n = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -630,7 +684,7 @@ mod tests {
         let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
         let counter = attempt_count.clone();
         let result: Result<&str, SdkError<MockServiceError, HttpResponse>> =
-            retry_aws_operation("test op", 3, 0, || {
+            retry_aws_operation("test op", test_policy(3), || {
                 let counter = counter.clone();
                 async move {
                     counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -644,5 +698,60 @@ mod tests {
             1,
             "non-retryable errors must terminate after one attempt"
         );
+    }
+
+    #[tokio::test]
+    async fn retry_aws_operation_exhausts_policy_budget() {
+        // A transient error that never clears must retry exactly
+        // max_attempts times, then surface the error.
+        let attempt_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let counter = attempt_count.clone();
+        let result: Result<&str, SdkError<MockServiceError, HttpResponse>> =
+            retry_aws_operation("create S3 bucket", test_policy(8), || {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Err(service_err("OperationAborted", None))
+                }
+            })
+            .await;
+        assert!(result.is_err());
+        assert_eq!(
+            attempt_count.load(std::sync::atomic::Ordering::SeqCst),
+            8,
+            "a never-clearing transient error must use the full budget"
+        );
+    }
+
+    #[test]
+    fn default_retry_policy_budget() {
+        // Reproduces carina-rs/carina-provider-aws#351: the previous
+        // per-site budgets (3 attempts for most S3 deletes, 5 for
+        // creates) were exhausted by S3 OperationAborted under load.
+        // The single default must be larger.
+        let p = RetryPolicy::default();
+        assert_eq!(p.max_attempts, 8);
+        assert_eq!(p.initial_delay_secs, 5);
+        assert_eq!(p.max_delay_secs, 120);
+    }
+
+    #[test]
+    fn retry_policy_delay_doubles_then_caps() {
+        let p = RetryPolicy::default();
+        // 5, 10, 20, 40, 80, then capped at 120.
+        assert_eq!(p.delay_secs(1), 5);
+        assert_eq!(p.delay_secs(2), 10);
+        assert_eq!(p.delay_secs(3), 20);
+        assert_eq!(p.delay_secs(4), 40);
+        assert_eq!(p.delay_secs(5), 80);
+        assert_eq!(p.delay_secs(6), 120, "delay must cap at max_delay_secs");
+        assert_eq!(p.delay_secs(7), 120);
+    }
+
+    #[test]
+    fn retry_policy_delay_does_not_overflow() {
+        // A large attempt number must not panic via shift/mul overflow.
+        let p = RetryPolicy::default();
+        assert_eq!(p.delay_secs(100), 120);
     }
 }

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -7,7 +7,8 @@ use aws_sdk_ec2::types::NatGatewayState;
 
 use crate::AwsProvider;
 use crate::helpers::{
-    PollState, require_string_attr, retry_aws_operation, sdk_error_message, wait_for_ec2_state,
+    PollState, RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message,
+    wait_for_ec2_state,
 };
 
 impl AwsProvider {
@@ -89,7 +90,7 @@ impl AwsProvider {
         }
 
         let rid = resource.id.clone();
-        let result = retry_aws_operation("create NAT gateway", 5, 5, || {
+        let result = retry_aws_operation("create NAT gateway", RetryPolicy::default(), || {
             let req = req.clone();
             async move { req.send().await }
         })

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 Security Group
@@ -81,7 +81,7 @@ impl AwsProvider {
         // Create Security Group
         let ec2 = &self.ec2_client;
         let rid = resource.id.clone();
-        let result = retry_aws_operation("create security group", 5, 5, || {
+        let result = retry_aws_operation("create security group", RetryPolicy::default(), || {
             let group_name = group_name.clone();
             let description = description.clone();
             let vpc_id = vpc_id.clone();

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 VPC
@@ -107,7 +107,7 @@ impl AwsProvider {
         }
 
         let rid = resource.id.clone();
-        let result = retry_aws_operation("create VPC", 5, 5, || {
+        let result = retry_aws_operation("create VPC", RetryPolicy::default(), || {
             let builder = create_vpc_builder.clone();
             async move { builder.send().await }
         })

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
     /// Read an EC2 VPC Endpoint
@@ -129,7 +129,7 @@ impl AwsProvider {
         }
 
         let rid = resource.id.clone();
-        let result = retry_aws_operation("create VPC endpoint", 5, 5, || {
+        let result = retry_aws_operation("create VPC endpoint", RetryPolicy::default(), || {
             let req = req.clone();
             async move { req.send().await }
         })

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -8,7 +8,7 @@ use carina_core::resource::{
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
     /// Read an S3 bucket
@@ -108,7 +108,7 @@ impl AwsProvider {
         // S3 returns when CreateBucket races a recent DeleteBucket for the
         // same name — the control plane clears after ~60–90s. See #156.
         let rid = resource.id.clone();
-        retry_aws_operation("create S3 bucket", 5, 5, || {
+        retry_aws_operation("create S3 bucket", RetryPolicy::default(), || {
             let req = req.clone();
             async move { req.send().await }
         })
@@ -169,7 +169,7 @@ impl AwsProvider {
             self.empty_s3_bucket(&id, identifier).await?;
         }
 
-        retry_aws_operation("delete S3 bucket", 3, 5, || {
+        retry_aws_operation("delete S3 bucket", RetryPolicy::default(), || {
             let client = &self.s3_client;
             async move { client.delete_bucket().bucket(identifier).send().await }
         })

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -6,7 +6,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 /// AWS group URIs used to identify canned-ACL grant patterns.
@@ -200,7 +200,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("reset bucket ACL", 3, 5, || {
+        let result = retry_aws_operation("reset bucket ACL", RetryPolicy::default(), || {
             let client = &self.s3_client;
             async move {
                 client

--- a/carina-provider-aws/src/services/s3/bucket_cors.rs
+++ b/carina-provider-aws/src/services/s3/bucket_cors.rs
@@ -6,7 +6,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -118,10 +118,14 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("delete bucket cors configuration", 3, 5, || {
-            let client = &self.s3_client;
-            async move { client.delete_bucket_cors().bucket(identifier).send().await }
-        })
+        let result = retry_aws_operation(
+            "delete bucket cors configuration",
+            RetryPolicy::default(),
+            || {
+                let client = &self.s3_client;
+                async move { client.delete_bucket_cors().bucket(identifier).send().await }
+            },
+        )
         .await;
 
         match result {

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -9,7 +9,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -133,17 +133,18 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("delete bucket encryption", 3, 5, || {
-            let client = &self.s3_client;
-            async move {
-                client
-                    .delete_bucket_encryption()
-                    .bucket(identifier)
-                    .send()
-                    .await
-            }
-        })
-        .await;
+        let result =
+            retry_aws_operation("delete bucket encryption", RetryPolicy::default(), || {
+                let client = &self.s3_client;
+                async move {
+                    client
+                        .delete_bucket_encryption()
+                        .bucket(identifier)
+                        .send()
+                        .await
+                }
+            })
+            .await;
 
         match result {
             Ok(_) => Ok(()),

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -11,7 +11,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -136,16 +136,20 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("delete bucket lifecycle configuration", 3, 5, || {
-            let client = &self.s3_client;
-            async move {
-                client
-                    .delete_bucket_lifecycle()
-                    .bucket(identifier)
-                    .send()
-                    .await
-            }
-        })
+        let result = retry_aws_operation(
+            "delete bucket lifecycle configuration",
+            RetryPolicy::default(),
+            || {
+                let client = &self.s3_client;
+                async move {
+                    client
+                        .delete_bucket_lifecycle()
+                        .bucket(identifier)
+                        .send()
+                        .await
+                }
+            },
+        )
         .await;
 
         match result {

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -9,7 +9,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -137,7 +137,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("clear bucket logging", 3, 5, || {
+        let result = retry_aws_operation("clear bucket logging", RetryPolicy::default(), || {
             let client = &self.s3_client;
             async move {
                 client

--- a/carina-provider-aws/src/services/s3/bucket_notification.rs
+++ b/carina-provider-aws/src/services/s3/bucket_notification.rs
@@ -10,7 +10,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -187,17 +187,21 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("clear bucket notification configuration", 3, 5, || {
-            let client = &self.s3_client;
-            async move {
-                client
-                    .put_bucket_notification_configuration()
-                    .bucket(identifier)
-                    .notification_configuration(NotificationConfiguration::builder().build())
-                    .send()
-                    .await
-            }
-        })
+        let result = retry_aws_operation(
+            "clear bucket notification configuration",
+            RetryPolicy::default(),
+            || {
+                let client = &self.s3_client;
+                async move {
+                    client
+                        .put_bucket_notification_configuration()
+                        .bucket(identifier)
+                        .notification_configuration(NotificationConfiguration::builder().build())
+                        .send()
+                        .await
+                }
+            },
+        )
         .await;
 
         match result {

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -5,7 +5,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -134,16 +134,20 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("delete bucket ownership controls", 3, 5, || {
-            let client = &self.s3_client;
-            async move {
-                client
-                    .delete_bucket_ownership_controls()
-                    .bucket(identifier)
-                    .send()
-                    .await
-            }
-        })
+        let result = retry_aws_operation(
+            "delete bucket ownership controls",
+            RetryPolicy::default(),
+            || {
+                let client = &self.s3_client;
+                async move {
+                    client
+                        .delete_bucket_ownership_controls()
+                        .bucket(identifier)
+                        .send()
+                        .await
+                }
+            },
+        )
         .await;
 
         match result {

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::iam::role::{iam_policy_json_to_value, resolve_iam_policy_attr};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -116,7 +116,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("delete bucket policy", 3, 5, || {
+        let result = retry_aws_operation("delete bucket policy", RetryPolicy::default(), || {
             let client = &self.s3_client;
             async move {
                 client

--- a/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
@@ -5,7 +5,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -153,17 +153,18 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("delete public access block", 3, 5, || {
-            let client = &self.s3_client;
-            async move {
-                client
-                    .delete_public_access_block()
-                    .bucket(identifier)
-                    .send()
-                    .await
-            }
-        })
-        .await;
+        let result =
+            retry_aws_operation("delete public access block", RetryPolicy::default(), || {
+                let client = &self.s3_client;
+                async move {
+                    client
+                        .delete_public_access_block()
+                        .bucket(identifier)
+                        .send()
+                        .await
+                }
+            })
+            .await;
 
         match result {
             Ok(_) => Ok(()),

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -10,7 +10,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -140,17 +140,18 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("delete bucket replication", 3, 5, || {
-            let client = &self.s3_client;
-            async move {
-                client
-                    .delete_bucket_replication()
-                    .bucket(identifier)
-                    .send()
-                    .await
-            }
-        })
-        .await;
+        let result =
+            retry_aws_operation("delete bucket replication", RetryPolicy::default(), || {
+                let client = &self.s3_client;
+                async move {
+                    client
+                        .delete_bucket_replication()
+                        .bucket(identifier)
+                        .send()
+                        .await
+                }
+            })
+            .await;
 
         match result {
             Ok(_) => Ok(()),

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 use aws_sdk_s3::types::{BucketVersioningStatus, MfaDelete, VersioningConfiguration};
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -129,22 +129,23 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("suspend bucket versioning", 3, 5, || {
-            let client = &self.s3_client;
-            async move {
-                client
-                    .put_bucket_versioning()
-                    .bucket(identifier)
-                    .versioning_configuration(
-                        VersioningConfiguration::builder()
-                            .status(BucketVersioningStatus::Suspended)
-                            .build(),
-                    )
-                    .send()
-                    .await
-            }
-        })
-        .await;
+        let result =
+            retry_aws_operation("suspend bucket versioning", RetryPolicy::default(), || {
+                let client = &self.s3_client;
+                async move {
+                    client
+                        .put_bucket_versioning()
+                        .bucket(identifier)
+                        .versioning_configuration(
+                            VersioningConfiguration::builder()
+                                .status(BucketVersioningStatus::Suspended)
+                                .build(),
+                        )
+                        .send()
+                        .await
+                }
+            })
+            .await;
 
         match result {
             Ok(_) => Ok(()),

--- a/carina-provider-aws/src/services/s3/bucket_website.rs
+++ b/carina-provider-aws/src/services/s3/bucket_website.rs
@@ -8,7 +8,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -207,7 +207,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
     ) -> ProviderResult<()> {
-        let result = retry_aws_operation("delete bucket website", 3, 5, || {
+        let result = retry_aws_operation("delete bucket website", RetryPolicy::default(), || {
             let client = &self.s3_client;
             async move {
                 client


### PR DESCRIPTION
## Summary

Fix S3 retry budget exhaustion under load (#351) and centralize the budget.

## Root cause

`retry_aws_operation` took `max_attempts` / `initial_delay_secs` as two bare integers, hardcoded at 18 call sites (mostly `3, 5`; creates `5, 5`). Two problems:

1. **Budget too small.** S3 `OperationAborted` (CreateBucket/DeleteBucket name races, ~60-90s to clear) and `RequestTimeout` recurring under the 10-account parallel acceptance load exhausted the retries — `is_retryable_sdk_error` classified them correctly (#272), but there simply was not enough budget. A `delete_bucket_replication` that gives up then leaves the parent bucket undeletable (`InvalidBucketState`).
2. **No central policy.** The numbers were scattered, so tuning meant editing every call site.

## Changes

- Introduce `RetryPolicy { max_attempts, initial_delay_secs, max_delay_secs }` with a single `Default` — **8 attempts, 5s initial, 120s cap** (backoff schedule 5,10,20,40,80,120,120 = 395s cumulative). Sized to outlast `OperationAborted`/`RequestTimeout` without pinning an operation for ~10min.
- `retry_aws_operation` now takes a `RetryPolicy`; all 18 S3/EC2 call sites pass `RetryPolicy::default()` — the budget is tuned in one place.
- The exponential-backoff math moves into `RetryPolicy::delay_secs`, hardened with `saturating_mul`/`saturating_pow` (the old inline `2u64.pow` could panic on overflow).

Design note: a single default policy was chosen over a fast/slow profile pair. `OperationAborted` and `RequestTimeout` both want the larger budget, so a profile split would add an unneeded per-call-site judgment without a real distinction to justify it. `RetryPolicy` is `pub(crate)` — `helpers` is a `pub(crate)` module and nothing re-exports it.

## Test plan

- [x] `cargo nextest run -p carina-provider-aws` — 284 passed (4 new: budget exhaustion, default values, backoff doubling+cap, overflow safety)
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo test --doc`, `cargo fmt --check` — pass
- [x] `scripts/check-carina-pin.sh` + codegen (`generate-schemas-smithy.sh`/`generate-provider.sh`) — no diff (change is provider logic only)

Closes #351