### PR TITLE
Bump carina-core rev to current main, absorb breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=bb00b795#bb00b79557b7c6b106e9ae8eb318b0d12027c2b7"
+source = "git+https://github.com/carina-rs/carina?rev=b38b62ed#b38b62edd497931ca9fd1c0576a32089eb77bc3b"
 dependencies = [
  "argon2",
  "futures",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=bb00b795#bb00b79557b7c6b106e9ae8eb318b0d12027c2b7"
+source = "git+https://github.com/carina-rs/carina?rev=b38b62ed#b38b62edd497931ca9fd1c0576a32089eb77bc3b"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=bb00b795#bb00b79557b7c6b106e9ae8eb318b0d12027c2b7"
+source = "git+https://github.com/carina-rs/carina?rev=b38b62ed#b38b62edd497931ca9fd1c0576a32089eb77bc3b"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "bb00b795" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "b38b62ed" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -292,6 +292,7 @@ pub fn validate_prefixed_resource_id(id: &str, expected_prefix: &str) -> Result<
 #[allow(dead_code)]
 pub fn aws_resource_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_bare_type(&[], "ResourceId")),
         pattern: Some("^[a-z-]+-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -310,6 +311,7 @@ pub fn aws_resource_id() -> AttributeType {
 /// VPC ID type (e.g., "vpc-1a2b3c4d")
 pub fn vpc_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "Vpc", "Id")),
         pattern: Some("^vpc-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -328,6 +330,7 @@ pub fn vpc_id() -> AttributeType {
 /// Subnet ID type (e.g., "subnet-0123456789abcdef0")
 pub fn subnet_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "Subnet", "Id")),
         pattern: Some("^subnet-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -346,6 +349,7 @@ pub fn subnet_id() -> AttributeType {
 /// Security Group ID type (e.g., "sg-12345678")
 pub fn security_group_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "SecurityGroup", "Id")),
         pattern: Some("^sg-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -364,6 +368,7 @@ pub fn security_group_id() -> AttributeType {
 /// Internet Gateway ID type (e.g., "igw-12345678")
 pub fn internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "InternetGateway", "Id")),
         pattern: Some("^igw-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -382,6 +387,7 @@ pub fn internet_gateway_id() -> AttributeType {
 /// Route Table ID type (e.g., "rtb-abcdef12")
 pub fn route_table_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "RouteTable", "Id")),
         pattern: Some("^rtb-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -400,6 +406,7 @@ pub fn route_table_id() -> AttributeType {
 /// NAT Gateway ID type (e.g., "nat-12345678")
 pub fn nat_gateway_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "NatGateway", "Id")),
         pattern: Some("^nat-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -418,6 +425,7 @@ pub fn nat_gateway_id() -> AttributeType {
 /// VPC Peering Connection ID type (e.g., "pcx-12345678")
 pub fn vpc_peering_connection_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "VpcPeeringConnection", "Id")),
         pattern: Some("^pcx-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -437,6 +445,7 @@ pub fn vpc_peering_connection_id() -> AttributeType {
 /// Transit Gateway ID type (e.g., "tgw-12345678")
 pub fn transit_gateway_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "TransitGateway", "Id")),
         pattern: Some("^tgw-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -455,6 +464,7 @@ pub fn transit_gateway_id() -> AttributeType {
 /// VPC CIDR Block Association ID type (e.g., "vpc-cidr-assoc-12345678")
 pub fn vpc_cidr_block_association_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "VpcCidrBlockAssociation", "Id")),
         pattern: Some("^vpc-cidr-assoc-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -474,6 +484,7 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
 /// Transit Gateway Route Table ID type (e.g., "tgw-rtb-12345678")
 pub fn tgw_route_table_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "TransitGatewayRouteTable", "Id")),
         pattern: Some("^tgw-rtb-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -492,6 +503,7 @@ pub fn tgw_route_table_id() -> AttributeType {
 /// VPN Gateway ID type (e.g., "vgw-12345678")
 pub fn vpn_gateway_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "VpnGateway", "Id")),
         pattern: Some("^vgw-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -515,6 +527,7 @@ pub fn gateway_id() -> AttributeType {
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
 pub fn egress_only_internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "EgressOnlyInternetGateway", "Id")),
         pattern: Some("^eigw-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -537,6 +550,7 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
 /// VPC Endpoint ID type (e.g., "vpce-12345678")
 pub fn vpc_endpoint_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "VpcEndpoint", "Id")),
         pattern: Some("^vpce-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -555,6 +569,7 @@ pub fn vpc_endpoint_id() -> AttributeType {
 /// Instance ID type (e.g., "i-0123456789abcdef0")
 pub fn instance_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "Instance", "Id")),
         pattern: Some("^i-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -573,6 +588,7 @@ pub fn instance_id() -> AttributeType {
 /// Network Interface ID type (e.g., "eni-0123456789abcdef0")
 pub fn network_interface_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "NetworkInterface", "Id")),
         pattern: Some("^eni-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -592,6 +608,7 @@ pub fn network_interface_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn allocation_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "Eip", "AllocationId")),
         pattern: Some("^eipalloc-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -610,6 +627,7 @@ pub fn allocation_id() -> AttributeType {
 /// Prefix List ID type (e.g., "pl-0123456789abcdef0")
 pub fn prefix_list_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "PrefixList", "Id")),
         pattern: Some("^pl-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -628,6 +646,7 @@ pub fn prefix_list_id() -> AttributeType {
 /// Carrier Gateway ID type (e.g., "cagw-0123456789abcdef0")
 pub fn carrier_gateway_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "CarrierGateway", "Id")),
         pattern: Some("^cagw-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -646,6 +665,7 @@ pub fn carrier_gateway_id() -> AttributeType {
 /// Local Gateway ID type (e.g., "lgw-0123456789abcdef0")
 pub fn local_gateway_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "LocalGateway", "Id")),
         pattern: Some("^lgw-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -665,6 +685,7 @@ pub fn local_gateway_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn network_acl_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "NetworkAcl", "Id")),
         pattern: Some("^acl-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -683,6 +704,7 @@ pub fn network_acl_id() -> AttributeType {
 /// Transit Gateway Attachment ID type (e.g., "tgw-attach-0123456789abcdef0")
 pub fn transit_gateway_attachment_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "TransitGatewayAttachment", "Id")),
         pattern: Some("^tgw-attach-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -702,6 +724,7 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
 /// Flow Log ID type (e.g., "fl-0123456789abcdef0")
 pub fn flow_log_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "FlowLog", "Id")),
         pattern: Some("^fl-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -720,6 +743,7 @@ pub fn flow_log_id() -> AttributeType {
 /// IPAM ID type (e.g., "ipam-0123456789abcdef0")
 pub fn ipam_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "Ipam", "Id")),
         pattern: Some("^ipam-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -738,6 +762,7 @@ pub fn ipam_id() -> AttributeType {
 /// Subnet Route Table Association ID type (e.g., "rtbassoc-0123456789abcdef0")
 pub fn subnet_route_table_association_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "SubnetRouteTableAssociation", "Id")),
         pattern: Some("^rtbassoc-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -760,6 +785,7 @@ pub fn subnet_route_table_association_id() -> AttributeType {
 /// Security Group Rule ID type (e.g., "sgr-0123456789abcdef0")
 pub fn security_group_rule_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "SecurityGroupRule", "Id")),
         pattern: Some("^sgr-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -792,6 +818,7 @@ pub fn validate_iam_role_id(id: &str) -> Result<(), String> {
 /// IAM Role ID type (e.g., "AROAEXAMPLEID")
 pub fn iam_role_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("iam", "Role", "Id")),
         pattern: Some("^AROA[A-Z0-9]+$".to_string()),
         length: None,
