### PR TITLE
sweep: migrate ec2 + s3 SDK error sites to api_error_with_meta (closes #3241)

### DIFF
--- a/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ManagedResource, ResourceId, State};
 
 use crate::AwsProvider;
-use crate::helpers::{build_tag_specification, require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{build_tag_specification, require_string_attr};
 
 impl AwsProvider {
     /// Read an EC2 Egress-Only Internet Gateway
@@ -24,10 +25,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to describe egress-only internet gateways",
-                    &e,
-                ))
+                    "ec2.DescribeEgressOnlyInternetGateways",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -74,10 +76,11 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message(
+            api_error_with_meta(
                 "Failed to create egress-only internet gateway",
-                &e,
-            ))
+                "ec2.CreateEgressOnlyInternetGateway",
+                e,
+            )
             .for_resource(resource.id.clone())
         })?;
 
@@ -125,10 +128,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to delete egress-only internet gateway",
-                    &e,
-                ))
+                    "ec2.DeleteEgressOnlyInternetGateway",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::error_helpers::api_error_with_meta;
 
 impl AwsProvider {
     /// Read an EC2 Elastic IP
@@ -31,7 +31,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe addresses", &e))
+                api_error_with_meta("Failed to describe addresses", "ec2.DescribeAddresses", e)
                     .for_resource(id.clone())
             })?;
 
@@ -70,7 +70,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to allocate address", &e))
+            api_error_with_meta("Failed to allocate address", "ec2.AllocateAddress", e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -122,7 +122,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to release address", &e))
+                api_error_with_meta("Failed to release address", "ec2.ReleaseAddress", e)
                     .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{build_tag_specification, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::build_tag_specification;
 
 impl AwsProvider {
     /// Read an EC2 Flow Log
@@ -31,7 +32,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe flow logs", &e))
+                api_error_with_meta("Failed to describe flow logs", "ec2.DescribeFlowLogs", e)
                     .for_resource(id.clone())
             })?;
 
@@ -184,10 +185,11 @@ impl AwsProvider {
                     {
                         continue;
                     }
-                    return Err(ProviderError::api_error(sdk_error_message(
+                    return Err(api_error_with_meta(
                         "Failed to create flow logs",
-                        &e,
-                    ))
+                        "ec2.CreateFlowLogs",
+                        e,
+                    )
                     .for_resource(resource.id.clone()));
                 }
             };
@@ -268,7 +270,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete flow logs", &e))
+                api_error_with_meta("Failed to delete flow logs", "ec2.DeleteFlowLogs", e)
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/internet_gateway.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::error_helpers::api_error_with_meta;
 
 impl AwsProvider {
     /// Read an EC2 Internet Gateway
@@ -31,10 +31,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to describe internet gateways",
-                    &e,
-                ))
+                    "ec2.DescribeInternetGateways",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -83,8 +84,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to create internet gateway", &e))
-                    .for_resource(resource.id.clone())
+                api_error_with_meta(
+                    "Failed to create internet gateway",
+                    "ec2.CreateInternetGateway",
+                    e,
+                )
+                .for_resource(resource.id.clone())
             })?;
 
         let igw_id = result
@@ -108,10 +113,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to attach internet gateway",
-                        &e,
-                    ))
+                        "ec2.AttachInternetGateway",
+                        e,
+                    )
                     .for_resource(resource.id.clone())
                 })?;
         }
@@ -135,10 +141,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to describe internet gateway",
-                    &e,
-                ))
+                    "ec2.DescribeInternetGateways",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -154,10 +161,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to detach internet gateway",
-                            &e,
-                        ))
+                            "ec2.DetachInternetGateway",
+                            e,
+                        )
                         .for_resource(id.clone())
                     })?;
             }
@@ -170,8 +178,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete internet gateway", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to delete internet gateway",
+                    "ec2.DeleteInternetGateway",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         Ok(())

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -6,9 +6,9 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use aws_sdk_ec2::types::NatGatewayState;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{
-    PollState, RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message,
-    wait_for_ec2_state,
+    PollState, RetryPolicy, require_string_attr, retry_aws_operation, wait_for_ec2_state,
 };
 
 impl AwsProvider {
@@ -36,8 +36,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe NAT gateways", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to describe NAT gateways",
+                    "ec2.DescribeNatGateways",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         if let Some(ngw) = result.nat_gateways().first() {
@@ -96,7 +100,7 @@ impl AwsProvider {
         })
         .await
         .map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create NAT gateway", &e))
+            api_error_with_meta("Failed to create NAT gateway", "ec2.CreateNatGateway", e)
                 .for_resource(rid.clone())
         })?;
 
