### PR TITLE
tests: drop dead AZ-prefix conversion unit tests (follow-up to #364)

### DIFF
--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -614,23 +614,6 @@ fn test_extract_ec2_subnet_attributes_map_public_ip_true() {
     );
 }
 
-// --- Subnet availability zone DSL format conversion ---
-
-#[test]
-fn test_subnet_availability_zone_dsl_format() {
-    // Simulates the AZ conversion in read_ec2_subnet
-    let az = "ap-northeast-1a";
-    let az_dsl = format!("aws.AvailabilityZone.{}", az.replace('-', "_"));
-    assert_eq!(az_dsl, "aws.AvailabilityZone.ap_northeast_1a");
-}
-
-#[test]
-fn test_subnet_availability_zone_dsl_format_us_east() {
-    let az = "us-east-1b";
-    let az_dsl = format!("aws.AvailabilityZone.{}", az.replace('-', "_"));
-    assert_eq!(az_dsl, "aws.AvailabilityZone.us_east_1b");
-}
-
 #[test]
 fn test_subnet_availability_zone_dsl_to_aws_sdk() {
     use carina_core::utils::convert_enum_value;


### PR DESCRIPTION
## Summary

- Follow-up to #364. That PR removed the read-path `availability_zone` override in `read_ec2_subnet`. Two unit tests still pinned the override's behavior with the comment "Simulates the AZ conversion in `read_ec2_subnet`" — leftover that misleads future contributors into reintroducing the same bandaid.
- Delete `test_subnet_availability_zone_dsl_format` and `test_subnet_availability_zone_dsl_format_us_east`. Keep `test_subnet_availability_zone_dsl_to_aws_sdk` immediately below — that one still pins `create_ec2_subnet`'s DSL→AWS hyphenated conversion.

## Test plan

- [x] `cargo nextest run -p carina-provider-aws` — 283 tests pass (was 285, two dead tests removed)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