@@ -826,6 +853,7 @@ pub fn validate_aws_account_id(id: &str) -> Result<(), String> {
 /// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
 pub fn aws_account_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_bare_type(&[], "AccountId")),
         pattern: Some("^\\d{12}$".to_string()),
         length: Some((Some(12), Some(12))),
@@ -963,6 +991,7 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
 /// ARN type (e.g., "arn:aws:s3:::my-bucket")
 pub fn arn() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_bare_type(&[], "Arn")),
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):[^:]+:.*$".to_string()),
         length: None,
@@ -981,6 +1010,7 @@ pub fn arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_role_arn() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("iam", "Role", "Arn")),
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$".to_string()),
         length: None,
@@ -1000,6 +1030,7 @@ pub fn iam_role_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_policy_arn() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("iam", "Policy", "Arn")),
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
         length: None,
@@ -1019,6 +1050,7 @@ pub fn iam_policy_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn kms_key_arn() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("kms", "Key", "Arn")),
         pattern: Some("^arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:key/.+$".to_string()),
         length: None,
@@ -1087,6 +1119,7 @@ pub fn validate_kms_key_id(value: &str) -> Result<(), String> {
 #[allow(dead_code)]
 pub fn kms_key_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("kms", "Key", "Id")),
         pattern: None,
         length: None,
