### PR TITLE
sweep: migrate ec2_*/provider_generated SDK error sites + codegen template

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1886,7 +1886,7 @@ fn generate_provider_code(
          #[allow(unused_imports)]\n\
          use carina_core::utils::extract_enum_value;\n\n\
          use crate::AwsProvider;\n\
-         use crate::helpers::sdk_error_message;\n\n",
+         use crate::error_helpers::api_error_with_meta;\n\n",
     );
 
     // Generate methods on AwsProvider
@@ -1917,6 +1917,19 @@ fn generate_provider_code(
         let display_name =
             pascal_to_snake(res.name.split('.').next_back().unwrap_or(res.name)).replace('_', " ");
 
+        // Operation string for the structured error display
+        // (carina-rs/carina#3242): `<service>.<Operation>`, e.g.
+        // "ec2.DeleteVpc". Derived from the per-resource `delete_op`
+        // (snake) → PascalCase, prefixed with the service segment
+        // of `service_namespace` (e.g. "com.amazonaws.ec2" → "ec2").
+        let op_str = format!(
+            "{}.{}",
+            res.service_namespace
+                .strip_prefix("com.amazonaws.")
+                .unwrap_or(res.service_namespace),
+            snake_to_pascal_type(&res.delete_op.to_snake_case()),
+        );
+
         code.push_str(&format!(
             "\x20   /// Delete {} (generated)\n\
              \x20   pub(crate) async fn {}(\n\
@@ -1925,12 +1938,12 @@ fn generate_provider_code(
              \x20       identifier: &str,\n\
              \x20   ) -> ProviderResult<()> {{\n\
              \x20       self.{}.{}().{}(identifier).send().await.map_err(|e| {{\n\
-             \x20           ProviderError::api_error(sdk_error_message(\"Failed to delete {}\", &e))\n\
+             \x20           api_error_with_meta(\"Failed to delete {}\", \"{}\", e)\n\
              \x20               .for_resource(id.clone())\n\
              \x20       }})?;\n\
              \x20       Ok(())\n\
              \x20   }}\n\n",
-            res.name, method_name, client_field, sdk_method, id_setter, display_name,
+            res.name, method_name, client_field, sdk_method, id_setter, display_name, op_str,
         ));
     }
 
@@ -2016,13 +2029,20 @@ fn generate_provider_code(
             code.push_str("\x20       identifier: &str,\n");
             code.push_str("\x20       attributes: &mut HashMap<String, Value>,\n");
             code.push_str("\x20   ) -> ProviderResult<()> {\n");
+            let op_str = format!(
+                "{}.{}",
+                res.service_namespace
+                    .strip_prefix("com.amazonaws.")
+                    .unwrap_or(res.service_namespace),
+                snake_to_pascal_type(&sdk_method.to_snake_case()),
+            );
             code.push_str(&format!(
                 "\x20       let output = self.{}.{}().{}(identifier).send().await.map_err(|e| {{\n",
                 client_field, sdk_method, id_setter
             ));
             code.push_str(&format!(
-                "\x20           ProviderError::api_error(sdk_error_message(\"Failed to read {}\", &e))\n",
-                op_desc
+                "\x20           api_error_with_meta(\"Failed to read {}\", \"{}\", e)\n",
+                op_desc, op_str,
             ));
             code.push_str("\x20               .for_resource(id.clone())\n");
             code.push_str("\x20       })?;\n");
@@ -2230,13 +2250,20 @@ fn generate_provider_code(
             // Send API call
             code.push_str("\x20       if has_changes {\n");
             code.push_str("\x20           let config = builder.build();\n");
+            let op_str = format!(
+                "{}.{}",
+                res.service_namespace
+                    .strip_prefix("com.amazonaws.")
+                    .unwrap_or(res.service_namespace),
+                snake_to_pascal_type(&sdk_method.to_snake_case()),
+            );
             code.push_str(&format!(
                 "\x20           self.{}.{}().{}(identifier).{}(config).send().await.map_err(|e| {{\n",
                 client_field, sdk_method, id_setter, struct_setter
             ));
             code.push_str(&format!(
-                "\x20               ProviderError::api_error(sdk_error_message(\"Failed to {}\", &e))\n",
-                op_desc
+                "\x20               api_error_with_meta(\"Failed to {}\", \"{}\", e)\n",
+                op_desc, op_str,
             ));
             code.push_str("\x20                   .for_resource(id.clone())\n");
             code.push_str("\x20           })?;\n");

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -7,7 +7,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::error_helpers::api_error_with_meta;
 
 impl AwsProvider {
     /// Read an EC2 Security Group Rule (shared between ingress and egress)
@@ -28,10 +28,11 @@ impl AwsProvider {
             req = req.security_group_rule_ids(*rule_id);
         }
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message(
+            api_error_with_meta(
                 "Failed to describe security group rules",
-                &e,
-            ))
+                "ec2.DescribeSecurityGroupRules",
+                e,
+            )
             .for_resource(id.clone())
         })?;
         let rules: Vec<_> = result
@@ -221,8 +222,12 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to create ingress rule", &e))
-                        .for_resource(resource.id.clone())
+                    api_error_with_meta(
+                        "Failed to create ingress rule",
+                        "ec2.AuthorizeSecurityGroupIngress",
+                        e,
+                    )
+                    .for_resource(resource.id.clone())
                 })?;
 
             result
@@ -239,8 +244,12 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to create egress rule", &e))
-                        .for_resource(resource.id.clone())
+                    api_error_with_meta(
+                        "Failed to create egress rule",
+                        "ec2.AuthorizeSecurityGroupEgress",
+                        e,
+                    )
+                    .for_resource(resource.id.clone())
                 })?;
 
             result
@@ -294,10 +303,11 @@ impl AwsProvider {
             req = req.security_group_rule_ids(*rule_id);
         }
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message(
+            api_error_with_meta(
                 "Failed to describe security group rules",
-                &e,
-            ))
+                "ec2.DescribeSecurityGroupRules",
+                e,
+            )
             .for_resource(id.clone())
         })?;
 