@@ -150,7 +154,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete NAT gateway", &e))
+                api_error_with_meta("Failed to delete NAT gateway", "ec2.DeleteNatGateway", e)
                     .for_resource(id.clone())
             })?;
 
@@ -177,10 +181,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to describe NAT gateway",
-                            &e,
-                        ))
+                            "ec2.DescribeNatGateways",
+                            e,
+                        )
                         .for_resource(rid.clone())
                     })?;
                 Ok(
@@ -224,10 +229,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to describe NAT gateway",
-                            &e,
-                        ))
+                            "ec2.DescribeNatGateways",
+                            e,
+                        )
                         .for_resource(rid.clone())
                     })?;
                 Ok(if let Some(ngw) = result.nat_gateways().first() {

--- a/carina-provider-aws/src/services/ec2/route.rs
+++ b/carina-provider-aws/src/services/ec2/route.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_string_attr;
 
 impl AwsProvider {
     /// Read an EC2 Route (routes are identified by route_table_id + destination)
@@ -30,8 +31,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe route table", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to describe route table",
+                    "ec2.DescribeRouteTables",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         if let Some(rt) = result.route_tables().first() {
@@ -87,7 +92,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create route", &e))
+            api_error_with_meta("Failed to create route", "ec2.CreateRoute", e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -143,7 +148,7 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to update route", &e))
+            api_error_with_meta("Failed to update route", "ec2.ReplaceRoute", e)
                 .for_resource(id.clone())
         })?;
 
@@ -174,8 +179,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete route", &e))
-                    .for_resource(id)
+                api_error_with_meta("Failed to delete route", "ec2.DeleteRoute", e).for_resource(id)
             })?;
 
         Ok(())

--- a/carina-provider-aws/src/services/ec2/route_table.rs
+++ b/carina-provider-aws/src/services/ec2/route_table.rs
@@ -5,7 +5,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_string_attr;
 
 impl AwsProvider {
     /// Read an EC2 Route Table
@@ -32,8 +33,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe route tables", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to describe route tables",
+                    "ec2.DescribeRouteTables",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         if let Some(rt) = result.route_tables().first() {
@@ -100,7 +105,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to create route table", &e))
+                api_error_with_meta("Failed to create route table", "ec2.CreateRouteTable", e)
                     .for_resource(resource.id.clone())
             })?;
 
@@ -144,11 +149,8 @@ impl AwsProvider {
                             .send()
                             .await
                             .map_err(|e| {
-                                ProviderError::api_error(sdk_error_message(
-                                    "Failed to create route",
-                                    &e,
-                                ))
-                                .for_resource(resource.id.clone())
+                                api_error_with_meta("Failed to create route", "ec2.CreateRoute", e)
+                                    .for_resource(resource.id.clone())
                             })?;
                     }
                 }

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
 
 impl AwsProvider {
     /// Read an EC2 Security Group
@@ -31,10 +32,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to describe security groups",
-                    &e,
-                ))
+                    "ec2.DescribeSecurityGroups",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -96,8 +98,12 @@ impl AwsProvider {
         })
         .await
         .map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create security group", &e))
-                .for_resource(rid.clone())
+            api_error_with_meta(
+                "Failed to create security group",
+                "ec2.CreateSecurityGroup",
+                e,
+            )
+            .for_resource(rid.clone())
         })?;
 
         let sg_id = result.group_id().ok_or_else(|| {

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -5,7 +5,8 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_string_attr;
 use aws_sdk_ec2::types::{AttributeBooleanValue, HostnameType};
 
 // `read_ec2_subnet` must store `availability_zone` as the AWS canonical
@@ -41,7 +42,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe subnets", &e))
+                api_error_with_meta("Failed to describe subnets", "ec2.DescribeSubnets", e)
                     .for_resource(id.clone())
             })?;
 