@@ -1121,6 +1154,7 @@ pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
 /// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
 pub fn ipam_pool_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_type("ec2", "IpamPool", "Id")),
         pattern: Some("^ipam-pool-[0-9a-f]{8,}$".to_string()),
         length: None,
@@ -1228,6 +1262,7 @@ pub fn validate_availability_zone_id(az_id: &str) -> Result<(), String> {
 /// Availability Zone ID type (e.g., "use1-az1", "usw2-az2", "apne1-az4")
 pub fn availability_zone_id() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(aws_bare_type(&["AvailabilityZone"], "ZoneId")),
         pattern: Some("^[a-z]+[0-9]+-az[0-9]+$".to_string()),
         length: None,
@@ -2496,6 +2531,7 @@ mod tests {
     fn aws_account_id_carries_pattern_and_length() {
         let t = aws_account_id();
         if let AttributeType::Custom {
+            to_dsl: None,
             identity,
             pattern,
             length,
@@ -2517,7 +2553,10 @@ mod tests {
     fn vpc_id_carries_identity_and_pattern() {
         let t = vpc_id();
         if let AttributeType::Custom {
-            identity, pattern, ..
+            to_dsl: None,
+            identity,
+            pattern,
+            ..
         } = t
         {
             assert_eq!(

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1284,6 +1284,7 @@ fn resolve_type(
                          \x20               length: {},\n\
                          \x20               base: Box::new(AttributeType::Int),\n\
                          \x20               validate: legacy_validator({}),\n\
+                         \x20               to_dsl: None,\n\
                          \x20           }}",
                         length_expr, validate_fn
                     ),

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "bb00b795" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "b38b62ed" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "bb00b795" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "bb00b795" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "b38b62ed" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "b38b62ed" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -266,6 +266,7 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             CoreAttributeType::Union(members.iter().map(proto_to_core_attribute_type).collect())
         }
         ProtoAttributeType::Custom { name, base } => CoreAttributeType::Custom {
+            to_dsl: None,
             identity: if name.is_empty() {
                 None
             } else {

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -62,6 +62,10 @@ impl AwsProcessProvider {
                 .map(|id| convert::core_to_proto_resource_id(id)),
             cause: detail.cause.as_ref().map(|c| c.to_string()),
             provider_name: detail.provider_name.clone(),
+            operation: detail.operation.clone(),
+            status: detail.status,
+            code: detail.code.clone(),
+            request_id: detail.request_id.clone(),
         }
     }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -77,6 +77,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                         length: None,
                         base: Box::new(AttributeType::Int),
                         validate: legacy_validator(validate_from_port_range),
+                        to_dsl: None,
                     },
                 )
                 .create_only()
@@ -143,6 +144,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                         length: None,
                         base: Box::new(AttributeType::Int),
                         validate: legacy_validator(validate_to_port_range),
+                        to_dsl: None,
                     },
                 )
                 .create_only()

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -69,6 +69,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 length: None,
                 base: Box::new(AttributeType::Int),
                 validate: legacy_validator(validate_from_port_range),
+                to_dsl: None,
             })
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the start of the port range. If the protocol is ICMP, this is the ICMP type or -1 (all ICMP types). To specify ...")
@@ -123,6 +124,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 length: None,
                 base: Box::new(AttributeType::Int),
                 validate: legacy_validator(validate_to_port_range),
