### PR TITLE
ec2_subnet: drop the read-path availability_zone override

### DIFF
--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -8,6 +8,14 @@ use crate::AwsProvider;
 use crate::helpers::{require_string_attr, sdk_error_message};
 use aws_sdk_ec2::types::{AttributeBooleanValue, HostnameType};
 
+// `read_ec2_subnet` must store `availability_zone` as the AWS canonical
+// form (`"ap-northeast-1a"`). Rewriting it to a DSL-prefixed identifier
+// (`"aws.AvailabilityZone.ap_northeast_1a"`) yields a phantom
+// `forces replacement` diff on every post-apply plan: the schema's
+// `CustomEnum.to_dsl` folds both sides to the same identifier when
+// rendered, so the printed values match while the underlying strings
+// do not, and the differ marks the create-only attribute as changed.
+
 impl AwsProvider {
     /// Read an EC2 Subnet
     pub(crate) async fn read_ec2_subnet(
@@ -42,15 +50,6 @@ impl AwsProvider {
 
             // Auto-generated attribute extraction
             let identifier_value = Self::extract_ec2_subnet_attributes(subnet, &mut attributes);
-
-            // Override availability_zone with DSL format
-            if let Some(az) = subnet.availability_zone() {
-                let az_dsl = format!("aws.AvailabilityZone.{}", az.replace('-', "_"));
-                attributes.insert(
-                    "availability_zone".to_string(),
-                    Value::Concrete(ConcreteValue::String(az_dsl)),
-                );
-            }
 
             // Extract user-defined tags
             if let Some(tags_value) = Self::ec2_tags_to_value(subnet.tags()) {


### PR DESCRIPTION
## Summary

- `read_ec2_subnet` was rewriting the `availability_zone` value returned by the SDK into a DSL-prefixed identifier (`"aws.AvailabilityZone.ap_northeast_1a"`) before storing it in state. The schema's `CustomEnum` already accepts the canonical form on the DSL side, so the override produced a phantom `forces replacement` diff on every post-apply plan (rendered values matched via `to_dsl`, raw strings did not).
- Drop the override block. `extract_ec2_subnet_attributes` already inserts the AWS canonical form (`"ap-northeast-1a"`), which is what state must hold. `VpnGateway`, the only sibling that also exposes an availability zone, never had this override.
- Leave a short comment at the top of the module so a future contributor does not reintroduce the same bandaid.

## Test plan

- [x] `cargo nextest run -p carina-provider-aws` — 285 tests pass (including the existing `test_extract_ec2_subnet_attributes` that pins the canonical AZ form)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-carina-pin.sh` / `bash scripts/check-examples.sh` — clean
- [x] Acceptance: `./acceptance-tests/run-tests.sh full --accounts 0-0 ec2_route/nat_gateway` against `carina-test-000` — **1 passed, 0 failed** (was failing plan-verify with `"ap_northeast_1a" → "ap_northeast_1a" (forces replacement)` on `main`)

Closes #363
