### PR TITLE
route53: migrate ChangeResourceRecordSets + ListResourceRecordSets to api_error_with_meta

### DIFF
--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -14,6 +14,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{require_enum_attr, require_string_attr, sdk_error_message};
 
 /// Composite identifier format: `hosted_zone_id|name|type`
@@ -210,8 +211,12 @@ async fn change_record_set(
         .send()
         .await
         .map_err(|e| {
-            ProviderError::api_error(sdk_error_message("ChangeResourceRecordSets failed", &e))
-                .for_resource(id.clone())
+            api_error_with_meta(
+                "ChangeResourceRecordSets failed",
+                "route53.ChangeResourceRecordSets",
+                e,
+            )
+            .for_resource(id.clone())
         })?;
 
     Ok(())
@@ -313,8 +318,12 @@ impl AwsProvider {
             }
 
             let result = request.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to list record sets", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to list record sets",
+                    "route53.ListResourceRecordSets",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
             match scan_page_for_record(result.resource_record_sets(), &normalized_name, record_type)


### PR DESCRIPTION
## Summary

Sweep PR in the [carina-rs/carina#3242](https://github.com/carina-rs/carina/issues/3242) AWS-error display series. Migrates 2 of the 7 `sdk_error_message` call sites in `services/route53/record_set.rs` to the structured `api_error_with_meta` helper added in carina-rs/carina-provider-aws#368.

The other 5 sites hand off `BuildError` from AWS SDK type-state `.build()` calls — those don't implement `ProvideErrorMetadata`, so they keep using `helpers::sdk_error_message` per the design D5 fallback (host renderer falls through to the single-line chain walk when no structured fields are populated).

## Migrated sites

- `ChangeResourceRecordSets failed` (record_set.rs:213) → operation `"route53.ChangeResourceRecordSets"`
- `Failed to list record sets` (record_set.rs:316) → operation `"route53.ListResourceRecordSets"`

Both sites are downstream of `.send().await.map_err(|e| { ... })`, so `e` is a `SdkError<E, HttpResponse>` and the structured-metadata extraction (`status` / `code` / `aws_message` / `request_id`) lands cleanly on `ProviderError`.

## What this does NOT close

carina-rs/carina#3241 stays open. ~258 `sdk_error_message` call sites across other services (s3, ec2, iam, logs, organizations, acm, sqs, sts, identitystore) still use the legacy path; subsequent per-service sweep PRs migrate them. carina-rs/carina#3241 closes when the final sweep PR lands.

## Verify

- `cargo nextest run` — 460 passed
- `cargo clippy -- -D warnings` — passed
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — passed
- `cargo fmt --check` — clean
- 5-round code review — zero blocking findings

Refs carina-rs/carina#3241
Refs carina-rs/carina#3242
