### PR TITLE
aws-error display: add api_error_with_meta + migrate iam.ListRoles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "aws-types",
  "carina-aws-types",
  "carina-core",
  "carina-plugin-sdk",

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -29,6 +29,7 @@ aws-credential-types = { version = "1" }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 aws-smithy-types = { version = "1" }
 aws-smithy-runtime-api = { version = "1" }
+aws-types = { version = "1" }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-cloudwatchlogs = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-ec2 = { version = "1", default-features = false, features = ["behavior-version-latest"] }

--- a/carina-provider-aws/src/error_helpers.rs
+++ b/carina-provider-aws/src/error_helpers.rs
@@ -1,0 +1,185 @@
+//! Structured AWS-error construction helpers for `ProviderError`.
+//!
+//! Turns an AWS SDK error into a `carina_core::ProviderError` carrying
+//! the response metadata as structured fields (`operation`, `status`,
+//! `code`, `request_id`) so the host's renderer can surface them as
+//! labeled lines instead of the single-line debug dump that motivated
+//! carina-rs/carina#3241.
+//!
+//! See carina-rs/carina#3242 for the unified design — D3 (one-shot
+//! constructor), D4 (WIT fields), D5 (Display fallback). The new
+//! `api_error_with_meta` helper here is the provider-side one-shot
+//! constructor.
+//!
+//! `helpers::sdk_error_message` is intentionally left in place; it
+//! still serves call sites that hand off non-SDK errors (builder
+//! errors from AWS SDK type-state builders, JSON encode errors,
+//! validator failures). Those don't implement `ProvideErrorMetadata`
+//! and have no HTTP-response shape — for them the host renderer's
+//! fallback path (PR carina-rs/carina#3247, design D5) handles the
+//! display correctly.
+//!
+//! Scope: `pub(crate)` on purpose. carina-provider-awscc faces the
+//! same shape and would copy this helper verbatim — but that goes
+//! against the `carina-aws-types` shared-vs-triplicated convention
+//! (see the carina#3242 design discussion). If cross-provider reuse
+//! becomes real, lift the helper to `carina-aws-types` rather than
+//! promoting it to `pub` here.
+
+use carina_core::provider::ProviderError;
+
+/// Type alias for the `aws-sdk-*` family's `SdkError` shape with the
+/// HTTP-response generic pinned. Every `aws-sdk-*` crate's
+/// `error::SdkError<E>` re-exports the same smithy
+/// `SdkError<E, HttpResponse>`, so this single alias matches every
+/// service's `.send().await.err()` shape. Lets the helper signature
+/// stay short and the future per-service migrations not re-import
+/// the long smithy path.
+pub(crate) type AwsSdkError<E> = aws_smithy_runtime_api::client::result::SdkError<
+    E,
+    aws_smithy_runtime_api::client::orchestrator::HttpResponse,
+>;
+
+/// Build a structured `ProviderError::ApiError` from an AWS SDK error.
+///
+/// Extracts HTTP status, AWS error code, AWS-side message, and request
+/// id via the SDK's `ProvideErrorMetadata` + `RequestId` traits. The
+/// host renderer (carina-rs/carina#3247) then surfaces them as labeled
+/// lines:
+///
+/// ```text
+/// [iam.Roles.admin_access_roles] Failed to list IAM roles: User is not authorized...
+///   operation: iam.ListRoles
+///   status: 403 AccessDenied
+///   request_id: 997aa923-...
+/// ```
+///
+/// `context` is the per-operation human-readable header (the same
+/// string the legacy `sdk_error_message` used, e.g. `"Failed to list
+/// IAM roles"`). The AWS-side message is appended to it as
+/// `"<context>: <aws-message>"` so the header line carries both —
+/// PR-1's design (carina#3242 D6) keeps the message in the header,
+/// not as a separate labeled line.
+///
+/// `operation` is the service-qualified API operation
+/// (e.g. `"iam.ListRoles"`, `"s3.HeadBucket"`) so the operator can
+/// grep CI logs by operation without re-parsing the message.
+///
+/// The SDK error is preserved as `ProviderError.cause` so
+/// transport-level diagnostics (DNS, TLS, network timeouts — none of
+/// which populate the HTTP-response fields) still reach the operator
+/// via the renderer's appended `cause:` line.
+pub fn api_error_with_meta<E, S>(
+    context: impl Into<String>,
+    operation: S,
+    err: AwsSdkError<E>,
+) -> ProviderError
+where
+    S: Into<String>,
+    E: std::error::Error
+        + aws_smithy_types::error::metadata::ProvideErrorMetadata
+        + Send
+        + Sync
+        + 'static,
+{
+    use aws_smithy_types::error::metadata::ProvideErrorMetadata;
+    use aws_types::request_id::RequestId;
+
+    let status = err.raw_response().map(|r| r.status().as_u16());
+    let code = err.code().map(str::to_owned);
+    let aws_message = err.message().map(str::to_owned);
+    let request_id = err.request_id().map(str::to_owned);
+
+    let context = context.into();
+    let header = match aws_message {
+        Some(m) => format!("{context}: {m}"),
+        None => context,
+    };
+
+    let mut pe = ProviderError::api_error(header).with_operation(operation);
+    if let Some(s) = status {
+        pe = pe.with_status(s);
+    }
+    if let Some(c) = code {
+        pe = pe.with_code(c);
+    }
+    if let Some(id) = request_id {
+        pe = pe.with_request_id(id);
+    }
+    pe.with_cause(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_iam::error::SdkError;
+    use aws_sdk_iam::operation::list_roles::ListRolesError;
+    use aws_sdk_iam::types::error::ServiceFailureException;
+    use aws_smithy_runtime_api::http::{Response, StatusCode};
+    use aws_smithy_types::body::SdkBody;
+    use aws_smithy_types::error::metadata::ErrorMetadata;
+    use carina_core::provider::ProviderError as CoreProviderError;
+
+    /// carina#3241: a real `SdkError::service_error(...)` round-trip
+    /// through `api_error_with_meta` populates the structured fields
+    /// the renderer surfaces — proving the extraction wiring works
+    /// against a real AWS SDK error type, not just a synthetic mock.
+    #[test]
+    fn api_error_with_meta_extracts_response_metadata() {
+        let meta = ErrorMetadata::builder()
+            .code("AccessDenied")
+            .message("User: arn:aws:sts::... is not authorized to perform: iam:ListRoles")
+            .build();
+        let inner = ListRolesError::ServiceFailureException(
+            ServiceFailureException::builder().meta(meta).build(),
+        );
+        let raw = Response::new(StatusCode::try_from(403u16).unwrap(), SdkBody::empty());
+        let sdk_err = SdkError::service_error(inner, raw);
+
+        let pe = api_error_with_meta("Failed to list IAM roles", "iam.ListRoles", sdk_err);
+        let CoreProviderError::ApiError(detail) = &pe else {
+            panic!("expected ApiError, got {:?}", pe);
+        };
+
+        assert_eq!(detail.operation.as_deref(), Some("iam.ListRoles"));
+        assert_eq!(detail.status, Some(403));
+        assert_eq!(detail.code.as_deref(), Some("AccessDenied"));
+        assert!(
+            detail.message.contains("Failed to list IAM roles"),
+            "header must keep per-operation context, got: {}",
+            detail.message
+        );
+        assert!(
+            detail.message.contains("User: arn:aws:sts::"),
+            "header must fold in AWS-side message, got: {}",
+            detail.message
+        );
+    }
+
+    /// carina#3241: when the SDK error carries no metadata (rare —
+    /// usually a transport-level failure that doesn't reach the
+    /// service-error path), the header stays as the per-operation
+    /// context only and structured fields are left `None` — letting
+    /// the renderer's fallback chain walker surface the underlying
+    /// error via the `cause:` line (design D5).
+    #[test]
+    fn api_error_with_meta_preserves_context_when_no_metadata() {
+        // A `ConstructionFailure` is the closest representable shape
+        // for "no HTTP response landed". Use a simple `&str` cause.
+        let sdk_err: SdkError<ListRolesError> = SdkError::construction_failure("dns lookup failed");
+
+        let pe = api_error_with_meta("Failed to list IAM roles", "iam.ListRoles", sdk_err);
+        let CoreProviderError::ApiError(detail) = &pe else {
+            panic!("expected ApiError, got {:?}", pe);
+        };
+
+        assert_eq!(detail.message, "Failed to list IAM roles");
+        assert_eq!(detail.operation.as_deref(), Some("iam.ListRoles"));
+        assert_eq!(detail.status, None);
+        assert_eq!(detail.code, None);
+        assert_eq!(detail.request_id, None);
+        // Cause is preserved so the renderer's fallback path surfaces
+        // the transport-level diagnostic.
+        assert!(detail.cause.is_some());
+    }
+}

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -5,6 +5,7 @@
 mod data_source_lookups;
 mod ec2_security_group_rules;
 mod ec2_tags;
+pub(crate) mod error_helpers;
 mod factory;
 pub(crate) mod helpers;
 mod normalizer;

--- a/carina-provider-aws/src/services/iam/roles.rs
+++ b/carina-provider-aws/src/services/iam/roles.rs
@@ -12,7 +12,8 @@ use carina_core::resource::{ConcreteValue, DataSource, State, Value};
 use regex::Regex;
 
 use crate::AwsProvider;
-use crate::helpers::{sdk_error_message, value_as_str};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::value_as_str;
 
 impl AwsProvider {
     /// Read `iam.Roles` given a `DataSource` with optional `path_prefix` /
@@ -72,7 +73,7 @@ async fn list_matching_roles(
             req = req.marker(m);
         }
         let resp = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to list IAM roles", &e))
+            api_error_with_meta("Failed to list IAM roles", "iam.ListRoles", e)
                 .for_resource(resource.id.clone())
         })?;
 