@@ -88,7 +89,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create subnet", &e))
+            api_error_with_meta("Failed to create subnet", "ec2.CreateSubnet", e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -148,10 +149,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to set map_public_ip_on_launch",
-                        &e,
-                    ))
+                        "ec2.ModifySubnetAttribute",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
         }
@@ -168,10 +170,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to set assign_ipv6_address_on_creation",
-                        &e,
-                    ))
+                        "ec2.ModifySubnetAttribute",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
         }
@@ -185,8 +188,12 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to set enable_dns64", &e))
-                        .for_resource(id.clone())
+                    api_error_with_meta(
+                        "Failed to set enable_dns64",
+                        "ec2.ModifySubnetAttribute",
+                        e,
+                    )
+                    .for_resource(id.clone())
                 })?;
         }
 
@@ -204,10 +211,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to set private_dns_name_options_on_launch.hostname_type",
-                            &e,
-                        ))
+                            "ec2.ModifySubnetAttribute",
+                            e,
+                        )
                         .for_resource(id.clone())
                     })?;
             }
@@ -223,10 +231,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_a_record",
-                            &e,
-                        ))
+                            "ec2.ModifySubnetAttribute",
+                            e,
+                        )
                         .for_resource(id.clone())
                     })?;
             }
@@ -242,10 +251,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_aaaa_record",
-                            &e,
-                        ))
+                            "ec2.ModifySubnetAttribute",
+                            e,
+                        )
                         .for_resource(id.clone())
                     })?;
             }

--- a/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_string_attr;
 
 impl AwsProvider {
     /// Read an EC2 Subnet Route Table Association
@@ -37,8 +38,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe route tables", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to describe route tables",
+                    "ec2.DescribeRouteTables",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         if let Some(rt) = result.route_tables().first() {
@@ -91,8 +96,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to associate route table", &e))
-                    .for_resource(resource.id.clone())
+                api_error_with_meta(
+                    "Failed to associate route table",
+                    "ec2.AssociateRouteTable",
+                    e,
+                )
+                .for_resource(resource.id.clone())
             })?;
 
         let assoc_id = result.association_id().ok_or_else(|| {
@@ -141,10 +150,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to replace route table association",
-                    &e,
-                ))
+                    "ec2.ReplaceRouteTableAssociation",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -181,10 +191,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to disassociate route table",
-                    &e,
-                ))
+                    "ec2.DisassociateRouteTable",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{PollState, build_tag_specification, sdk_error_message, wait_for_ec2_state};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{PollState, build_tag_specification, wait_for_ec2_state};
 
 impl AwsProvider {
     /// Read an EC2 Transit Gateway
@@ -24,10 +25,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to describe transit gateways",
-                    &e,
-                ))
+                    "ec2.DescribeTransitGateways",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -135,8 +137,12 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create transit gateway", &e))
-                .for_resource(resource.id.clone())
+            api_error_with_meta(
+                "Failed to create transit gateway",
+                "ec2.CreateTransitGateway",
+                e,
+            )
+            .for_resource(resource.id.clone())
         })?;
 
         let tgw_id = result
@@ -186,8 +192,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete transit gateway", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to delete transit gateway",
+                    "ec2.DeleteTransitGateway",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         // Wait for transit gateway to be deleted
@@ -214,10 +224,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to describe transit gateway",
-                            &e,
-                        ))
+                            "ec2.DescribeTransitGateways",
+                            e,
+                        )
                         .for_resource(rid.clone())
                     })?;
                 Ok(
@@ -258,10 +269,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to describe transit gateway",
-                            &e,
-                        ))
+                            "ec2.DescribeTransitGateways",
+                            e,
+                        )
                         .for_resource(rid.clone())
                     })?;
                 Ok(if let Some(tgw) = result.transit_gateways().first() {

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -4,9 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{
-    PollState, build_tag_specification, require_string_attr, sdk_error_message, wait_for_ec2_state,
-};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{PollState, build_tag_specification, require_string_attr, wait_for_ec2_state};
 
 impl AwsProvider {
     /// Read an EC2 Transit Gateway VPC Attachment
@@ -26,10 +25,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to describe transit gateway VPC attachments",
-                    &e,
-                ))
+                    "ec2.DescribeTransitGatewayVpcAttachments",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -107,10 +107,11 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message(
+            api_error_with_meta(
                 "Failed to create transit gateway VPC attachment",
-                &e,
-            ))
+                "ec2.CreateTransitGatewayVpcAttachment",
+                e,
+            )
             .for_resource(resource.id.clone())
         })?;
 
