### PR TITLE
aws-types: migrate to structured TypeIdentity (S3 of carina#2807)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
+source = "git+https://github.com/carina-rs/carina?rev=a5f54215#a5f54215d3e481869b8d44e7d42849d18aaa1f84"
 dependencies = [
  "argon2",
  "futures",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
+source = "git+https://github.com/carina-rs/carina?rev=a5f54215#a5f54215d3e481869b8d44e7d42849d18aaa1f84"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
+source = "git+https://github.com/carina-rs/carina?rev=a5f54215#a5f54215d3e481869b8d44e7d42849d18aaa1f84"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "a5f54215" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -5,7 +5,31 @@
 //! schema config structs) remain in their respective crates.
 
 use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, CompletionValue, StructField, legacy_validator};
+use carina_core::schema::{
+    AttributeType, CompletionValue, StructField, TypeIdentity, legacy_validator,
+};
+
+/// Structured identity for an AWS resource-scoped custom type.
+///
+/// `service` + `resource` become the namespace segments and `kind` the
+/// reference-kind tail, yielding `aws.<service>.<Resource>.<kind>` —
+/// e.g. `aws.ec2.Vpc.Id`, `aws.iam.Role.Arn`. The provider axis keeps
+/// the type distinct from any same-named type a future non-AWS provider
+/// might define; the service/resource axis distinguishes, say,
+/// `aws.iam.Role.Arn` from `aws.acm.Certificate.Arn`.
+fn aws_type(service: &str, resource: &str, kind: &str) -> TypeIdentity {
+    TypeIdentity::new(Some("aws"), [service, resource], kind)
+}
+
+/// Structured identity for an AWS custom type with no service axis.
+///
+/// Used for `AvailabilityZone` (a cross-service concept owned by no
+/// single service — `aws.AvailabilityZone.ZoneId`) and for the
+/// fully-generic provider-scoped types (`aws.Arn`, `aws.ResourceId`,
+/// `aws.AccountId`), which pass an empty `segments` slice.
+fn aws_bare_type(segments: &[&str], kind: &str) -> TypeIdentity {
+    TypeIdentity::new(Some("aws"), segments.iter().copied(), kind)
+}
 
 // ========== Enum helpers ==========
 
@@ -268,7 +292,7 @@ pub fn validate_prefixed_resource_id(id: &str, expected_prefix: &str) -> Result<
 #[allow(dead_code)]
 pub fn aws_resource_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AwsResourceId".to_string()),
+        identity: Some(aws_bare_type(&[], "ResourceId")),
         pattern: Some("^[a-z-]+-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
@@ -288,7 +312,7 @@ pub fn aws_resource_id() -> AttributeType {
 /// VPC ID type (e.g., "vpc-1a2b3c4d")
 pub fn vpc_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(aws_type("ec2", "Vpc", "Id")),
         pattern: Some("^vpc-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -308,7 +332,7 @@ pub fn vpc_id() -> AttributeType {
 /// Subnet ID type (e.g., "subnet-0123456789abcdef0")
 pub fn subnet_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SubnetId".to_string()),
+        identity: Some(aws_type("ec2", "Subnet", "Id")),
         pattern: Some("^subnet-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -328,7 +352,7 @@ pub fn subnet_id() -> AttributeType {
 /// Security Group ID type (e.g., "sg-12345678")
 pub fn security_group_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SecurityGroupId".to_string()),
+        identity: Some(aws_type("ec2", "SecurityGroup", "Id")),
         pattern: Some("^sg-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -348,7 +372,7 @@ pub fn security_group_id() -> AttributeType {
 /// Internet Gateway ID type (e.g., "igw-12345678")
 pub fn internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("InternetGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "InternetGateway", "Id")),
         pattern: Some("^igw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -368,7 +392,7 @@ pub fn internet_gateway_id() -> AttributeType {
 /// Route Table ID type (e.g., "rtb-abcdef12")
 pub fn route_table_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("RouteTableId".to_string()),
+        identity: Some(aws_type("ec2", "RouteTable", "Id")),
         pattern: Some("^rtb-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -388,7 +412,7 @@ pub fn route_table_id() -> AttributeType {
 /// NAT Gateway ID type (e.g., "nat-12345678")
 pub fn nat_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("NatGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "NatGateway", "Id")),
         pattern: Some("^nat-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -408,7 +432,7 @@ pub fn nat_gateway_id() -> AttributeType {
 /// VPC Peering Connection ID type (e.g., "pcx-12345678")
 pub fn vpc_peering_connection_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcPeeringConnectionId".to_string()),
+        identity: Some(aws_type("ec2", "VpcPeeringConnection", "Id")),
         pattern: Some("^pcx-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -429,7 +453,7 @@ pub fn vpc_peering_connection_id() -> AttributeType {
 /// Transit Gateway ID type (e.g., "tgw-12345678")
 pub fn transit_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("TransitGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "TransitGateway", "Id")),
         pattern: Some("^tgw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -449,7 +473,7 @@ pub fn transit_gateway_id() -> AttributeType {
 /// VPC CIDR Block Association ID type (e.g., "vpc-cidr-assoc-12345678")
 pub fn vpc_cidr_block_association_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcCidrBlockAssociationId".to_string()),
+        identity: Some(aws_type("ec2", "VpcCidrBlockAssociation", "Id")),
         pattern: Some("^vpc-cidr-assoc-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -470,7 +494,7 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
 /// Transit Gateway Route Table ID type (e.g., "tgw-rtb-12345678")
 pub fn tgw_route_table_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("TgwRouteTableId".to_string()),
+        identity: Some(aws_type("ec2", "TransitGatewayRouteTable", "Id")),
         pattern: Some("^tgw-rtb-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -490,7 +514,7 @@ pub fn tgw_route_table_id() -> AttributeType {
 /// VPN Gateway ID type (e.g., "vgw-12345678")
 pub fn vpn_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpnGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "VpnGateway", "Id")),
         pattern: Some("^vgw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -515,7 +539,7 @@ pub fn gateway_id() -> AttributeType {
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
 pub fn egress_only_internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("EgressOnlyInternetGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "EgressOnlyInternetGateway", "Id")),
         pattern: Some("^eigw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -539,7 +563,7 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
 /// VPC Endpoint ID type (e.g., "vpce-12345678")
 pub fn vpc_endpoint_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcEndpointId".to_string()),
+        identity: Some(aws_type("ec2", "VpcEndpoint", "Id")),
         pattern: Some("^vpce-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -559,7 +583,7 @@ pub fn vpc_endpoint_id() -> AttributeType {
 /// Instance ID type (e.g., "i-0123456789abcdef0")
 pub fn instance_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("InstanceId".to_string()),
+        identity: Some(aws_type("ec2", "Instance", "Id")),
         pattern: Some("^i-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -579,7 +603,7 @@ pub fn instance_id() -> AttributeType {
 /// Network Interface ID type (e.g., "eni-0123456789abcdef0")
 pub fn network_interface_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("NetworkInterfaceId".to_string()),
+        identity: Some(aws_type("ec2", "NetworkInterface", "Id")),
         pattern: Some("^eni-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -600,7 +624,7 @@ pub fn network_interface_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn allocation_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AllocationId".to_string()),
+        identity: Some(aws_type("ec2", "Eip", "AllocationId")),
         pattern: Some("^eipalloc-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -620,7 +644,7 @@ pub fn allocation_id() -> AttributeType {
 /// Prefix List ID type (e.g., "pl-0123456789abcdef0")
 pub fn prefix_list_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("PrefixListId".to_string()),
+        identity: Some(aws_type("ec2", "PrefixList", "Id")),
         pattern: Some("^pl-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -640,7 +664,7 @@ pub fn prefix_list_id() -> AttributeType {
 /// Carrier Gateway ID type (e.g., "cagw-0123456789abcdef0")
 pub fn carrier_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("CarrierGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "CarrierGateway", "Id")),
         pattern: Some("^cagw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -660,7 +684,7 @@ pub fn carrier_gateway_id() -> AttributeType {
 /// Local Gateway ID type (e.g., "lgw-0123456789abcdef0")
 pub fn local_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("LocalGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "LocalGateway", "Id")),
         pattern: Some("^lgw-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -681,7 +705,7 @@ pub fn local_gateway_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn network_acl_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("NetworkAclId".to_string()),
+        identity: Some(aws_type("ec2", "NetworkAcl", "Id")),
         pattern: Some("^acl-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -701,7 +725,7 @@ pub fn network_acl_id() -> AttributeType {
 /// Transit Gateway Attachment ID type (e.g., "tgw-attach-0123456789abcdef0")
 pub fn transit_gateway_attachment_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("TransitGatewayAttachmentId".to_string()),
+        identity: Some(aws_type("ec2", "TransitGatewayAttachment", "Id")),
         pattern: Some("^tgw-attach-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -722,7 +746,7 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
 /// Flow Log ID type (e.g., "fl-0123456789abcdef0")
 pub fn flow_log_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("FlowLogId".to_string()),
+        identity: Some(aws_type("ec2", "FlowLog", "Id")),
         pattern: Some("^fl-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -742,7 +766,7 @@ pub fn flow_log_id() -> AttributeType {
 /// IPAM ID type (e.g., "ipam-0123456789abcdef0")
 pub fn ipam_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IpamId".to_string()),
+        identity: Some(aws_type("ec2", "Ipam", "Id")),
         pattern: Some("^ipam-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -762,7 +786,7 @@ pub fn ipam_id() -> AttributeType {
 /// Subnet Route Table Association ID type (e.g., "rtbassoc-0123456789abcdef0")
 pub fn subnet_route_table_association_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SubnetRouteTableAssociationId".to_string()),
+        identity: Some(aws_type("ec2", "SubnetRouteTableAssociation", "Id")),
         pattern: Some("^rtbassoc-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -786,7 +810,7 @@ pub fn subnet_route_table_association_id() -> AttributeType {
 /// Security Group Rule ID type (e.g., "sgr-0123456789abcdef0")
 pub fn security_group_rule_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SecurityGroupRuleId".to_string()),
+        identity: Some(aws_type("ec2", "SecurityGroupRule", "Id")),
         pattern: Some("^sgr-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -820,7 +844,7 @@ pub fn validate_iam_role_id(id: &str) -> Result<(), String> {
 /// IAM Role ID type (e.g., "AROAEXAMPLEID")
 pub fn iam_role_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IamRoleId".to_string()),
+        identity: Some(aws_type("iam", "Role", "Id")),
         pattern: Some("^AROA[A-Z0-9]+$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -856,7 +880,7 @@ pub fn validate_aws_account_id(id: &str) -> Result<(), String> {
 /// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
 pub fn aws_account_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AwsAccountId".to_string()),
+        identity: Some(aws_bare_type(&[], "AccountId")),
         pattern: Some("^\\d{12}$".to_string()),
         length: Some((Some(12), Some(12))),
         base: Box::new(AttributeType::String),
@@ -995,7 +1019,7 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
 /// ARN type (e.g., "arn:aws:s3:::my-bucket")
 pub fn arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("Arn".to_string()),
+        identity: Some(aws_bare_type(&[], "Arn")),
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):[^:]+:.*$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
@@ -1015,7 +1039,7 @@ pub fn arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_role_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IamRoleArn".to_string()),
+        identity: Some(aws_type("iam", "Role", "Arn")),
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$".to_string()),
         length: None,
         base: Box::new(arn()),
@@ -1036,7 +1060,7 @@ pub fn iam_role_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_policy_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IamPolicyArn".to_string()),
+        identity: Some(aws_type("iam", "Policy", "Arn")),
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
         length: None,
         base: Box::new(arn()),
@@ -1057,7 +1081,7 @@ pub fn iam_policy_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn kms_key_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("KmsKeyArn".to_string()),
+        identity: Some(aws_type("kms", "Key", "Arn")),
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:key/.+$".to_string()),
         length: None,
         base: Box::new(arn()),
@@ -1127,7 +1151,7 @@ pub fn validate_kms_key_id(value: &str) -> Result<(), String> {
 #[allow(dead_code)]
 pub fn kms_key_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("KmsKeyId".to_string()),
+        identity: Some(aws_type("kms", "Key", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -1163,7 +1187,7 @@ pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
 /// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
 pub fn ipam_pool_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IpamPoolId".to_string()),
+        identity: Some(aws_type("ec2", "IpamPool", "Id")),
         pattern: Some("^ipam-pool-[0-9a-f]{8,}$".to_string()),
         length: None,
         base: Box::new(aws_resource_id()),
@@ -1272,7 +1296,7 @@ pub fn validate_availability_zone_id(az_id: &str) -> Result<(), String> {
 /// Availability Zone ID type (e.g., "use1-az1", "usw2-az2", "apne1-az4")
 pub fn availability_zone_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AvailabilityZoneId".to_string()),
+        identity: Some(aws_bare_type(&["AvailabilityZone"], "ZoneId")),
         pattern: Some("^[a-z]+[0-9]+-az[0-9]+$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
@@ -2509,13 +2533,16 @@ mod tests {
     fn aws_account_id_carries_pattern_and_length() {
         let t = aws_account_id();
         if let AttributeType::Custom {
-            semantic_name,
+            identity,
             pattern,
             length,
             ..
         } = t
         {
-            assert_eq!(semantic_name.as_deref(), Some("AwsAccountId"));
+            assert_eq!(
+                identity.map(|id| id.to_string()).as_deref(),
+                Some("aws.AccountId")
+            );
             assert_eq!(pattern.as_deref(), Some(r"^\d{12}$"));
             assert_eq!(length, Some((Some(12), Some(12))));
         } else {
@@ -2524,15 +2551,16 @@ mod tests {
     }
 
     #[test]
-    fn vpc_id_carries_semantic_name_and_pattern() {
+    fn vpc_id_carries_identity_and_pattern() {
         let t = vpc_id();
         if let AttributeType::Custom {
-            semantic_name,
-            pattern,
-            ..
+            identity, pattern, ..
         } = t
         {
-            assert_eq!(semantic_name.as_deref(), Some("VpcId"));
+            assert_eq!(
+                identity.map(|id| id.to_string()).as_deref(),
+                Some("aws.ec2.Vpc.Id")
+            );
             assert!(pattern.is_some(), "VpcId should carry a pattern");
         } else {
             panic!("vpc_id() should be AttributeType::Custom");

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1279,7 +1279,7 @@ fn resolve_type(
                 (
                     format!(
                         "AttributeType::Custom {{\n\
-                         \x20               semantic_name: None,\n\
+                         \x20               identity: None,\n\
                          \x20               pattern: None,\n\
                          \x20               length: {},\n\
                          \x20               base: Box::new(AttributeType::Int),\n\

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "a5f54215" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "a5f54215" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "a5f54215" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -264,10 +264,10 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             base,
             namespace,
         } => CoreAttributeType::Custom {
-            semantic_name: if name.is_empty() {
+            identity: if name.is_empty() {
                 None
             } else {
-                Some(name.clone())
+                Some(carina_core::schema::TypeIdentity::from_dotted(name))
             },
             pattern: None,
             length: None,
@@ -393,12 +393,19 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             fields: fields.iter().map(core_to_proto_struct_field).collect(),
         },
         CoreAttributeType::Custom {
-            semantic_name,
+            identity,
             base,
             namespace,
             ..
         } => ProtoAttributeType::Custom {
-            name: semantic_name.clone().unwrap_or_default(),
+            // Serialize the structured identity to its dotted display
+            // form for the wire. The host's `TypeIdentity::from_dotted`
+            // parses it back on the other side, so the provider axis
+            // survives the JSON round-trip.
+            name: identity
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
             base: Box::new(core_to_proto_attribute_type(base)),
             namespace: namespace.clone(),
         },

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -212,13 +212,23 @@ impl CarinaProvider for AwsProcessProvider {
         carina_provider_aws::schemas::generated::build_enum_aliases_map()
     }
 
-    fn validate_custom_type(&self, type_name: &str, value: &str) -> Result<(), String> {
+    fn validate_custom_type(
+        &self,
+        identity: &carina_plugin_sdk::types::TypeIdentity,
+        value: &str,
+    ) -> Result<(), String> {
         use carina_provider_aws::schemas::types::aws_validators;
         use std::sync::OnceLock;
         type ValidatorMap = HashMap<String, Box<dyn Fn(&str) -> Result<(), String> + Send + Sync>>;
         static VALIDATORS: OnceLock<ValidatorMap> = OnceLock::new();
         let validators = VALIDATORS.get_or_init(aws_validators);
-        if let Some(validator) = validators.get(type_name) {
+        // Inner lookup map is still snake_case-keyed; convert the
+        // structured identity's `kind` to snake at this single
+        // boundary. Provider-axis collisions are already filtered by
+        // the host before the call reaches us — the SDK only routes
+        // identities scoped to this provider here.
+        let key = carina_core::parser::pascal_to_snake(&identity.kind);
+        if let Some(validator) = validators.get(&key) {
             validator(value)
         } else {
             Ok(())
@@ -450,7 +460,23 @@ fn main() {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use carina_plugin_sdk::types::ValidatorType;
+    use carina_plugin_sdk::types::{TypeIdentity, ValidatorType};
+
+    /// Test helper: build a structured identity whose dotted display
+    /// round-trips back to the legacy snake-cased semantic name via
+    /// `pascal_to_snake(identity.kind)`. The production
+    /// `validate_custom_type` impl looks the validator up in
+    /// `aws_validators`, which is still keyed on snake-cased semantic
+    /// names — so a bare identity with the PascalCase kind hits the
+    /// same map entry. Migrating `aws_validators` itself to a
+    /// structured-identity map is S2.5c follow-up work.
+    fn ident(legacy_snake: &str) -> TypeIdentity {
+        TypeIdentity {
+            provider: String::new(),
+            segments: vec![],
+            kind: carina_core::parser::snake_to_pascal(legacy_snake),
+        }
+    }
 
     #[test]
     fn schemas_include_tags_validator_for_tagged_resources() {
@@ -506,7 +532,7 @@ mod tests {
         let provider = AwsProcessProvider::new();
         assert!(
             provider
-                .validate_custom_type("vpc_id", "vpc-12345678")
+                .validate_custom_type(&ident("vpc_id"), "vpc-12345678")
                 .is_ok()
         );
     }
@@ -516,7 +542,7 @@ mod tests {
         let provider = AwsProcessProvider::new();
         assert!(
             provider
-                .validate_custom_type("vpc_id", "subnet-12345678")
+                .validate_custom_type(&ident("vpc_id"), "subnet-12345678")
                 .is_err()
         );
     }
@@ -526,7 +552,7 @@ mod tests {
         let provider = AwsProcessProvider::new();
         assert!(
             provider
-                .validate_custom_type("arn", "arn:aws:s3:::my-bucket")
+                .validate_custom_type(&ident("arn"), "arn:aws:s3:::my-bucket")
                 .is_ok()
         );
     }
@@ -534,7 +560,11 @@ mod tests {
     #[test]
     fn validate_custom_type_rejects_invalid_arn() {
         let provider = AwsProcessProvider::new();
-        assert!(provider.validate_custom_type("arn", "not-an-arn").is_err());
+        assert!(
+            provider
+                .validate_custom_type(&ident("arn"), "not-an-arn")
+                .is_err()
+        );
     }
 
     #[test]
@@ -542,7 +572,7 @@ mod tests {
         let provider = AwsProcessProvider::new();
         assert!(
             provider
-                .validate_custom_type("unknown_type", "any-value")
+                .validate_custom_type(&ident("unknown_type"), "any-value")
                 .is_ok()
         );
     }
@@ -576,7 +606,10 @@ mod tests {
         let provider = AwsProcessProvider::new();
         assert!(
             provider
-                .validate_custom_type("iam_role_arn", "arn:aws:iam::123456789012:role/my-role")
+                .validate_custom_type(
+                    &ident("iam_role_arn"),
+                    "arn:aws:iam::123456789012:role/my-role"
+                )
                 .is_ok()
         );
     }
@@ -586,7 +619,10 @@ mod tests {
         let provider = AwsProcessProvider::new();
         assert!(
             provider
-                .validate_custom_type("iam_role_arn", "arn:aws:iam::123456789012:policy/my-policy")
+                .validate_custom_type(
+                    &ident("iam_role_arn"),
+                    "arn:aws:iam::123456789012:policy/my-policy"
+                )
                 .is_err()
         );
     }

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -72,7 +72,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                 AttributeSchema::new(
                     "from_port",
                     AttributeType::Custom {
-                        semantic_name: None,
+                        identity: None,
                         pattern: None,
                         length: None,
                         base: Box::new(AttributeType::Int),
@@ -137,7 +137,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                 AttributeSchema::new(
                     "to_port",
                     AttributeType::Custom {
-                        semantic_name: None,
+                        identity: None,
                         pattern: None,
                         length: None,
                         base: Box::new(AttributeType::Int),

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -64,7 +64,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("from_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -120,7 +120,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -87,7 +87,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((Some(0), Some(32))),
                 base: Box::new(AttributeType::Int),
@@ -119,7 +119,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv6_netmask_length", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((Some(0), Some(128))),
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -69,7 +69,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((Some(0), Some(32))),
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -45,7 +45,7 @@ pub fn iam_role_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("max_session_duration", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((Some(3600), Some(43200))),
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -62,7 +62,7 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ttl", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((Some(0), Some(2147483647))),
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -8,7 +8,7 @@ pub use carina_aws_types::*;
 use std::collections::HashMap;
 
 use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, ResourceSchema, legacy_validator};
+use carina_core::schema::{AttributeType, ResourceSchema, TypeIdentity, legacy_validator};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 
 /// AWS schema configuration
@@ -58,13 +58,18 @@ pub fn cloudfront_hosted_zone_id() -> AttributeType {
 /// - Shorthand: ap_northeast_1
 pub fn aws_region() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("Region".to_string()),
+        identity: Some(TypeIdentity::new(
+            Some("aws"),
+            Vec::<String>::new(),
+            "Region",
+        )),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_enum_namespace(s, "Region", "aws")
+                let id = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region");
+                validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
                 // Normalize the input to AWS format (hyphens)
                 let normalized = extract_enum_value(s).replace('_', "-");
@@ -93,13 +98,18 @@ pub fn aws_region() -> AttributeType {
 /// - Shorthand: us_east_1a
 pub fn availability_zone() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AvailabilityZone".to_string()),
+        identity: Some(TypeIdentity::new(
+            Some("aws"),
+            ["AvailabilityZone"],
+            "ZoneName",
+        )),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_enum_namespace(s, "AvailabilityZone", "aws")
+                let id = TypeIdentity::new(Some("aws"), ["AvailabilityZone"], "ZoneName");
+                validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 let extracted = extract_enum_value(s);
                 let normalized = extracted.replace('_', "-");
@@ -124,7 +134,7 @@ pub fn availability_zone() -> AttributeType {
 /// Multiple grantees can be comma-separated.
 pub fn s3_grantee() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("S3Grantee".to_string()),
+        identity: Some(TypeIdentity::new(Some("aws"), ["s3"], "Grantee")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -237,7 +247,8 @@ pub fn aws_validators() -> HashMap<String, CustomValidatorFn> {
             // present, then convert underscores to hyphens before validating.
             availability_zone => |s: &str| {
                 if s.contains('.') {
-                    carina_core::utils::validate_enum_namespace(s, "AvailabilityZone", "aws")
+                    let id = TypeIdentity::new(Some("aws"), ["AvailabilityZone"], "ZoneName");
+                    carina_core::utils::validate_enum_namespace(s, &id)
                         .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 }
                 let extracted = carina_core::utils::extract_enum_value(s);
@@ -346,10 +357,13 @@ mod tests {
     #[test]
     fn az_accepts_dsl_format() {
         let az_type = availability_zone();
+        // The full DSL form for the zone-name variant carries the
+        // `ZoneName` kind segment — `aws.AvailabilityZone.ZoneName.<v>` —
+        // matching the structured identity's dotted display.
         assert!(
             az_type
                 .validate(&Value::Concrete(ConcreteValue::String(
-                    "aws.AvailabilityZone.us_east_1a".to_string()
+                    "aws.AvailabilityZone.ZoneName.us_east_1a".to_string()
                 )))
                 .is_ok()
         );
@@ -629,11 +643,13 @@ mod tests {
         assert!(az("ap-northeast-1c").is_ok());
 
         // Fully-qualified DSL format (the form acceptance tests use)
-        assert!(az("aws.AvailabilityZone.ap_northeast_1a").is_ok());
-        assert!(az("aws.AvailabilityZone.us_east_1a").is_ok());
+        // — the structured identity is `aws.AvailabilityZone.ZoneName`
+        // for the zone-name variant.
+        assert!(az("aws.AvailabilityZone.ZoneName.ap_northeast_1a").is_ok());
+        assert!(az("aws.AvailabilityZone.ZoneName.us_east_1a").is_ok());
 
-        // Shorthand DSL form (TypeName.value)
-        assert!(az("AvailabilityZone.ap_northeast_1a").is_ok());
+        // Shorthand DSL form (TypeName.value, where TypeName == kind)
+        assert!(az("ZoneName.ap_northeast_1a").is_ok());
 
         // Rejects non-AZ strings (regions, garbage)
         assert!(az("us-east-1").is_err()); // region, not AZ


### PR DESCRIPTION
Sub-issue S3 of carina-rs/carina#2807. Migrates the aws `carina-aws-types` copy from the legacy flat `semantic_name` field to the structured `TypeIdentity` introduced in carina#3056.

Depends on the carina-side chain (all merged):
- S1: carina-rs/carina-plugin-wit#16
- S2: carina-rs/carina#3204
- S2.5a: carina-rs/carina#3215
- S2.5a hotfix: carina-rs/carina#3216
- S2.5b: carina-rs/carina#3217

## Identity scheme

The 35 semantic types in this crate map onto a uniform `aws.<service>.<Resource>.<kind>` shape:

- **EC2 IDs (20+ types)**: `aws.ec2.<Resource>.Id` (e.g. `aws.ec2.Vpc.Id`, `aws.ec2.Subnet.Id`).
- **Resources whose reference key is something other than `Id`** keep their distinctive kind: `aws.ec2.Eip.AllocationId` (EIP is referenced by its allocation ID).
- **IAM / KMS**: `aws.iam.Role.Arn`, `aws.iam.Policy.Arn`, `aws.kms.Key.Arn`, `aws.kms.Key.Id`, `aws.iam.Role.Id`.
- **Cross-service concepts**: `aws.AvailabilityZone.ZoneId` — AZ is not owned by a single service.
- **Provider-scoped generic types**: `aws.Arn`, `aws.ResourceId`, `aws.AccountId` — segments empty.

Two helpers in the crate root keep the calls concise: `aws_type(service, resource, kind)` for the segmented form and `aws_bare_type(segments, kind)` for the segments-as-data form.

## Provider-side adjustments

- `schemas/types.rs` provider-private types (`aws_region`, `availability_zone`, `s3_grantee`) carry structured identities. `availability_zone` is `aws.AvailabilityZone.ZoneName`.
- Codegen template emits `identity: None` for anonymous Custom fallbacks; 6 generated schema files re-ran through `scripts/generate-schemas-smithy.sh`.
- `convert.rs` proto<->core round-trips through `TypeIdentity::from_dotted` / `Display`.
- `main.rs` impls the new `CarinaProvider::validate_custom_type` signature (`&TypeIdentity`). The inner `aws_validators` map is still keyed on snake-cased semantic names; the impl applies `pascal_to_snake(identity.kind)` at this single boundary. Migrating `aws_validators` to a structured-identity map is S2.5c follow-up.

## Cargo deps bump

`carina-aws-types` and `carina-provider-aws` move their `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` git revs to the S2.5b merge commit (`a5f54215`).

## Verification

- `cargo nextest run --workspace`: 453 passed.
- `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -D warnings`: green.
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`: green.

AvailabilityZone DSL value tests adopt the new `aws.AvailabilityZone.ZoneName.<value>` form to match the structured identity's dotted name space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
