### PR TITLE
deps: bump carina pin to include #3257 wasi:http tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=b38b62ed#b38b62edd497931ca9fd1c0576a32089eb77bc3b"
+source = "git+https://github.com/carina-rs/carina?rev=ed0fa554#ed0fa5549a00896a6c38d1090b68a1d19d1a2ab9"
 dependencies = [
  "argon2",
  "futures",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=b38b62ed#b38b62edd497931ca9fd1c0576a32089eb77bc3b"
+source = "git+https://github.com/carina-rs/carina?rev=ed0fa554#ed0fa5549a00896a6c38d1090b68a1d19d1a2ab9"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=b38b62ed#b38b62edd497931ca9fd1c0576a32089eb77bc3b"
+source = "git+https://github.com/carina-rs/carina?rev=ed0fa554#ed0fa5549a00896a6c38d1090b68a1d19d1a2ab9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2034,7 +2034,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2296,10 +2296,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "b38b62ed" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "ed0fa554" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "b38b62ed" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "ed0fa554" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "b38b62ed" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "b38b62ed" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "ed0fa554" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "ed0fa554" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

Bumps the carina git pin from `b38b62ed` → `ed0fa554`.

The new pin includes carina-rs/carina#3257, which adds a `CARINA_WASI_HTTP_TRACE` env-var-gated per-phase tracing seam in `carina-plugin-sdk::wasi_http`. With this bump the provider's compiled WASM contains the instrumentation, so an acceptance run with the env var set can locate which phase eats the ~60 s of S3 transport latency tracked in carina-rs/carina#3254.

No behavioural change when `CARINA_WASI_HTTP_TRACE` is unset (the default). Off-by-default cost is a single atomic load per request phase.

## Test plan

- [x] `cargo nextest run -p carina-provider-aws` — 285/285 pass
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-carina-pin.sh` — `ed0fa554 is at/after required 741f7afc`
- [x] `bash scripts/check-examples.sh` — clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — clean

refs carina-rs/carina#3254
