### PR TITLE
sts: migrate GetCallerIdentity (data-source) to api_error_with_meta

### DIFF
--- a/carina-provider-aws/src/services/sts/caller_identity.rs
+++ b/carina-provider-aws/src/services/sts/caller_identity.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
+use carina_core::provider::{BoxFuture, ProviderResult};
 use carina_core::resource::{ConcreteValue, DataSource, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::error_helpers::api_error_with_meta;
 
 impl AwsProvider {
     /// Read STS caller identity (data source).
@@ -24,10 +24,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to get STS caller identity",
-                        &e,
-                    ))
+                        "sts.GetCallerIdentity",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
 


### PR DESCRIPTION
## Summary

Sweep PR in the [carina-rs/carina#3242](https://github.com/carina-rs/carina/issues/3242) series. Migrates 1 of 2 `sdk_error_message` call sites in `services/sts/` to the structured `api_error_with_meta` helper added in carina-rs/carina-provider-aws#368.

## Migrated site

- `services/sts/caller_identity.rs:27` — `Failed to get STS caller identity` → operation `"sts.GetCallerIdentity"`. The `aws.sts.CallerIdentity` data-source's read path; downstream of `.send().await.map_err(|e| { ... })`, so `e` is a structured `SdkError<E, HttpResponse>` and the helper extracts `status` / `code` / `aws_message` / `request_id` cleanly.

## Deferred from this PR

- `services/sts/account_guard.rs:81` is NOT migrated. That function signature is `Result<(), String>` (legacy string-only return); migrating would require widening the return type to `ProviderError`, which is outside the scope of an AWS-error display sweep. `helpers::sdk_error_message` continues to serve it. A future cleanup PR can revisit once a broader policy on the account_guard return type is decided.

## What this does NOT close

carina-rs/carina#3241 stays open. Remaining `sdk_error_message` call sites across other services (s3, ec2, iam, logs, organizations, acm, sqs, identitystore, ec2_*) still use the legacy path; subsequent per-service sweep PRs migrate them. carina-rs/carina#3241 closes when the final sweep PR lands.

## Verify

- `cargo nextest run` — 460 passed
- `cargo clippy -- -D warnings` — passed
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — passed
- `cargo fmt --check` — clean
- 5-round code review — zero blocking findings

Refs carina-rs/carina#3241
Refs carina-rs/carina#3242