@@ -162,10 +163,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to delete transit gateway VPC attachment",
-                    &e,
-                ))
+                    "ec2.DeleteTransitGatewayVpcAttachment",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -193,10 +195,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to describe transit gateway VPC attachment",
-                            &e,
-                        ))
+                            "ec2.DescribeTransitGatewayVpcAttachments",
+                            e,
+                        )
                         .for_resource(rid.clone())
                     })?;
                 Ok(
@@ -237,10 +240,11 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message(
+                        api_error_with_meta(
                             "Failed to describe transit gateway VPC attachment",
-                            &e,
-                        ))
+                            "ec2.DescribeTransitGatewayVpcAttachments",
+                            e,
+                        )
                         .for_resource(rid.clone())
                     })?;
                 Ok(

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
 
 impl AwsProvider {
     /// Read an EC2 VPC
@@ -28,7 +29,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe VPCs", &e))
+                api_error_with_meta("Failed to describe VPCs", "ec2.DescribeVpcs", e)
                     .for_resource(id.clone())
             })?;
 
@@ -113,7 +114,7 @@ impl AwsProvider {
         })
         .await
         .map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create VPC", &e))
+            api_error_with_meta("Failed to create VPC", "ec2.CreateVpc", e)
                 .for_resource(rid.clone())
         })?;
 
@@ -141,7 +142,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to set DNS support", &e))
+                    api_error_with_meta("Failed to set DNS support", "ec2.ModifyVpcAttribute", e)
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -161,7 +162,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to set DNS hostnames", &e))
+                    api_error_with_meta("Failed to set DNS hostnames", "ec2.ModifyVpcAttribute", e)
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -196,7 +197,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to update DNS support", &e))
+                    api_error_with_meta("Failed to update DNS support", "ec2.ModifyVpcAttribute", e)
                         .for_resource(id.clone())
                 })?;
         }
@@ -216,10 +217,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to update DNS hostnames",
-                        &e,
-                    ))
+                        "ec2.ModifyVpcAttribute",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
 
 impl AwsProvider {
     /// Read an EC2 VPC Endpoint
@@ -24,8 +25,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe VPC endpoints", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to describe VPC endpoints",
+                    "ec2.DescribeVpcEndpoints",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         if let Some(endpoint) = result.vpc_endpoints().first() {
@@ -135,7 +140,7 @@ impl AwsProvider {
         })
         .await
         .map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create VPC endpoint", &e))
+            api_error_with_meta("Failed to create VPC endpoint", "ec2.CreateVpcEndpoint", e)
                 .for_resource(rid.clone())
         })?;
 
@@ -332,7 +337,7 @@ impl AwsProvider {
 
         if has_modifications {
             req.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to modify VPC endpoint", &e))
+                api_error_with_meta("Failed to modify VPC endpoint", "ec2.ModifyVpcEndpoint", e)
                     .for_resource(id.clone())
             })?;
         }
@@ -362,7 +367,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete VPC endpoint", &e))
+                api_error_with_meta("Failed to delete VPC endpoint", "ec2.DeleteVpcEndpoints", e)
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_string_attr;
 
 impl AwsProvider {
     /// Read an EC2 VPC Gateway Attachment
@@ -58,10 +59,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to describe internet gateways",
-                    &e,
-                ))
+                    "ec2.DescribeInternetGateways",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -109,8 +111,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe VPN gateways", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to describe VPN gateways",
+                    "ec2.DescribeVpnGateways",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         if let Some(vgw) = result.vpn_gateways().first() {
@@ -156,10 +162,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to attach internet gateway",
-                        &e,
-                    ))
+                        "ec2.AttachInternetGateway",
+                        e,
+                    )
                     .for_resource(resource.id.clone())
                 })?;
 
