### PR TITLE
sweep: migrate iam/sqs/organizations/acm/logs SDK error sites to api_error_with_meta

### DIFF
--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -19,6 +19,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{require_string_attr, sdk_error_message};
 
 fn extract_string(value: &Value) -> Option<&str> {
@@ -300,7 +301,7 @@ impl AwsProvider {
         // carina-rs/carina-provider-aws#296.
 
         let output = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("RequestCertificate failed", &e))
+            api_error_with_meta("RequestCertificate failed", "acm.RequestCertificate", e)
                 .for_resource(id.clone())
         })?;
 
@@ -328,10 +329,11 @@ impl AwsProvider {
                         .send()
                         .await
                         .map_err(|e| {
-                            ProviderError::api_error(sdk_error_message(
+                            api_error_with_meta(
                                 "DescribeCertificate failed",
-                                &e,
-                            ))
+                                "acm.DescribeCertificate",
+                                e,
+                            )
                             .for_resource(id.clone())
                         })
                         .map(|out| out.certificate().cloned())
@@ -366,7 +368,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("DescribeCertificate failed", &e))
+                api_error_with_meta("DescribeCertificate failed", "acm.DescribeCertificate", e)
                     .for_resource(id.clone())
             })?;
         self.read_acm_certificate_from_detail(id, arn, output.certificate())
@@ -399,8 +401,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("ListTagsForCertificate failed", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "ListTagsForCertificate failed",
+                    "acm.ListTagsForCertificate",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
         let tags = tag_output.tags();
         if !tags.is_empty() {
@@ -446,10 +452,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "UpdateCertificateOptions failed",
-                        &e,
-                    ))
+                        "acm.UpdateCertificateOptions",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
         }
@@ -498,7 +505,7 @@ impl AwsProvider {
                 req = req.tags(tag);
             }
             req.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("AddTagsToCertificate failed", &e))
+                api_error_with_meta("AddTagsToCertificate failed", "acm.AddTagsToCertificate", e)
                     .for_resource(id.clone())
             })?;
         }
@@ -523,8 +530,12 @@ impl AwsProvider {
                 req = req.tags(tag);
             }
             req.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("RemoveTagsFromCertificate failed", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "RemoveTagsFromCertificate failed",
+                    "acm.RemoveTagsFromCertificate",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
         }
 
@@ -543,7 +554,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("DeleteCertificate failed", &e))
+                api_error_with_meta("DeleteCertificate failed", "acm.DeleteCertificate", e)
                     .for_resource(id)
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -5,6 +5,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{require_string_attr, sdk_error_message};
 
 impl AwsProvider {
@@ -70,7 +71,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::api_error(sdk_error_message("Failed to get IAM role", &e))
+                    api_error_with_meta("Failed to get IAM role", "iam.GetRole", e)
                         .for_resource(id.clone()),
                 )
             }
@@ -123,7 +124,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create IAM role", &e))
+            api_error_with_meta("Failed to create IAM role", "iam.CreateRole", e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -148,10 +149,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to update assume role policy",
-                        &e,
-                    ))
+                        "iam.UpdateAssumeRolePolicy",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
         }
@@ -174,7 +176,7 @@ impl AwsProvider {
 
         if needs_update {
             req.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to update IAM role", &e))
+                api_error_with_meta("Failed to update IAM role", "iam.UpdateRole", e)
                     .for_resource(id.clone())
             })?;
         }
@@ -203,7 +205,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete IAM role", &e))
+                api_error_with_meta("Failed to delete IAM role", "iam.DeleteRole", e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -239,7 +241,7 @@ impl AwsProvider {
                 req = req.tag_keys(key);
             }
             req.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to untag IAM role", &e))
+                api_error_with_meta("Failed to untag IAM role", "iam.UntagRole", e)
                     .for_resource(id.clone())
             })?;
         }
@@ -272,7 +274,7 @@ impl AwsProvider {
                 req = req.tags(tag);
             }
             req.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to tag IAM role", &e))
