### PR TITLE
carina-provider-aws: PoC test STS GetCallerIdentity via winterbaume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -86,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +114,8 @@ checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -109,11 +126,14 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
+ "hex",
  "http 1.4.0",
+ "sha1",
  "time",
  "tokio",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -126,6 +146,28 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
 ]
 
 [[package]]
@@ -387,6 +429,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-sso"
+version = "1.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sts"
 version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +590,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-json"
 version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +649,7 @@ checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -613,6 +728,12 @@ dependencies = [
  "rustc_version",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -760,6 +881,8 @@ dependencies = [
  "tokio",
  "urlencoding",
  "wasi 0.14.7+wasi-0.2.4",
+ "winterbaume-core",
+ "winterbaume-sts",
  "wit-bindgen 0.54.0",
 ]
 
@@ -781,10 +904,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -827,10 +974,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -919,6 +1091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,7 +1115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -945,6 +1123,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -972,6 +1156,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1073,15 +1263,57 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1184,6 +1416,96 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1308,6 +1630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1646,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1401,7 +1739,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1439,6 +1777,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "outref"
@@ -1576,6 +1920,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1937,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1641,6 +2001,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,7 +2033,54 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1675,10 +2096,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1752,6 +2205,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,7 +2239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1836,10 +2295,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1916,7 +2375,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1929,6 +2388,51 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1962,6 +2466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2494,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2021,7 +2537,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2037,6 +2553,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2185,10 +2710,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2197,6 +2784,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winterbaume-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9135da905ed2cbe0f7464134bf88feb0e1b1f3ce3315536805b4505db6abd4"
+dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "http 1.4.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "winterbaume-sts"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917187e9e549209e66d8dfec3cae0724138955080a95ef87946d2541008d6355"
+dependencies = [
+ "bytes",
+ "chrono",
+ "http 1.4.0",
+ "quick-xml",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+ "winterbaume-core",
 ]
 
 [[package]]

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -53,3 +53,11 @@ tokio = { version = "1", features = ["full"] }
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "time"] }
 wit-bindgen = { version = "0.54", default-features = false, features = ["macros"] }
 wasi = "0.14"
+
+# In-process AWS service emulator for integration tests. Host-only —
+# the WASM target does not exercise these (it goes through
+# `wasi:http` to a real endpoint). PoC seed for #355 (STS data source);
+# follow-ups will reuse the same dev-deps for other services.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+winterbaume-core = "0.2"
+winterbaume-sts = "0.2"

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -76,18 +76,69 @@ impl AwsProvider {
     ) -> Self {
         let config = Self::build_config(region, assume_role).await;
 
+        Self::from_clients(
+            region.to_string(),
+            allowed_account_ids,
+            forbidden_account_ids,
+            S3Client::new(&config),
+            Ec2Client::new(&config),
+            IamClient::new(&config),
+            CloudWatchLogsClient::new(&config),
+            StsClient::new(&config),
+            OrganizationsClient::new(&config),
+            IdentityStoreClient::new(&config),
+            Route53Client::new(&config),
+            AcmClient::new(&config),
+            SqsClient::new(&config),
+        )
+    }
+
+    /// Construct an `AwsProvider` from caller-supplied SDK clients.
+    ///
+    /// `new_with_account_guard` is the production entry point — it
+    /// resolves the region, optionally layers an `AssumeRoleProvider`
+    /// onto the credential chain, builds an `SdkConfig`, and constructs
+    /// all 10 clients itself. This constructor exists so integration
+    /// tests can inject clients wired to an in-process AWS mock
+    /// (`winterbaume`, library mode) and exercise the real SDK I/O
+    /// path with no real AWS and no external process (#355).
+    ///
+    /// All 10 clients are required arguments by design: when an 11th
+    /// SDK is added in the future every caller — production and tests
+    /// alike — is forced by the compiler to provide it. An
+    /// `Option<Client>`-shape would silently let tests skip newly-added
+    /// clients; a `from_sdk_config`-shape would block the eventual
+    /// "swap one client for a mock, keep the rest on real AWS"-style
+    /// finer-grained injection. The 10-arg boilerplate is the deliberate
+    /// trade for the type-level guarantee.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_clients(
+        region: String,
+        allowed_account_ids: Vec<String>,
+        forbidden_account_ids: Vec<String>,
+        s3_client: S3Client,
+        ec2_client: Ec2Client,
+        iam_client: IamClient,
+        logs_client: CloudWatchLogsClient,
+        sts_client: StsClient,
+        organizations_client: OrganizationsClient,
+        identitystore_client: IdentityStoreClient,
+        route53_client: Route53Client,
+        acm_client: AcmClient,
+        sqs_client: SqsClient,
+    ) -> Self {
         Self {
-            s3_client: S3Client::new(&config),
-            ec2_client: Ec2Client::new(&config),
-            iam_client: IamClient::new(&config),
-            logs_client: CloudWatchLogsClient::new(&config),
-            sts_client: StsClient::new(&config),
-            organizations_client: OrganizationsClient::new(&config),
-            identitystore_client: IdentityStoreClient::new(&config),
-            route53_client: Route53Client::new(&config),
-            acm_client: AcmClient::new(&config),
-            sqs_client: SqsClient::new(&config),
-            region: region.to_string(),
+            s3_client,
+            ec2_client,
+            iam_client,
+            logs_client,
+            sts_client,
+            organizations_client,
+            identitystore_client,
+            route53_client,
+            acm_client,
+            sqs_client,
+            region,
             allowed_account_ids,
             forbidden_account_ids,
         }
@@ -146,37 +197,5 @@ impl AwsProvider {
         let provider = builder.build().await;
         let shared = aws_credential_types::provider::SharedCredentialsProvider::new(provider);
         base.into_builder().credentials_provider(shared).build()
-    }
-
-    /// Create with specific clients (for testing)
-    #[allow(clippy::too_many_arguments)]
-    pub fn with_clients(
-        s3_client: S3Client,
-        ec2_client: Ec2Client,
-        iam_client: IamClient,
-        logs_client: CloudWatchLogsClient,
-        sts_client: StsClient,
-        organizations_client: OrganizationsClient,
-        identitystore_client: IdentityStoreClient,
-        route53_client: Route53Client,
-        acm_client: AcmClient,
-        sqs_client: SqsClient,
-        region: String,
-    ) -> Self {
-        Self {
-            s3_client,
-            ec2_client,
-            iam_client,
-            logs_client,
-            sts_client,
-            organizations_client,
-            identitystore_client,
-            route53_client,
-            acm_client,
-            sqs_client,
-            region,
-            allowed_account_ids: Vec::new(),
-            forbidden_account_ids: Vec::new(),
-        }
     }
 }