@@ -177,7 +184,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to attach VPN gateway", &e))
+                    api_error_with_meta("Failed to attach VPN gateway", "ec2.AttachVpnGateway", e)
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -226,10 +233,11 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message(
+                    api_error_with_meta(
                         "Failed to detach internet gateway",
-                        &e,
-                    ))
+                        "ec2.DetachInternetGateway",
+                        e,
+                    )
                     .for_resource(id.clone())
                 })?;
         } else if gateway_id.starts_with("vgw-") {
@@ -240,7 +248,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to detach VPN gateway", &e))
+                    api_error_with_meta("Failed to detach VPN gateway", "ec2.DetachVpnGateway", e)
                         .for_resource(id.clone())
                 })?;
         } else {

--- a/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{build_tag_specification, require_string_attr, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{build_tag_specification, require_string_attr};
 
 impl AwsProvider {
     /// Read an EC2 VPC Peering Connection
@@ -24,10 +25,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to describe VPC peering connections",
-                    &e,
-                ))
+                    "ec2.DescribeVpcPeeringConnections",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -100,10 +102,11 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message(
+            api_error_with_meta(
                 "Failed to create VPC peering connection",
-                &e,
-            ))
+                "ec2.CreateVpcPeeringConnection",
+                e,
+            )
             .for_resource(resource.id.clone())
         })?;
 
@@ -151,10 +154,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to delete VPC peering connection",
-                    &e,
-                ))
+                    "ec2.DeleteVpcPeeringConnection",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -4,7 +4,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::sdk_error_message;
+use crate::error_helpers::api_error_with_meta;
 
 impl AwsProvider {
     /// Read an EC2 VPN Gateway
@@ -31,8 +31,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to describe VPN gateways", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to describe VPN gateways",
+                    "ec2.DescribeVpnGateways",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         if let Some(vgw) = result.vpn_gateways().first() {
@@ -85,7 +89,7 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create VPN gateway", &e))
+            api_error_with_meta("Failed to create VPN gateway", "ec2.CreateVpnGateway", e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -135,7 +139,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to delete VPN gateway", &e))
+                api_error_with_meta("Failed to delete VPN gateway", "ec2.DeleteVpnGateway", e)
                     .for_resource(id.clone())
             })?;
         Ok(())

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -8,6 +8,7 @@ use carina_core::resource::{
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, retry_aws_operation, sdk_error_message};
 
 impl AwsProvider {
@@ -55,11 +56,12 @@ impl AwsProvider {
                         name
                     ))
                     .for_resource(id.clone())),
-                    HeadBucketErrorKind::Other => Err(ProviderError::api_error(sdk_error_message(
-                        "Failed to read bucket",
-                        &err,
-                    ))
-                    .for_resource(id.clone())),
+                    HeadBucketErrorKind::Other => {
+                        Err(
+                            api_error_with_meta("Failed to read bucket", "s3.HeadBucket", err)
+                                .for_resource(id.clone()),
+                        )
+                    }
                 }
             }
         }
@@ -114,7 +116,7 @@ impl AwsProvider {
         })
         .await
         .map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to create bucket", &e))
+            api_error_with_meta("Failed to create bucket", "s3.CreateBucket", e)
                 .for_resource(rid.clone())
         })?;
 
@@ -147,7 +149,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to delete bucket tags", &e))
+                    api_error_with_meta("Failed to delete bucket tags", "s3.DeleteBucketTagging", e)
                         .for_resource(id.clone())
                 })?;
         } else {
@@ -175,7 +177,7 @@ impl AwsProvider {
         })
         .await
         .map_err(|e| {
-            ProviderError::api_error(sdk_error_message("Failed to delete bucket", &e))
+            api_error_with_meta("Failed to delete bucket", "s3.DeleteBucket", e)
                 .for_resource(id.clone())
         })?;
         Ok(())
@@ -200,7 +202,7 @@ impl AwsProvider {
             }
 
             let response = req.send().await.map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to list object versions", &e))
+                api_error_with_meta("Failed to list object versions", "s3.ListObjectVersions", e)
                     .for_resource(id.clone())
             })?;
 
@@ -261,7 +263,7 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::api_error(sdk_error_message("Failed to delete objects", &e))
+                        api_error_with_meta("Failed to delete objects", "s3.DeleteObjects", e)
                             .for_resource(id.clone())
                     })?;
             }