### PR DESCRIPTION
## Summary

PR 3 of the [carina-rs/carina#3242](https://github.com/carina-rs/carina/issues/3242) unified AWS error renderer series. PR-1 (carina-rs/carina#3247, merged) added the carina-core `ProviderError` builder methods + multi-line `Display` rendering; PR-2 (carina-rs/carina#3250, merged) closed carina-rs/carina#3235 for the carina-state S3 backend path. **This PR ships the provider-aws migration helper and migrates the single call site that issue carina-rs/carina#3241 directly reproduces against.**

## What's in this PR

- **`carina-provider-aws/src/error_helpers.rs` (new module)**:
  - `api_error_with_meta(context, operation, err) -> ProviderError`: one-shot constructor that extracts `status` / `code` / `aws_message` / `request_id` from a `SdkError<E, HttpResponse>` via `ProvideErrorMetadata` + `RequestId`, folds the AWS-side message into the header (`"<context>: <aws-message>"`) per design D6, populates the structured fields via the new builders, and preserves the SDK error as `with_cause(err)` so transport-level diagnostics survive via the renderer's `cause:` line (D5).
  - `AwsSdkError<E>` type alias for the verbose `SdkError<E, HttpResponse>` shape so subsequent per-service PRs read cleanly.
  - 2 unit tests: real `SdkError::service_error` round-trip (status + code + AWS message + header folding) and the `ConstructionFailure` fallback (header preserved, structured fields `None`, cause preserved).

- **`carina-provider-aws/src/services/iam/roles.rs`**: the `iam.ListRoles` call site that issue carina-rs/carina#3241 names is migrated from `ProviderError::api_error(sdk_error_message(...))` to `api_error_with_meta("Failed to list IAM roles", "iam.ListRoles", e)`. This is the **single** site changed.

- **`Cargo.toml`**: explicit `aws-types = "1"` dep (already transitive via `aws-config`; the explicit declaration makes the direct usage of `RequestId` honest, adds zero new crates to the dep graph).

## What is intentionally NOT in this PR — and why

- **carina-rs/carina#3241 is NOT closed by this PR.** ~268 other `sdk_error_message` call sites across ~123 files in this repository still use the legacy string-flattening path. Sweeping them all in one PR would be unreviewable. Subsequent per-service PRs migrate the remaining sites (s3, ec2, route53, acm, sqs, organizations, …); each gets its own review unit. carina-rs/carina#3241 closes when the final sweep PR lands.
- **`helpers::sdk_error_message` stays in place.** It still serves call sites that hand off non-SDK errors (builder errors from AWS SDK type-state builders, JSON encode errors, validator failures). Those don't implement `ProvideErrorMetadata` and have no HTTP-response shape — for them the host renderer's fallback path (carina-rs/carina#3247 design D5) handles the display correctly. Final removal lands as a cleanup PR after every SDK-error site is migrated.

## Before / after (the user-visible win at the iam.ListRoles call site)

Before (issue carina-rs/carina#3241's CI log):

```
Error: [iam.Roles.admin_access_roles] Failed to list IAM roles: service error: unhandled error (AccessDenied): Error { code: "AccessDenied", message: "User: arn:aws:sts::... is not authorized to perform: iam:ListRoles ..." (... 4 KB single-line debug dump ...)
```

After:

```
Error: [iam.Roles.admin_access_roles] Failed to list IAM roles: User: arn:aws:sts::... is not authorized to perform: iam:ListRoles on resource: arn:aws:iam::...:role/aws-reserved/sso.amazonaws.com/ because no identity-based policy allows the iam:ListRoles action
  operation: iam.ListRoles
  status: 403 AccessDenied
  request_id: 997aa923-...
```

## Test plan

- [x] `cargo nextest run` — 460 passed (458 pre-existing + 2 new `api_error_with_meta` tests)
- [x] `cargo clippy -- -D warnings` — passed
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — passed
- [x] `cargo fmt --check` — passed
- [x] 5-round code review — zero blocking findings

## Design follow-ups not in this PR

- Per-call-site `const OP: &str = "iam.ListRoles";` convention to catch operation-name typos in the sweep PRs.
- Renderer-side header redaction (`Authorization`, `X-Amz-Security-Token`) for the `cause:` line in the carina-core renderer — follow-up against carina-rs/carina#3247.
- awscc-equivalent helper when an analogue of carina-rs/carina#3241 surfaces there. Per the existing `carina-aws-types`-style triplication convention, the helper body would copy verbatim rather than be promoted to `pub` here.

Refs carina-rs/carina#3241
Refs carina-rs/carina#3242