+                api_error_with_meta("Failed to tag IAM role", "iam.TagRole", e)
                     .for_resource(id.clone())
             })?;
         }

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -1,11 +1,12 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::ProviderResult;
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_string_attr;
 
 impl AwsProvider {
     /// Read a CloudWatch Logs Log Group
@@ -25,7 +26,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe log groups", &e))
+                api_error_with_meta("Failed to describe log groups", "logs.DescribeLogGroups", e)
                     .for_resource(id.clone())
             })?;
 
@@ -146,7 +147,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create log group", &e))
+            api_error_with_meta("Failed to create log group", "logs.CreateLogGroup", e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -161,10 +162,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to set retention policy",
-                        &e,
-                    ))
+                        "logs.PutRetentionPolicy",
+                        e,
+                    )
                     .for_resource(resource.id.clone())
                 })?;
         }
@@ -191,10 +193,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to set retention policy",
-                            &e,
-                        ))
+                            "logs.PutRetentionPolicy",
+                            e,
+                        )
                         .for_resource(id.clone())
                     })?;
             }
@@ -206,10 +209,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to delete retention policy",
-                            &e,
-                        ))
+                            "logs.DeleteRetentionPolicy",
+                            e,
+                        )
                         .for_resource(id.clone())
                     })?;
             }
@@ -225,7 +229,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to associate KMS key", &e))
+                    api_error_with_meta("Failed to associate KMS key", "logs.AssociateKmsKey", e)
                         .for_resource(id.clone())
                 })?;
         } else if from.attributes.contains_key("kms_key_id") {
@@ -235,10 +239,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to disassociate KMS key",
-                        &e,
-                    ))
+                        "logs.DisassociateKmsKey",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
         }
@@ -267,7 +272,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete log group", &e))
+                api_error_with_meta("Failed to delete log group", "logs.DeleteLogGroup", e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -307,7 +312,7 @@ impl AwsProvider {
                 req = req.tags(key);
             }
             req.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to untag log group", &e))
+                api_error_with_meta("Failed to untag log group", "logs.UntagLogGroup", e)
                     .for_resource(id.clone())
             })?;
         }
@@ -335,7 +340,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to tag log group", &e))
+                    api_error_with_meta("Failed to tag log group", "logs.TagLogGroup", e)
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -5,6 +5,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{PollState, require_string_attr, sdk_error_message, wait_for_ec2_state};
 
 impl AwsProvider {
@@ -146,10 +147,12 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(
-                    ProviderError::api_error(sdk_error_message("Failed to describe account", &e))
-                        .for_resource(id.clone()),
+                Err(api_error_with_meta(
+                    "Failed to describe account",
+                    "organizations.DescribeAccount",
+                    e,
                 )
+                .for_resource(id.clone()))
             }
         }
     }
@@ -199,7 +202,7 @@ impl AwsProvider {
         }
 
         let response = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create account", &e))
+            api_error_with_meta("Failed to create account", "organizations.CreateAccount", e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -226,10 +229,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to describe create account status",
-                            &e,
-                        ))
+                            "organizations.DescribeCreateAccountStatus",
+                            e,
+                        )
                         .for_resource(resource_id.clone())
                     })?;
                 if let Some(status) = result.create_account_status() {
@@ -260,10 +264,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to get final create account status",
-                    &e,
-                ))
+                    "organizations.DescribeCreateAccountStatus",
+                    e,
+                )
                 .for_resource(resource.id.clone())
             })?;
 
@@ -287,10 +292,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to list parents for new account",
-                        &e,
-                    ))
+                        "organizations.ListParents",
+                        e,
+                    )
                     .for_resource(resource.id.clone())
                 })?;
 
@@ -306,10 +312,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to move account to parent",
-                            &e,
-                        ))
+                            "organizations.MoveAccount",
+                            e,
+                        )
                         .for_resource(resource.id.clone())
                     })?;
             }
@@ -348,7 +355,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to move account", &e))
+                    api_error_with_meta("Failed to move account", "organizations.MoveAccount", e)
                         .for_resource(id.clone())
                 })?;
         }
@@ -377,7 +384,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to close account", &e))
+                api_error_with_meta("Failed to close account", "organizations.CloseAccount", e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -415,7 +422,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to untag account", &e))
+                    api_error_with_meta("Failed to untag account", "organizations.UntagResource", e)
                         .for_resource(id.clone())
                 })?;
         }