@@ -308,10 +310,11 @@ impl AwsProvider {
             }
             Err(err) => {
                 if !is_s3_not_configured_error(&err, "NoSuchTagSet") {
-                    return Err(ProviderError::api_error(sdk_error_message(
+                    return Err(api_error_with_meta(
                         "Failed to read bucket tagging",
-                        &err,
-                    ))
+                        "s3.GetBucketTagging",
+                        err,
+                    )
                     .for_resource(id.clone()));
                 }
             }
@@ -354,7 +357,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to put bucket tags", &e))
+                    api_error_with_meta("Failed to put bucket tags", "s3.PutBucketTagging", e)
                         .for_resource(id.clone())
                 })?;
         }
@@ -414,11 +417,10 @@ impl AwsProvider {
                              different AWS account."
                         ))
                         .for_resource(resource.id.clone()),
-                        HeadBucketErrorKind::Other => ProviderError::api_error(sdk_error_message(
-                            "Failed to head bucket",
-                            &err,
-                        ))
-                        .for_resource(resource.id.clone()),
+                        HeadBucketErrorKind::Other => {
+                            api_error_with_meta("Failed to head bucket", "s3.HeadBucket", err)
+                                .for_resource(resource.id.clone())
+                        }
                     }
                 })?;
 
@@ -431,7 +433,7 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::api_error(sdk_error_message("Failed to get bucket location", &e))
+                    api_error_with_meta("Failed to get bucket location", "s3.GetBucketLocation", e)
                         .for_resource(resource.id.clone())
                 })?
                 .location_constraint()

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -6,7 +6,8 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 /// AWS group URIs used to identify canned-ACL grant patterns.
@@ -135,7 +136,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::api_error(sdk_error_message("Failed to get bucket ACL", &e))
+                    api_error_with_meta("Failed to get bucket ACL", "s3.GetBucketAcl", e)
                         .for_resource(id.clone()),
                 )
             }
@@ -186,7 +187,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put bucket ACL", &e))
+                api_error_with_meta("Failed to put bucket ACL", "s3.PutBucketAcl", e)
                     .for_resource(id.clone())
             })?;
 
@@ -216,11 +217,10 @@ impl AwsProvider {
         match result {
             Ok(_) => Ok(()),
             Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
-                "Failed to reset bucket ACL",
-                &e,
-            ))
-            .for_resource(id.clone())),
+            Err(e) => Err(
+                api_error_with_meta("Failed to reset bucket ACL", "s3.PutBucketAcl", e)
+                    .for_resource(id.clone()),
+            ),
         }
     }
 }

--- a/carina-provider-aws/src/services/s3/bucket_cors.rs
+++ b/carina-provider-aws/src/services/s3/bucket_cors.rs
@@ -6,6 +6,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -41,10 +42,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get bucket cors configuration",
-                    &e,
-                ))
+                    "s3.GetBucketCors",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -105,7 +107,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put bucket cors", &e))
+                api_error_with_meta("Failed to put bucket cors", "s3.PutBucketCors", e)
                     .for_resource(id.clone())
             })?;
 
@@ -136,10 +138,11 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to delete bucket cors configuration",
-                &e,
-            ))
+                "s3.DeleteBucketCors",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -9,6 +9,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -53,10 +54,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get bucket encryption",
-                    &e,
-                ))
+                    "s3.GetBucketEncryption",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -120,8 +122,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put bucket encryption", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to put bucket encryption",
+                    "s3.PutBucketEncryption",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         self.read_s3_bucket_server_side_encryption_configuration(id, Some(bucket))
@@ -156,10 +162,11 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to delete bucket encryption",
-                &e,
-            ))
+                "s3.DeleteBucketEncryption",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -11,6 +11,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -53,10 +54,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get bucket lifecycle configuration",
-                    &e,
-                ))
+                    "s3.GetBucketLifecycleConfiguration",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -120,10 +122,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to put bucket lifecycle configuration",
-                    &e,
-                ))
+                    "s3.PutBucketLifecycleConfiguration",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -160,10 +163,11 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to delete bucket lifecycle configuration",
-                &e,
-            ))
+                "s3.DeleteBucketLifecycle",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -9,6 +9,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -59,7 +60,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::api_error(sdk_error_message("Failed to get bucket logging", &e))
+                    api_error_with_meta("Failed to get bucket logging", "s3.GetBucketLogging", e)
                         .for_resource(id.clone()),
                 )
             }
