### PR TITLE
identitystore: migrate DescribeUser + GetUserId to api_error_with_meta

### DIFF
--- a/carina-provider-aws/src/services/identitystore/user.rs
+++ b/carina-provider-aws/src/services/identitystore/user.rs
@@ -12,6 +12,7 @@ use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, DataSource, State, Value};
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{sdk_error_message, value_as_str};
 
 impl AwsProvider {
@@ -43,10 +44,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
-                        &format!("Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'"),
-                        &e,
-                    ))
+                    api_error_with_meta(
+                        format!("Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'"),
+                        "identitystore.DescribeUser",
+                        e,
+                    )
                     .for_resource(resource.id.clone())
                 })?;
 
@@ -100,10 +102,11 @@ async fn resolve_user_id(
         .send()
         .await
         .map_err(|e| {
-            ProviderError::api_error(sdk_error_message(
-                &format!("Failed to look up user_id for user_name '{user_name}' in store '{identity_store_id}'"),
-                &e,
-            ))
+            api_error_with_meta(
+                format!("Failed to look up user_id for user_name '{user_name}' in store '{identity_store_id}'"),
+                "identitystore.GetUserId",
+                e,
+            )
             .for_resource(resource.id.clone())
         })?;
 


### PR DESCRIPTION
## Summary

Sweep PR in the [carina-rs/carina#3242](https://github.com/carina-rs/carina/issues/3242) series. Migrates 2 of 3 `sdk_error_message` call sites in `services/identitystore/user.rs` to the structured `api_error_with_meta` helper added in carina-rs/carina-provider-aws#368.

## Migrated

- `Failed to describe identitystore user '{user_id}' in store '{identity_store_id}'` (line 46) → operation `"identitystore.DescribeUser"`
- `Failed to look up user_id for user_name '{user_name}' in store '{identity_store_id}'` (line 103) → operation `"identitystore.GetUserId"`

Both are downstream of `.send().await.map_err(|e| { ... })`, so `e` is `SdkError<E, HttpResponse>` and the helper extracts the AWS response metadata cleanly.

## Deferred

- `UniqueAttribute::builder().build()` failure (line 87) is a Smithy type-state `BuildError`, not an `SdkError<E>`. Stays on `helpers::sdk_error_message` per design D5 fallback (host renderer's chain-walk path handles it correctly).

## Verify

- `cargo nextest run` — 460 passed
- `cargo clippy -- -D warnings` — passed
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — passed
- `cargo fmt --check` — clean
- 5-round code review — zero blocking findings

Refs carina-rs/carina#3241
Refs carina-rs/carina#3242