--- a/carina-provider-aws/tests/sts_caller_identity_winterbaume.rs
+++ b/carina-provider-aws/tests/sts_caller_identity_winterbaume.rs
@@ -1,0 +1,107 @@
+//! PoC integration test: exercise `AwsProvider`'s STS data-source read
+//! against an in-process AWS mock (`winterbaume`, library mode).
+//!
+//! This is the first foothold for winterbaume coverage in
+//! `carina-provider-aws` (#355). It proves:
+//!
+//! - The `AwsProvider::from_clients(...)` injection seam works end to end.
+//! - The full production read path runs:
+//!   `Provider::read_data_source` → codegen-generated
+//!   `dispatch_read_data_source` → `DataSourceLookups`
+//!   → `do_read_sts_caller_identity_data_source`. This is the exact
+//!   chain `carina apply`/`plan` invokes for a data source.
+//! - `winterbaume-sts`'s `GetCallerIdentity` handler is wire-compatible
+//!   with `aws-sdk-sts` and our provider's response unwrapping.
+//!
+//! Follow-ups will reuse the same `from_clients` seam to test the CRUD
+//! surfaces of managed resources (s3 bucket, ec2 vpc, etc.).
+
+// winterbaume is a host-process AWS emulator and does not build under
+// the WASM target. The cfg-gated dev-dependencies block in `Cargo.toml`
+// excludes winterbaume from WASM compiles; this attribute keeps the
+// test source consistent with that gating so `cargo test --target
+// wasm32-*` does not try to compile imports it cannot resolve.
+#![cfg(not(target_arch = "wasm32"))]
+
+use aws_sdk_acm::Client as AcmClient;
+use aws_sdk_cloudwatchlogs::Client as CloudWatchLogsClient;
+use aws_sdk_ec2::Client as Ec2Client;
+use aws_sdk_iam::Client as IamClient;
+use aws_sdk_identitystore::Client as IdentityStoreClient;
+use aws_sdk_organizations::Client as OrganizationsClient;
+use aws_sdk_route53::Client as Route53Client;
+use aws_sdk_s3::Client as S3Client;
+use aws_sdk_sqs::Client as SqsClient;
+use aws_sdk_sts::Client as StsClient;
+
+use carina_core::provider::Provider;
+use carina_core::resource::{ConcreteValue, DataSource, Value};
+use carina_provider_aws::AwsProvider;
+use winterbaume_core::MockAws;
+use winterbaume_sts::StsService;
+
+const TEST_REGION: &str = "us-east-1";
+
+/// Canonical resource_type for this data source as emitted by codegen
+/// (PascalCase tail). The production `dispatch_read_data_source` matches
+/// on this string verbatim; using `sts.caller_identity` (snake_case)
+/// would fall into the default "not implemented" arm.
+const STS_CALLER_IDENTITY_TYPE: &str = "sts.CallerIdentity";
+
+#[tokio::test]
+async fn sts_caller_identity_data_source_returns_account_arn_user_id_from_winterbaume() {
+    // `from_clients` requires all 10 SDK clients (see its doc-comment in
+    // `lib.rs` for the type-safety rationale). This test only calls STS,
+    // so we register `StsService` in the mock and wire the other 9
+    // clients to the same `sdk_config`. They are never invoked here; a
+    // future fan-out to an unregistered service would surface as a
+    // loud winterbaume error rather than passing silently.
+    let mock = MockAws::builder().with_service(StsService::new()).build();
+    let sdk_config = mock.sdk_config(TEST_REGION).await;
+
+    let provider = AwsProvider::from_clients(
+        TEST_REGION.to_string(),
+        Vec::new(),
+        Vec::new(),
+        S3Client::new(&sdk_config),
+        Ec2Client::new(&sdk_config),
+        IamClient::new(&sdk_config),
+        CloudWatchLogsClient::new(&sdk_config),
+        StsClient::new(&sdk_config),
+        OrganizationsClient::new(&sdk_config),
+        IdentityStoreClient::new(&sdk_config),
+        Route53Client::new(&sdk_config),
+        AcmClient::new(&sdk_config),
+        SqsClient::new(&sdk_config),
+    );
+
+    let ds = DataSource::with_provider("aws", STS_CALLER_IDENTITY_TYPE, "me", None);
+
+    // Go through `Provider::read_data_source`, the same entry point
+    // `carina apply`/`plan` uses for data sources. That runs the
+    // codegen-generated dispatcher (which matches on the PascalCase
+    // resource_type above), the `DataSourceLookups` trait method, and
+    // the `do_read_*` worker — the full chain, not just the worker.
+    let state = provider
+        .read_data_source(&ds)
+        .await
+        .expect("Provider::read_data_source must succeed");
+
+    // All three attributes must be present as non-empty strings — proves
+    // the SDK ↔ winterbaume wire round-trip and our response unwrap.
+    for attr in ["account_id", "arn", "user_id"] {
+        let value = state
+            .attributes
+            .get(attr)
+            .unwrap_or_else(|| panic!("returned state missing `{attr}` attribute"));
+        match value {
+            Value::Concrete(ConcreteValue::String(s)) => {
+                assert!(
+                    !s.is_empty(),
+                    "attribute `{attr}` came back as an empty string",
+                );
+            }
+            other => panic!("attribute `{attr}` expected to be a String, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
Closes #355

## Summary

`carina-provider-aws` calls AWS through 10 SDK clients held by `AwsProvider`, but the host-process integration tests cover this surface only via `acceptance-tests/` against real AWS. There is no in-process coverage — the equivalent in the main carina repo is what PRs carina-rs/carina#3206 (S3 backend) and #3229 (KMS decryptor) addressed with a winterbaume library-mode injection seam.

This PoC applies the same pattern here against the simplest possible target: `STS:GetCallerIdentity` (a data source, single SDK call, no state mutation).

## Changes

- **`AwsProvider::from_clients(...)`** — a new `pub fn` taking all 10 SDK clients (plus `region`, `allowed_account_ids`, `forbidden_account_ids`) and constructing the struct directly. `new_with_account_guard` now delegates to it; production behavior is unchanged (same fields, same order, same values).
- **`winterbaume-core` / `winterbaume-sts`** added as host-only dev-deps under `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]` (they don't pull into the WASM provider build).
- **Integration test** at `carina-provider-aws/tests/sts_caller_identity_winterbaume.rs` goes through the full production read path — `Provider::read_data_source` → codegen-generated `dispatch_read_data_source` → `DataSourceLookups` → `do_read_sts_caller_identity_data_source` — against a winterbaume `StsService`, asserting the three returned attributes (`account_id`, `arn`, `user_id`) are present and non-empty. The file is `#![cfg(not(target_arch = "wasm32"))]` to match the dev-dep gating.

## Type-safety rationale

The 10-required-arg shape on `from_clients` is deliberate. When an 11th SDK is added in the future, every caller — production and tests alike — is forced by the compiler to provide it. An `Option<Client>`-shape would silently let tests skip newly-added clients; a `from_sdk_config`-shape would block the eventual "swap one client for a mock, keep the rest on real AWS"-style finer-grained injection. The 10-arg boilerplate is the deliberate trade for the type-level guarantee.

## Breaking change (internal)

Deletes `pub fn AwsProvider::with_clients(...)`. It had zero callers in this workspace, `carina-rs/carina`, `carina-rs/carina-provider-awscc`, or any infra repo; `carina-provider-aws` is not on crates.io, and a GitHub code search for `AwsProvider::with_clients` returned no external callers. It was a strict subset of the new `from_clients` (same 10 clients, just hard-coded the two account-guard vecs to empty) and undermined the type-safety rationale by providing a parallel seam future SDKs would need to track separately. Removing it keeps `from_clients` as the single forcing function.

## Verification

- `cargo nextest run -p carina-provider-aws` — 285 passed
- `cargo test -p carina-provider-aws --doc` — clean (`[lib] doctest = false`)
- `cargo clippy -p carina-provider-aws --all-targets -- -D warnings` — clean
- `scripts/check-*.sh` — both pass (`check-carina-pin.sh`, `check-examples.sh`)
- New test runs in ~0.02s in-process

## Out of scope (follow-ups)

- CRUD coverage for any managed resource (s3 bucket, ec2 vpc, iam role, etc.). The PoC stops at one data-source read.
- Refactoring the existing `build_config` / SDK-config plumbing.
- Replacing the `acceptance-tests/` real-AWS suite — the in-process suite complements it, doesn't replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