@@ -125,7 +126,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put bucket logging", &e))
+                api_error_with_meta("Failed to put bucket logging", "s3.PutBucketLogging", e)
                     .for_resource(id.clone())
             })?;
 
@@ -153,11 +154,12 @@ impl AwsProvider {
         match result {
             Ok(_) => Ok(()),
             Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
-                "Failed to clear bucket logging",
-                &e,
-            ))
-            .for_resource(id.clone())),
+            Err(e) => {
+                Err(
+                    api_error_with_meta("Failed to clear bucket logging", "s3.PutBucketLogging", e)
+                        .for_resource(id.clone()),
+                )
+            }
         }
     }
 }

--- a/carina-provider-aws/src/services/s3/bucket_notification.rs
+++ b/carina-provider-aws/src/services/s3/bucket_notification.rs
@@ -10,6 +10,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -84,10 +85,11 @@ impl AwsProvider {
                 if is_s3_not_configured_error(&e, "NoSuchBucket") {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get bucket notification configuration",
-                    &e,
-                ))
+                    "s3.GetBucketNotificationConfiguration",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -171,10 +173,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to put bucket notification configuration",
-                    &e,
-                ))
+                    "s3.PutBucketNotificationConfiguration",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -207,10 +210,11 @@ impl AwsProvider {
         match result {
             Ok(_) => Ok(()),
             Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to clear bucket notification configuration",
-                &e,
-            ))
+                "s3.PutBucketNotificationConfiguration",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -5,6 +5,7 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -50,10 +51,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get bucket ownership controls",
-                    &e,
-                ))
+                    "s3.GetBucketOwnershipControls",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -118,10 +120,11 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message(
+                api_error_with_meta(
                     "Failed to put bucket ownership controls",
-                    &e,
-                ))
+                    "s3.PutBucketOwnershipControls",
+                    e,
+                )
                 .for_resource(id.clone())
             })?;
 
@@ -158,10 +161,11 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to delete bucket ownership controls",
-                &e,
-            ))
+                "s3.DeleteBucketOwnershipControls",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -4,7 +4,8 @@ use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
 use crate::services::iam::role::{iam_policy_json_to_value, resolve_iam_policy_attr};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -55,7 +56,7 @@ impl AwsProvider {
                     return Ok(State::not_found(id.clone()));
                 }
                 Err(
-                    ProviderError::api_error(sdk_error_message("Failed to get bucket policy", &e))
+                    api_error_with_meta("Failed to get bucket policy", "s3.GetBucketPolicy", e)
                         .for_resource(id.clone()),
                 )
             }
@@ -98,7 +99,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put bucket policy", &e))
+                api_error_with_meta("Failed to put bucket policy", "s3.PutBucketPolicy", e)
                     .for_resource(id.clone())
             })?;
 
@@ -136,10 +137,11 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to delete bucket policy",
-                &e,
-            ))
+                "s3.DeleteBucketPolicy",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
 use aws_sdk_s3::types::PublicAccessBlockConfiguration;
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::ProviderResult;
 use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 
 use crate::AwsProvider;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -71,10 +72,11 @@ impl AwsProvider {
                 if is_s3_not_configured_error(&e, "NoSuchPublicAccessBlockConfiguration") {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get public access block",
-                    &e,
-                ))
+                    "s3.GetPublicAccessBlock",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -136,8 +138,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put public access block", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to put public access block",
+                    "s3.PutPublicAccessBlock",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         self.read_s3_bucket_public_access_block(id, Some(bucket))
@@ -174,10 +180,11 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to delete public access block",
-                &e,
-            ))
+                "s3.DeletePublicAccessBlock",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -10,6 +10,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -58,10 +59,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get bucket replication",
-                    &e,
-                ))
+                    "s3.GetBucketReplication",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -127,8 +129,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put bucket replication", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to put bucket replication",
+                    "s3.PutBucketReplication",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         self.read_s3_bucket_replication_configuration(id, Some(bucket))
@@ -161,10 +167,11 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to delete bucket replication",
-                &e,
-            ))
+                "s3.DeleteBucketReplication",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use crate::AwsProvider;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::error_helpers::api_error_with_meta;
+use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 use aws_sdk_s3::types::{BucketVersioningStatus, MfaDelete, VersioningConfiguration};
 use carina_core::provider::{ProviderError, ProviderResult};