+                to_dsl: None,
             })
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP, this is the ICMP code or -1 (all ICMP codes). If the start ...")

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -92,6 +92,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 length: Some((Some(0), Some(32))),
                 base: Box::new(AttributeType::Int),
                 validate: legacy_validator(validate_ipv4_netmask_length_range),
+                to_dsl: None,
             })
                 .create_only()
                 .with_description("An IPv4 netmask length for the subnet.")
@@ -122,6 +123,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 length: Some((Some(0), Some(128))),
                 base: Box::new(AttributeType::Int),
                 validate: legacy_validator(validate_ipv6_netmask_length_range),
+                to_dsl: None,
             })
                 .create_only()
                 .with_description("An IPv6 netmask length for the subnet.")

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -74,6 +74,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
                 length: Some((Some(0), Some(32))),
                 base: Box::new(AttributeType::Int),
                 validate: legacy_validator(validate_ipv4_netmask_length_range),
+                to_dsl: None,
             })
                 .create_only()
                 .with_description("The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Amazon VPC IP Address Manager (IPAM) pool. For more information about IPA...")

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -50,6 +50,7 @@ pub fn iam_role_config() -> AwsSchemaConfig {
                 length: Some((Some(3600), Some(43200))),
                 base: Box::new(AttributeType::Int),
                 validate: legacy_validator(validate_max_session_duration_range),
+                to_dsl: None,
             })
                 .create_only()
                 .with_description("The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default val...")

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -67,6 +67,7 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
                 length: Some((Some(0), Some(2147483647))),
                 base: Box::new(AttributeType::Int),
                 validate: legacy_validator(validate_ttl_range),
+                to_dsl: None,
             })
                 .with_description("The resource record cache time to live (TTL), in seconds. Note the following: If you're creating or updating an alias resource record set, omit TTL. A...")
                 .with_provider_name("TTL"),

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -123,6 +123,7 @@ pub fn availability_zone() -> AttributeType {
 /// Multiple grantees can be comma-separated.
 pub fn s3_grantee() -> AttributeType {
     AttributeType::Custom {
+        to_dsl: None,
         identity: Some(TypeIdentity::new(Some("aws"), ["s3"], "Grantee")),
         pattern: None,
         length: None,


### PR DESCRIPTION
## Summary

Catches `carina-provider-aws` up to the latest `carina-rs/carina` main (`bb00b795` → `b38b62ed`). Prerequisite for the AWS error display work tracked at carina-rs/carina#3242 — the new `ProviderError` builder methods (`with_operation` / `with_status` / `with_code` / `with_request_id`) that the migration helper will use only exist in the bumped rev.

## Changes

- `carina-provider-aws/Cargo.toml` + `carina-aws-types/Cargo.toml`: bump `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` to `b38b62ed`.
- `carina-plugin-wit` submodule: bump to `3695b68` so the wit-bindgen-generated `wit_types::ErrorDetail` carries the four new optional fields (`operation` / `status` / `code` / `request-id`) the WIT contract gained in carina-rs/carina-plugin-wit#18.
- `AttributeType::Custom` literal sites — 35 in `carina-aws-types/src/lib.rs`, 10 in `carina-provider-aws/src/schemas/generated/**`: all gain the new required `to_dsl: None` field that the carina-core variant grew upstream. `None` is the structural default (no AWS-side type currently needs a state→DSL normalization callback).
- `carina-provider-aws/src/main.rs`: the `proto::ProviderError` construction site that mirrors the host-side `ErrorDetail` now populates the four new fields. Until the per-call-site migration (the follow-up for #3241) lands, these will all be `None` at runtime; the host renderer falls back to the legacy chain-walking single-line form via the carina-rs/carina#3242 D5 fallback path.

## Verify

- `cargo nextest run` — 458 passed
- `cargo clippy -- -D warnings` — passed
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — passed
- `cargo fmt --check` — passed

## Scope

Catch-up only. The actual AWS error display migration (replacing `sdk_error_message` call sites with structured-metadata-aware `ProviderError::api_error(...).with_*(...)` chains for carina-rs/carina#3241) lands as a follow-up PR on top of this one.

Closes #366