@@ -450,7 +457,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to tag account", &e))
+                    api_error_with_meta("Failed to tag account", "organizations.TagResource", e)
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::error_helpers::api_error_with_meta;
 
 impl AwsProvider {
     /// Extract attributes from an Organizations Organization object
@@ -93,10 +93,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to describe organization",
-                    &e,
-                ))
+                    "organizations.DescribeOrganization",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -118,8 +119,12 @@ impl AwsProvider {
         }
 
         let response = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create organization", &e))
-                .for_resource(resource.id.clone())
+            api_error_with_meta(
+                "Failed to create organization",
+                "organizations.CreateOrganization",
+                e,
+            )
+            .for_resource(resource.id.clone())
         })?;
 
         if let Some(org) = response.organization() {
@@ -150,8 +155,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete organization", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to delete organization",
+                    "organizations.DeleteOrganization",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
         Ok(())
     }

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -15,7 +15,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_string_attr;
 // IAM policy doc Struct↔JSON converters are borrowed via pub(crate)
 // from services/iam/role.rs until aws#286 extracts them into a shared
 // module. SQS's Policy and RedriveAllowPolicy are IAM-shaped.
@@ -400,10 +401,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                return Err(ProviderError::api_error(sdk_error_message(
+                return Err(api_error_with_meta(
                     "Failed to get queue attributes",
-                    &err,
-                ))
+                    "sqs.GetQueueAttributes",
+                    err,
+                )
                 .for_resource(id.clone()));
             }
         };
@@ -495,7 +497,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create SQS queue", &e))
+            api_error_with_meta("Failed to create SQS queue", "sqs.CreateQueue", e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -544,10 +546,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to set queue attributes",
-                        &e,
-                    ))
+                        "sqs.SetQueueAttributes",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
         }
@@ -575,7 +578,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete SQS queue", &e))
+                api_error_with_meta("Failed to delete SQS queue", "sqs.DeleteQueue", e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -612,7 +615,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to untag SQS queue", &e))
+                    api_error_with_meta("Failed to untag SQS queue", "sqs.UntagQueue", e)
                         .for_resource(id.clone())
                 })?;
         }
@@ -638,7 +641,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to tag SQS queue", &e))
+                    api_error_with_meta("Failed to tag SQS queue", "sqs.TagQueue", e)
                         .for_resource(id.clone())
                 })?;
         }


### PR DESCRIPTION
sweep: migrate iam/sqs/organizations/acm/logs SDK error sites to api_error_with_meta (refs #3241)

Sweep PR (batch 1) in the carina-rs/carina#3242 series. Migrates the
SDK-operation error sites in iam/role.rs (7), sqs/queue.rs (6),
organizations/organization.rs (3), organizations/account.rs (10),
acm/certificate.rs (8), and logs/log_group.rs (10) from
`ProviderError::api_error(sdk_error_message(...))` to the structured
`api_error_with_meta` helper added in carina-rs/carina-provider-aws#368.

Total: 44 sites migrated across 6 files.

## Batched together rather than per-service

Each migration is mechanical and the same shape (`.send().await.map_err(|e| api_error_with_meta(context, "service.Op", e).for_resource(...))`). Per-service PRs would balloon the review-cycle cost for what is structurally one topic — "small/medium service AWS-error display sweep" — so all 6 files land together. ec2 (90 sites) and s3 (83 sites) get their own PRs because of size, not topic distinction.

## Deferred — builder errors

Each file has 0-4 additional `sdk_error_message` call sites that hand off `BuildError` from AWS SDK type-state `.build()` calls (e.g. `Tag::builder().build()`). Those don't implement `ProvideErrorMetadata` and stay on `helpers::sdk_error_message` per the design D5 fallback (host renderer's chain-walk single-line render handles them correctly).

## Verify

* `cargo nextest run` — 460 passed
* `cargo clippy -- -D warnings` — passed
* `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — passed
* `cargo fmt --check` — clean

Refs carina-rs/carina#3241
Refs carina-rs/carina#3242