@@ -322,8 +332,12 @@ impl AwsProvider {
                 request = request.security_group_rule_ids(*rule_id);
             }
             request.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete ingress rules", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to delete ingress rules",
+                    "ec2.RevokeSecurityGroupIngress",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
         } else {
             let mut request = self
@@ -334,8 +348,12 @@ impl AwsProvider {
                 request = request.security_group_rule_ids(*rule_id);
             }
             request.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete egress rules", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to delete egress rules",
+                    "ec2.RevokeSecurityGroupEgress",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
         }
 

--- a/carina-provider-aws/src/ec2_tags.rs
+++ b/carina-provider-aws/src/ec2_tags.rs
@@ -3,11 +3,11 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::ProviderResult;
 use carina_core::resource::{ConcreteValue, ResourceId, Value};
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::error_helpers::api_error_with_meta;
 
 impl AwsProvider {
     /// Extract tags from EC2 tag list into a Value::Map
@@ -77,7 +77,7 @@ impl AwsProvider {
                     req = req.tags(aws_sdk_ec2::types::Tag::builder().key(key.as_str()).build());
                 }
                 req.send().await.map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to delete tags", &e))
+                    api_error_with_meta("Failed to delete tags", "ec2.DeleteTags", e)
                         .for_resource(resource_id.clone())
                 })?;
             }
@@ -92,7 +92,7 @@ impl AwsProvider {
                     req = req.tags(tag);
                 }
                 req.send().await.map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to tag resource", &e))
+                    api_error_with_meta("Failed to tag resource", "ec2.CreateTags", e)
                         .for_resource(resource_id.clone())
                 })?;
             }

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -12,7 +12,7 @@ use carina_core::resource::{ConcreteValue, DataSource, ManagedResource, Resource
 use carina_core::utils::extract_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::error_helpers::api_error_with_meta;
 
 // ===== Generated Methods on AwsProvider =====
 
@@ -30,7 +30,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete vpc", &e))
+                api_error_with_meta("Failed to delete vpc", "ec2.DeleteVpc", e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -48,7 +48,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete subnet", &e))
+                api_error_with_meta("Failed to delete subnet", "ec2.DeleteSubnet", e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -66,7 +66,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete route table", &e))
+                api_error_with_meta("Failed to delete route table", "ec2.DeleteRouteTable", e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -84,8 +84,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete security group", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to delete security group",
+                    "ec2.DeleteSecurityGroup",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
         Ok(())
     }


### PR DESCRIPTION
sweep: migrate ec2_*/provider_generated SDK error sites + codegen template (refs #3241)

Sweep PR in the carina-rs/carina#3242 series. Migrates the SDK-operation
error sites in 3 root-level files:

* `ec2_security_group_rules.rs` (6 sites): DescribeSecurityGroupRules ×2,
  AuthorizeSecurityGroupIngress, AuthorizeSecurityGroupEgress,
  RevokeSecurityGroupIngress, RevokeSecurityGroupEgress
* `ec2_tags.rs` (2 sites): DeleteTags, CreateTags
* `provider_generated.rs` (4 sites): DeleteVpc, DeleteSubnet,
  DeleteRouteTable, DeleteSecurityGroup

## Codegen template update

`provider_generated.rs` is regenerated from `carina-codegen-aws`.
Three call-site templates updated:

1. Simple-delete method (`fn delete_<service>_<resource>`) — operation
   string `<service>.<DeleteOp>` derived from
   `service_namespace.strip_prefix("com.amazonaws.")` + `snake_to_pascal_type(delete_op)`.
2. Read method with a single SDK op (`fn read_<service>_<resource>`).
3. Update method that builds a CertificateOptions-style config struct.

Header import is also updated: `use crate::helpers::sdk_error_message`
→ `use crate::error_helpers::api_error_with_meta`.

## Verify

* `cargo nextest run` — 460 passed
* `cargo clippy -- -D warnings` — passed
* `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — passed
* `cargo fmt --check` — clean
* Codegen re-run: `scripts/generate-provider.sh` produces the migrated
  `provider_generated.rs` with no other diff.

Refs carina-rs/carina#3241
Refs carina-rs/carina#3242