@@ -55,10 +56,11 @@ impl AwsProvider {
                 if is_s3_not_configured_error(&e, "NoSuchBucket") {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get bucket versioning",
-                    &e,
-                ))
+                    "s3.GetBucketVersioning",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -111,8 +113,12 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put bucket versioning", &e))
-                    .for_resource(id.clone())
+                api_error_with_meta(
+                    "Failed to put bucket versioning",
+                    "s3.PutBucketVersioning",
+                    e,
+                )
+                .for_resource(id.clone())
             })?;
 
         self.read_s3_bucket_versioning(id, Some(bucket)).await
@@ -150,10 +156,11 @@ impl AwsProvider {
         match result {
             Ok(_) => Ok(()),
             Err(e) if is_s3_not_configured_error(&e, "NoSuchBucket") => Ok(()),
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to suspend bucket versioning",
-                &e,
-            ))
+                "s3.PutBucketVersioning",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }

--- a/carina-provider-aws/src/services/s3/bucket_website.rs
+++ b/carina-provider-aws/src/services/s3/bucket_website.rs
@@ -8,6 +8,7 @@ use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, V
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
+use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
@@ -82,10 +83,11 @@ impl AwsProvider {
                 {
                     return Ok(State::not_found(id.clone()));
                 }
-                Err(ProviderError::api_error(sdk_error_message(
+                Err(api_error_with_meta(
                     "Failed to get bucket website configuration",
-                    &e,
-                ))
+                    "s3.GetBucketWebsite",
+                    e,
+                )
                 .for_resource(id.clone()))
             }
         }
@@ -194,7 +196,7 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::api_error(sdk_error_message("Failed to put bucket website", &e))
+                api_error_with_meta("Failed to put bucket website", "s3.PutBucketWebsite", e)
                     .for_resource(id.clone())
             })?;
 
@@ -227,10 +229,11 @@ impl AwsProvider {
             {
                 Ok(())
             }
-            Err(e) => Err(ProviderError::api_error(sdk_error_message(
+            Err(e) => Err(api_error_with_meta(
                 "Failed to delete bucket website",
-                &e,
-            ))
+                "s3.DeleteBucketWebsite",
+                e,
+            )
             .for_resource(id.clone())),
         }
     }


### PR DESCRIPTION
Final sweep PR in the carina-rs/carina#3242 series — migrates the
remaining 88 ec2 and 83 s3 SDK-op `sdk_error_message` call sites in
`carina-provider-aws` to the structured `api_error_with_meta` helper
introduced by carina-rs/carina-provider-aws#368.

Builder-error sites (AWS SDK type-state `.build()` calls that produce
`BuildError`, not `SdkError<E>`) keep `helpers::sdk_error_message` per
the design D5 fallback (host renderer falls through to the single-line
chain walk when no structured fields are populated).

## Scope

- **ec2**: 17 files, 88 SDK-op sites
- **s3**: 13 files, 83 SDK-op sites

Each migrated site rewrites:

```rust
ProviderError::api_error(sdk_error_message("Failed to X", &e))
    .for_resource(id.clone())
```

into the structured one-shot constructor:

```rust
api_error_with_meta("Failed to X", "service.OperationName", e)
    .for_resource(id.clone())
```

Operation strings use AWS API canonical names (`ec2.DescribeVpcs`,
`s3.HeadBucket`, etc.) so operators can grep CI logs by operation.

## What remains

Builder-error sites in `bucket.rs`, `bucket_replication.rs`,
`bucket_website.rs`, `bucket_notification.rs`, `bucket_lifecycle.rs`,
`bucket_ownership_controls.rs`, `bucket_encryption.rs`,
`bucket_cors.rs`, and `bucket_logging.rs` keep
`helpers::sdk_error_message` — they aren't `SdkError<E>` and don't
implement `ProvideErrorMetadata`. The host renderer's fallback path
(carina-rs/carina#3247, design D5) handles them correctly.

## Verify

- `cargo nextest run --workspace --all-features` — 460 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — passed

Closes carina-rs/carina#3241
Refs carina-rs/carina#3242
