### PR TITLE
Bump carina pin to 83a9597b and absorb ManagedResource->Resource rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=ed0fa554#ed0fa5549a00896a6c38d1090b68a1d19d1a2ab9"
+source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
 dependencies = [
  "argon2",
  "futures",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=ed0fa554#ed0fa5549a00896a6c38d1090b68a1d19d1a2ab9"
+source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=ed0fa554#ed0fa5549a00896a6c38d1090b68a1d19d1a2ab9"
+source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
 dependencies = [
  "serde",
  "serde_json",
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2034,7 +2034,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "ed0fa554" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1881,7 +1881,7 @@ fn generate_provider_code(
          use std::collections::HashMap;\n\n\
          use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};\n\
          use carina_core::resource::{\n\
-         \x20   ConcreteValue, DataSource, ManagedResource, ResourceId, State, Value,\n\
+         \x20   ConcreteValue, DataSource, Resource, ResourceId, State, Value,\n\
          };\n\
          #[allow(unused_imports)]\n\
          use carina_core::utils::extract_enum_value;\n\n\
@@ -1964,7 +1964,7 @@ fn generate_provider_code(
                  \x20       id: ResourceId,\n\
                  \x20       identifier: &str,\n\
                  \x20       from: &State,\n\
-                 \x20       to: ManagedResource,\n\
+                 \x20       to: Resource,\n\
                  \x20   ) -> ProviderResult<State> {{\n\
                  \x20       self.apply_ec2_tags(&id, identifier, &to.resolved_attributes(), Some(&from.attributes))\n\
                  \x20           .await?;\n\
@@ -1979,7 +1979,7 @@ fn generate_provider_code(
                  \x20       &self,\n\
                  \x20       id: ResourceId,\n\
                  \x20       identifier: &str,\n\
-                 \x20       _to: ManagedResource,\n\
+                 \x20       _to: Resource,\n\
                  \x20   ) -> ProviderResult<State> {{\n\
                  \x20       self.{}(&id, Some(identifier)).await\n\
                  \x20   }}\n\n",

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "ed0fa554" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "ed0fa554" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "ed0fa554" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -8,8 +8,7 @@ use std::collections::HashMap;
 
 use carina_core::resource::{
     ConcreteValue, DataSource as CoreDataSource, DeferredValue, Directives as CoreDirectives,
-    ManagedResource as CoreResource, ResourceId as CoreResourceId, State as CoreState,
-    Value as CoreValue,
+    Resource as CoreResource, ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
@@ -158,7 +157,7 @@ pub fn proto_to_core_state(s: &ProtoState) -> CoreState {
     }
 }
 
-// -- ManagedResource --
+// -- Resource --
 
 pub fn core_to_proto_resource(r: &CoreResource) -> ProtoResource {
     ProtoResource {
@@ -360,14 +359,14 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
 
 fn proto_to_core_schema_kind(k: ProtoSchemaKind) -> CoreSchemaKind {
     match k {
-        ProtoSchemaKind::Managed => CoreSchemaKind::Managed,
+        ProtoSchemaKind::Managed => CoreSchemaKind::Resource,
         ProtoSchemaKind::DataSource => CoreSchemaKind::DataSource,
     }
 }
 
 fn core_to_proto_schema_kind(k: CoreSchemaKind) -> ProtoSchemaKind {
     match k {
-        CoreSchemaKind::Managed => ProtoSchemaKind::Managed,
+        CoreSchemaKind::Resource => ProtoSchemaKind::Managed,
         CoreSchemaKind::DataSource => ProtoSchemaKind::DataSource,
     }
 }

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
@@ -106,7 +106,7 @@ impl AwsProvider {
     /// Create an EC2 Security Group Rule (shared between ingress and egress)
     pub(crate) async fn create_ec2_security_group_rule(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
         is_ingress: bool,
     ) -> ProviderResult<State> {
         let sg_id = match resource.get_attr("group_id") {
@@ -278,7 +278,7 @@ impl AwsProvider {
         &self,
         id: ResourceId,
         identifier: &str,
-        to: ManagedResource,
+        to: Resource,
         is_ingress: bool,
     ) -> ProviderResult<State> {
         // Security group rules are immutable - delete and recreate

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -14,7 +14,7 @@ use aws_smithy_types::retry::ProvideErrorKind;
 use tokio::time::sleep;
 
 use carina_core::provider::{PatchOpKind, ProviderError, ProviderResult, UpdatePatch};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 /// Borrow a `Value` as `&str` if it is a concrete string, otherwise `None`.
 pub fn value_as_str(v: &Value) -> Option<&str> {
@@ -28,7 +28,7 @@ pub fn value_as_str(v: &Value) -> Option<&str> {
 /// Extract a required `String` attribute from a resource.
 ///
 /// Returns the string value or a `ProviderError` with `"{attr_name} is required"`.
-pub fn require_string_attr(resource: &ManagedResource, attr_name: &str) -> ProviderResult<String> {
+pub fn require_string_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
     match resource.get_attr(attr_name) {
         Some(Value::Concrete(ConcreteValue::String(s))) => Ok(s.clone()),
         _ => Err(
@@ -49,7 +49,7 @@ pub fn require_string_attr(resource: &ManagedResource, attr_name: &str) -> Provi
 /// stripped a DSL namespace prefix, but normalization now happens
 /// upstream and namespaces never reach the provider. The helper is
 /// kept so caller intent stays readable.
-pub fn require_enum_attr(resource: &ManagedResource, attr_name: &str) -> ProviderResult<String> {
+pub fn require_enum_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
     require_string_attr(resource, attr_name)
 }
 
@@ -57,7 +57,7 @@ pub fn require_enum_attr(resource: &ManagedResource, attr_name: &str) -> Provide
 ///
 /// Returns `None` if the resource has no `tags` attribute.
 pub fn build_tag_specification(
-    resource: &ManagedResource,
+    resource: &Resource,
     resource_type: ResourceType,
 ) -> Option<TagSpecification> {
     if let Some(Value::Concrete(ConcreteValue::Map(tags))) = resource.get_attr("tags") {
@@ -253,12 +253,12 @@ where
     }
 }
 
-/// Reconstruct a `ManagedResource` from `from` state plus an `UpdatePatch`.
+/// Reconstruct a `Resource` from `from` state plus an `UpdatePatch`.
 ///
 /// The aws provider's existing per-resource `update_*` methods take
-/// `to: ManagedResource` (a full desired state). The Level 3 `Provider::update`
+/// `to: Resource` (a full desired state). The Level 3 `Provider::update`
 /// signature replaces `to` with `(from: State, patch: UpdatePatch)`, so
-/// this adapter rebuilds an equivalent desired `ManagedResource` by applying
+/// this adapter rebuilds an equivalent desired `Resource` by applying
 /// each [`PatchOpKind`] on top of `from`'s attributes:
 ///
 /// - `Add` / `Replace` set the attribute to the patch value.
@@ -269,12 +269,11 @@ where
 /// style. Per-resource update methods continue to write the same fields
 /// they always did.
 ///
-/// The returned `ManagedResource` carries `from`'s `ResourceId` and an empty
+/// The returned `Resource` carries `from`'s `ResourceId` and an empty
 /// `Directives` (directives are delete-only and are not consulted on
 /// update paths in this provider).
-pub fn apply_patch_to_state(from: &State, patch: &UpdatePatch) -> ManagedResource {
-    let mut resource =
-        ManagedResource::new(from.id.resource_type.clone(), from.id.name.to_string());
+pub fn apply_patch_to_state(from: &State, patch: &UpdatePatch) -> Resource {
+    let mut resource = Resource::new(from.id.resource_type.clone(), from.id.name.to_string());
     resource.id = from.id.clone();
     resource.attributes = from
         .attributes
@@ -334,8 +333,8 @@ where
 mod tests {
     use super::*;
 
-    fn make_test_resource(attrs: Vec<(&str, &str)>) -> ManagedResource {
-        let mut resource = ManagedResource::new("route53.RecordSet", "test");
+    fn make_test_resource(attrs: Vec<(&str, &str)>) -> Resource {
+        let mut resource = Resource::new("route53.RecordSet", "test");
         for (k, v) in attrs {
             resource.attributes.insert(
                 k.to_string(),

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use indexmap::IndexMap;
 
 use carina_core::provider::{self, BoxFuture, ProviderNormalizer, SavedAttrs, ready_noop};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::{AttributeType, SchemaRegistry};
 
 /// Schema extension for the AWS provider.
@@ -14,7 +14,7 @@ use carina_core::schema::{AttributeType, SchemaRegistry};
 pub struct AwsNormalizer;
 
 impl ProviderNormalizer for AwsNormalizer {
-    fn normalize_desired<'a>(&'a self, resources: &'a mut [ManagedResource]) -> BoxFuture<'a, ()> {
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
         // Bodies are pure (enum resolution, dns-name strip — no I/O);
         // the trait is async only so the WASM host impl can `.await`
         // the guest directly (carina#3112). Wrapping the existing sync
@@ -42,7 +42,7 @@ impl ProviderNormalizer for AwsNormalizer {
 
     fn merge_default_tags<'a>(
         &'a self,
-        resources: &'a mut [ManagedResource],
+        resources: &'a mut [Resource],
         default_tags: &'a IndexMap<String, Value>,
         registry: &'a SchemaRegistry,
     ) -> BoxFuture<'a, ()> {
@@ -72,7 +72,7 @@ impl ProviderNormalizer for AwsNormalizer {
 ///
 /// The recursion is the contract: every enum value reaching the
 /// provider is API-canonical no matter how deeply it is nested.
-pub(crate) fn resolve_enum_identifiers(resources: &mut [ManagedResource]) {
+pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
     let configs = crate::schemas::generated::configs();
 
     for resource in resources.iter_mut() {
@@ -348,8 +348,7 @@ mod tests {
     // (e.g. `"aws.s3.BucketVersioning.VersioningStatus.enabled"`).
     #[test]
     fn test_resolve_enum_identifiers_namespaced_value() {
-        let mut resource =
-            ManagedResource::with_provider("aws", "s3.BucketVersioning", "test", None);
+        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -368,8 +367,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource =
-            ManagedResource::with_provider("aws", "s3.BucketVersioning", "test", None);
+        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
@@ -387,7 +385,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
         let mut resource =
-            ManagedResource::with_provider("aws", "s3.BucketOwnershipControls", "test", None);
+            Resource::with_provider("aws", "s3.BucketOwnershipControls", "test", None);
         resource.set_attr(
             "object_ownership".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -406,8 +404,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_plain_string() {
-        let mut resource =
-            ManagedResource::with_provider("aws", "s3.BucketVersioning", "test", None);
+        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
@@ -424,8 +421,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_aws() {
-        let mut resource =
-            ManagedResource::with_provider("awscc", "s3.BucketVersioning", "test", None);
+        let mut resource = Resource::with_provider("awscc", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
@@ -449,7 +445,7 @@ mod tests {
         // API-canonical; pass-1 only namespaces it, pass-2 strips the
         // namespace and canonicalizes via api_for).
         let mut resource =
-            ManagedResource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule", None);
+            Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("-1".to_string())),
@@ -553,8 +549,7 @@ mod tests {
         // canonicalized to AWS API spelling `Enabled` before reaching
         // the provider's SDK::from() call. Without this, the SDK wraps
         // the unknown value and S3 returns MalformedXML.
-        let mut resource =
-            ManagedResource::with_provider("aws", "s3.BucketVersioning", "test", None);
+        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
         resource.set_attr(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -577,7 +572,7 @@ mod tests {
         // in BucketLogging) must be canonicalized through the recursion,
         // not just the top-level attribute.
         use indexmap::IndexMap;
-        let mut resource = ManagedResource::with_provider("aws", "s3.BucketLogging", "test", None);
+        let mut resource = Resource::with_provider("aws", "s3.BucketLogging", "test", None);
         let mut pp = IndexMap::new();
         pp.insert(
             "partition_date_source".to_string(),
@@ -649,7 +644,7 @@ mod tests {
             )])),
         );
 
-        let mut resource = ManagedResource::with_provider("aws", "iam.Role", "test-role", None);
+        let mut resource = Resource::with_provider("aws", "iam.Role", "test-role", None);
         resource.set_attr(
             "assume_role_policy_document".to_string(),
             Value::Concrete(ConcreteValue::Map(policy)),
@@ -692,7 +687,7 @@ mod tests {
         // descends into the struct and rewrites via `DslMap::api_for`.
         use indexmap::IndexMap;
         let mut resource =
-            ManagedResource::with_provider("aws", "route53.RecordSet", "test-cf-alias", None);
+            Resource::with_provider("aws", "route53.RecordSet", "test-cf-alias", None);
         let mut alias_target = IndexMap::new();
         alias_target.insert(
             "dns_name".to_string(),
@@ -734,8 +729,7 @@ mod tests {
     fn test_resolve_enum_identifiers_cloudfront_hosted_zone_id_input_shapes() {
         use indexmap::IndexMap;
         let make_resource = |hzid: &str| {
-            let mut resource =
-                ManagedResource::with_provider("aws", "route53.RecordSet", "test", None);
+            let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test", None);
             let mut at = IndexMap::new();
             at.insert(
                 "dns_name".to_string(),
@@ -808,7 +802,7 @@ mod tests {
         // own Route 53 zone (plain String in the schema) — a literal
         // hosted-zone ID like `Z1XYZABC123` must NOT be rewritten.
         let mut resource =
-            ManagedResource::with_provider("aws", "route53.RecordSet", "test-toplevel", None);
+            Resource::with_provider("aws", "route53.RecordSet", "test-toplevel", None);
         resource.set_attr(
             "hosted_zone_id".to_string(),
             Value::Concrete(ConcreteValue::String("Z1XYZABC123".to_string())),
@@ -825,7 +819,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ec2_vpc_instance_tenancy() {
-        let mut resource = ManagedResource::with_provider("aws", "ec2.Vpc", "test-vpc", None);
+        let mut resource = Resource::with_provider("aws", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -845,7 +839,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ec2_security_group_ingress_protocol() {
         let mut resource =
-            ManagedResource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule", None);
+            Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("IpProtocol.tcp".to_string())),
@@ -965,8 +959,7 @@ mod tests {
         // .resource_record.name`), the AWS API returns the FQDN with a
         // trailing dot. AwsNormalizer::normalize_desired must strip it so
         // the diff against the dot-stripped state row is stable.
-        let mut resource =
-            ManagedResource::with_provider("aws", "route53.RecordSet", "test-rec", None);
+        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-rec", None);
         resource.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String("_abc.example.com.".to_string())),
@@ -1042,7 +1035,7 @@ mod tests {
             )])),
         );
 
-        let mut resource = ManagedResource::with_provider("aws", "iam.Role", "test-role", None);
+        let mut resource = Resource::with_provider("aws", "iam.Role", "test-role", None);
         resource.set_attr(
             "assume_role_policy_document".to_string(),
             Value::Concrete(ConcreteValue::Map(policy)),
@@ -1124,7 +1117,7 @@ mod tests {
                 )])),
             );
 
-            let mut resource = ManagedResource::with_provider("aws", "iam.Role", "test-role", None);
+            let mut resource = Resource::with_provider("aws", "iam.Role", "test-role", None);
             resource.set_attr(
                 "assume_role_policy_document".to_string(),
                 Value::Concrete(ConcreteValue::Map(policy)),

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -265,7 +265,7 @@ impl Provider for AwsProvider {
         let identifier = identifier.to_string();
         let from = request.from.clone();
         // The aws provider's per-resource `update_*` methods predate the
-        // Level 3 patch contract and accept a full `to: ManagedResource`.
+        // Level 3 patch contract and accept a full `to: Resource`.
         // Reconstruct that from `(from, patch)` here so each method's
         // existing logic continues to work without per-resource churn.
         // Future per-resource updates can read `request.patch` directly

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, DataSource, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, DataSource, Resource, ResourceId, State, Value};
 #[allow(unused_imports)]
 use carina_core::utils::extract_enum_value;
 
@@ -100,7 +100,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,
@@ -118,7 +118,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,
@@ -136,7 +136,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,
@@ -153,7 +153,7 @@ impl AwsProvider {
         &self,
         id: ResourceId,
         identifier: &str,
-        _to: ManagedResource,
+        _to: Resource,
     ) -> ProviderResult<State> {
         self.read_organizations_organization(&id, Some(identifier))
             .await

--- a/carina-provider-aws/src/schemas/mod.rs
+++ b/carina-provider-aws/src/schemas/mod.rs
@@ -19,7 +19,7 @@ mod tests {
         let configs = super::generated::configs();
         let managed = configs
             .iter()
-            .find(|c| c.resource_type_name == "s3.Bucket" && c.schema.kind == SchemaKind::Managed);
+            .find(|c| c.resource_type_name == "s3.Bucket" && c.schema.kind == SchemaKind::Resource);
         let data_source = configs.iter().find(|c| {
             c.resource_type_name == "s3.Bucket" && c.schema.kind == SchemaKind::DataSource
         });

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -16,7 +16,7 @@ use aws_sdk_acm::types::ValidationMethod;
 use indexmap::IndexMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -239,10 +239,7 @@ impl AwsProvider {
     /// the validation status is `PENDING_VALIDATION` until the user
     /// satisfies the DNS / EMAIL challenge — typically wired via a
     /// `wait` construct on `cert.status`.
-    pub(crate) async fn create_acm_certificate(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_acm_certificate(&self, resource: Resource) -> ProviderResult<State> {
         let id = resource.id.clone();
         let domain_name = require_string_attr(&resource, "domain_name")?;
 
@@ -435,7 +432,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         if let Some(pref) = to
             .get_attr("certificate_transparency_logging_preference")
@@ -474,7 +471,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         arn: &str,
-        to: &ManagedResource,
+        to: &Resource,
         from: &State,
     ) -> ProviderResult<()> {
         let empty = IndexMap::new();

--- a/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ManagedResource, ResourceId, State};
+use carina_core::resource::{Resource, ResourceId, State};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -58,7 +58,7 @@ impl AwsProvider {
     /// Create an EC2 Egress-Only Internet Gateway
     pub(crate) async fn create_ec2_egress_only_internet_gateway(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
 
@@ -103,7 +103,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -58,7 +58,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Elastic IP
-    pub(crate) async fn create_ec2_eip(&self, resource: ManagedResource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_eip(&self, resource: Resource) -> ProviderResult<State> {
         let mut req = self.ec2_client.allocate_address();
 
         if let Some(Value::Concrete(ConcreteValue::String(domain))) = resource.get_attr("domain") {
@@ -98,7 +98,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -74,10 +74,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Flow Log
-    pub(crate) async fn create_ec2_flow_log(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_flow_log(&self, resource: Resource) -> ProviderResult<State> {
         let resource_ids_val: Vec<String> = match resource.get_attr("resource_ids") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
@@ -245,7 +242,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,

--- a/carina-provider-aws/src/services/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/internet_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -75,7 +75,7 @@ impl AwsProvider {
     /// Create an EC2 Internet Gateway
     pub(crate) async fn create_ec2_internet_gateway(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         // Create Internet Gateway
         let result = self

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use aws_sdk_ec2::types::NatGatewayState;
 
@@ -72,10 +72,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 NAT Gateway
-    pub(crate) async fn create_ec2_nat_gateway(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_nat_gateway(&self, resource: Resource) -> ProviderResult<State> {
         let subnet_id = require_string_attr(&resource, "subnet_id")?;
 
         let mut req = self.ec2_client.create_nat_gateway().subnet_id(&subnet_id);
@@ -130,7 +127,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,

--- a/carina-provider-aws/src/services/ec2/route.rs
+++ b/carina-provider-aws/src/services/ec2/route.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -65,10 +65,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Route
-    pub(crate) async fn create_ec2_route(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_route(&self, resource: Resource) -> ProviderResult<State> {
         let route_table_id = require_string_attr(&resource, "route_table_id")?;
         let destination_cidr = require_string_attr(&resource, "destination_cidr_block")?;
 
@@ -109,7 +106,7 @@ impl AwsProvider {
         &self,
         id: ResourceId,
         _identifier: &str,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         let route_table_id = match to.get_attr("route_table_id") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),

--- a/carina-provider-aws/src/services/ec2/route_table.rs
+++ b/carina-provider-aws/src/services/ec2/route_table.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -91,10 +91,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Route Table
-    pub(crate) async fn create_ec2_route_table(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_route_table(&self, resource: Resource) -> ProviderResult<State> {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
 
         // Create Route Table

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -65,7 +65,7 @@ impl AwsProvider {
     /// Create an EC2 Security Group
     pub(crate) async fn create_ec2_security_group(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
 

--- a/carina-provider-aws/src/services/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/services/ec2/security_group_egress.rs
@@ -1,5 +1,5 @@
 use carina_core::provider::ProviderResult;
-use carina_core::resource::{ManagedResource, ResourceId, State};
+use carina_core::resource::{Resource, ResourceId, State};
 
 use crate::AwsProvider;
 
@@ -17,7 +17,7 @@ impl AwsProvider {
     /// Create an EC2 Security Group Egress Rule
     pub(crate) async fn create_ec2_security_group_egress(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         self.create_ec2_security_group_rule(resource, false).await
     }
@@ -27,7 +27,7 @@ impl AwsProvider {
         &self,
         id: ResourceId,
         identifier: &str,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.update_ec2_security_group_rule(id, identifier, to, false)
             .await

--- a/carina-provider-aws/src/services/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/services/ec2/security_group_ingress.rs
@@ -1,5 +1,5 @@
 use carina_core::provider::ProviderResult;
-use carina_core::resource::{ManagedResource, ResourceId, State};
+use carina_core::resource::{Resource, ResourceId, State};
 
 use crate::AwsProvider;
 
@@ -17,7 +17,7 @@ impl AwsProvider {
     /// Create an EC2 Security Group Ingress Rule
     pub(crate) async fn create_ec2_security_group_ingress(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         self.create_ec2_security_group_rule(resource, true).await
     }
@@ -27,7 +27,7 @@ impl AwsProvider {
         &self,
         id: ResourceId,
         identifier: &str,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.update_ec2_security_group_rule(id, identifier, to, true)
             .await

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
@@ -69,10 +69,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Subnet
-    pub(crate) async fn create_ec2_subnet(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_subnet(&self, resource: Resource) -> ProviderResult<State> {
         let cidr_block = require_string_attr(&resource, "cidr_block")?;
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
 
@@ -117,7 +114,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         // Apply subnet attributes that require ModifySubnetAttribute
         let attrs = to.resolved_attributes();

--- a/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -83,7 +83,7 @@ impl AwsProvider {
     /// Create an EC2 Subnet Route Table Association
     pub(crate) async fn create_ec2_subnet_route_table_association(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let route_table_id = require_string_attr(&resource, "route_table_id")?;
         let subnet_id = require_string_attr(&resource, "subnet_id")?;
@@ -122,7 +122,7 @@ impl AwsProvider {
         &self,
         id: ResourceId,
         identifier: &str,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         // Parse composite identifier: association_id|subnet_id
         let Some((association_id, subnet_id)) = identifier.split_once('|') else {

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -63,7 +63,7 @@ impl AwsProvider {
     /// Create an EC2 Transit Gateway
     pub(crate) async fn create_ec2_transit_gateway(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let mut req = self.ec2_client.create_transit_gateway();
 
@@ -168,7 +168,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -63,7 +63,7 @@ impl AwsProvider {
     /// Create an EC2 Transit Gateway VPC Attachment
     pub(crate) async fn create_ec2_transit_gateway_attachment(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let transit_gateway_id = require_string_attr(&resource, "transit_gateway_id")?;
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
@@ -138,7 +138,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -89,7 +89,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 VPC
-    pub(crate) async fn create_ec2_vpc(&self, resource: ManagedResource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_vpc(&self, resource: Resource) -> ProviderResult<State> {
         let cidr_block = require_string_attr(&resource, "cidr_block")?;
 
         // Create VPC with optional instance_tenancy
@@ -177,7 +177,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         // identifier is the VPC ID (e.g., vpc-12345678)
         let vpc_id = identifier.to_string();

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -63,7 +63,7 @@ impl AwsProvider {
     /// Create an EC2 VPC Endpoint
     pub(crate) async fn create_ec2_vpc_endpoint(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
         let service_name = require_string_attr(&resource, "service_name")?;
@@ -172,7 +172,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         let mut req = self
             .ec2_client

--- a/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -147,7 +147,7 @@ impl AwsProvider {
     /// Create an EC2 VPC Gateway Attachment
     pub(crate) async fn create_ec2_vpc_gateway_attachment(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
 

--- a/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -70,7 +70,7 @@ impl AwsProvider {
     /// Create an EC2 VPC Peering Connection
     pub(crate) async fn create_ec2_vpc_peering_connection(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let vpc_id = require_string_attr(&resource, "vpc_id")?;
         let peer_vpc_id = require_string_attr(&resource, "peer_vpc_id")?;
@@ -129,7 +129,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -66,10 +66,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 VPN Gateway
-    pub(crate) async fn create_ec2_vpn_gateway(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_vpn_gateway(&self, resource: Resource) -> ProviderResult<State> {
         let gw_type = match resource.get_attr("type") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {
@@ -115,7 +112,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.apply_ec2_tags(
             &id,

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -79,7 +79,7 @@ impl AwsProvider {
     }
 
     /// Create an IAM Role
-    pub(crate) async fn create_iam_role(&self, resource: ManagedResource) -> ProviderResult<State> {
+    pub(crate) async fn create_iam_role(&self, resource: Resource) -> ProviderResult<State> {
         let role_name = require_string_attr(&resource, "role_name")?;
 
         let assume_role_policy_document =
@@ -137,7 +137,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         // Update assume role policy document
         if to.get_attr("assume_role_policy_document").is_some() {
@@ -360,7 +360,7 @@ impl AwsProvider {
 /// `version` → `Version`, `statement` → `Statement`) and condition
 /// operators (e.g. `bool` → `Bool`, `string_equals` → `StringEquals`)
 /// are case-converted. Condition variable keys (`aws:SecureTransport`,
-/// `s3:prefix`, ...), ARN values, and Action / ManagedResource literals are
+/// `s3:prefix`, ...), ARN values, and Action / Resource literals are
 /// passed through verbatim. A blanket `snake_to_pascal` would mangle
 /// them (e.g. `aws:SecureTransport` → `Aws:SecureTransport`), which
 /// AWS treats as an unknown — and therefore unenforced — condition.
@@ -371,15 +371,12 @@ pub fn value_to_iam_policy_json(value: &Value) -> Result<String, String> {
 }
 
 /// Resolve an IAM-style policy attribute (e.g. `assume_role_policy_document`,
-/// `policy`) on a `ManagedResource` into a JSON string suitable for the AWS API.
+/// `policy`) on a `Resource` into a JSON string suitable for the AWS API.
 ///
 /// Accepts either a pre-serialized JSON string or a Carina `Value::Map`
 /// (block-syntax DSL form). Errors when the attribute is missing or has an
 /// unsupported type.
-pub fn resolve_iam_policy_attr(
-    resource: &ManagedResource,
-    attr_name: &str,
-) -> ProviderResult<String> {
+pub fn resolve_iam_policy_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
     match resource.get_attr(attr_name) {
         Some(Value::Concrete(ConcreteValue::String(s))) => Ok(s.clone()),
         Some(value @ Value::Concrete(ConcreteValue::Map(_))) => value_to_iam_policy_json(value)
@@ -614,7 +611,7 @@ fn scalar_to_json(value: &Value) -> serde_json::Value {
 ///
 /// Mirrors `value_to_iam_policy_json`'s position-aware case conversion:
 /// only IAM standard fields and condition operators are mapped to
-/// snake_case; condition variable keys, ARN values, and Action / ManagedResource
+/// snake_case; condition variable keys, ARN values, and Action / Resource
 /// literals are preserved verbatim.
 pub fn iam_policy_json_to_value(json_str: &str) -> Result<Value, String> {
     let json: serde_json::Value =
@@ -674,7 +671,7 @@ fn json_to_policy_statement(json: &serde_json::Value) -> Value {
             // spelling-agnostic `StringEnum` arm reconcile it against
             // the parsed-desired alias side (aws#326). No special arm
             // needed.
-            // `Action` / `ManagedResource` are `Map<String, StringOrList>`
+            // `Action` / `Resource` are `Map<String, StringOrList>`
             // — AWS may return a scalar (`"sts:AssumeRole"`) or a list.
             // The DSL schema accepts both, but to avoid post-apply
             // plan-verify churn we normalize scalars to a single-element
@@ -802,8 +799,8 @@ mod tests {
     use super::*;
     use indexmap::IndexMap;
 
-    fn make_resource(policy: Option<Value>) -> ManagedResource {
-        let mut r = ManagedResource::new("test.Type", "test");
+    fn make_resource(policy: Option<Value>) -> Resource {
+        let mut r = Resource::new("test.Type", "test");
         if let Some(v) = policy {
             r.set_attr("policy", v);
         }

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::ProviderResult;
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -112,10 +112,7 @@ impl AwsProvider {
     }
 
     /// Create a CloudWatch Logs Log Group
-    pub(crate) async fn create_logs_log_group(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_logs_log_group(&self, resource: Resource) -> ProviderResult<State> {
         let log_group_name = require_string_attr(&resource, "log_group_name")?;
 
         let mut req = self
@@ -181,7 +178,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         // Update retention
         match to.get_attr("retention_in_days") {

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -160,7 +160,7 @@ impl AwsProvider {
     /// Create an Organizations account
     pub(crate) async fn create_organizations_account(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let name = require_string_attr(&resource, "account_name")?;
         let email = require_string_attr(&resource, "email")?;
@@ -332,7 +332,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         // Handle parent_id change via MoveAccount
         let desired_parent = to.get_attr("parent_id").and_then(|v| match v {

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -106,7 +106,7 @@ impl AwsProvider {
     /// Create an Organizations organization
     pub(crate) async fn create_organizations_organization(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let mut req = self.organizations_client.create_organization();
 

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -11,7 +11,7 @@ use aws_sdk_route53::types::{
 };
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -151,7 +151,7 @@ fn build_alias_target_from_map(
 }
 
 /// Build an AWS SDK ResourceRecordSet from carina resource attributes.
-fn build_record_set(resource: &ManagedResource) -> ProviderResult<ResourceRecordSet> {
+fn build_record_set(resource: &Resource) -> ProviderResult<ResourceRecordSet> {
     let name = require_string_attr(resource, "name")?;
     let record_type = require_enum_attr(resource, "type")?;
 
@@ -356,7 +356,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_route53_record_set(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let hosted_zone_id = require_string_attr(&resource, "hosted_zone_id")?;
         let name = require_string_attr(&resource, "name")?;
@@ -381,7 +381,7 @@ impl AwsProvider {
         &self,
         id: ResourceId,
         _identifier: &str,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         let hosted_zone_id = require_string_attr(&to, "hosted_zone_id")?;
         let name = require_string_attr(&to, "name")?;
@@ -474,7 +474,7 @@ impl AwsProvider {
 /// the apply would just re-UPSERT the same DNS name.
 ///
 /// See aws#300, follow-up to aws#117.
-pub(crate) fn normalize_record_set_dns_names(resources: &mut [ManagedResource]) {
+pub(crate) fn normalize_record_set_dns_names(resources: &mut [Resource]) {
     for resource in resources.iter_mut() {
         if resource.id.provider != "aws" || resource.id.resource_type != "route53.RecordSet" {
             continue;
@@ -509,10 +509,10 @@ pub(crate) fn normalize_record_set_dns_names(resources: &mut [ManagedResource]) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use carina_core::resource::ManagedResource;
+    use carina_core::resource::Resource;
 
-    fn record_set(name: &str) -> ManagedResource {
-        let mut r = ManagedResource::with_provider("aws", "route53.RecordSet", "test-rec", None);
+    fn record_set(name: &str) -> Resource {
+        let mut r = Resource::with_provider("aws", "route53.RecordSet", "test-rec", None);
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String(name.to_string())),
@@ -582,7 +582,7 @@ mod tests {
 
     #[test]
     fn ignores_non_route53_record_set_resources() {
-        let mut r = ManagedResource::with_provider("aws", "s3.Bucket", "test", None);
+        let mut r = Resource::with_provider("aws", "s3.Bucket", "test", None);
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -601,7 +601,7 @@ mod tests {
 
     #[test]
     fn ignores_non_aws_provider() {
-        let mut r = ManagedResource::with_provider("awscc", "route53.RecordSet", "test", None);
+        let mut r = Resource::with_provider("awscc", "route53.RecordSet", "test", None);
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String("foo.example.com.".to_string())),

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{
-    ConcreteValue, DataSource, Directives, ManagedResource, ResourceId, State, Value,
+    ConcreteValue, DataSource, Directives, Resource, ResourceId, State, Value,
 };
 use carina_core::utils::convert_enum_value;
 
@@ -68,10 +68,7 @@ impl AwsProvider {
     }
 
     /// Create an S3 bucket
-    pub(crate) async fn create_s3_bucket(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_s3_bucket(&self, resource: Resource) -> ProviderResult<State> {
         let bucket_name = match resource.get_attr("bucket") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {
@@ -135,7 +132,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         let bucket_name = identifier.to_string();
 

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::{BucketCannedAcl, Grant, Permission, Type as GranteeType};
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
@@ -143,10 +143,7 @@ impl AwsProvider {
         }
     }
 
-    pub(crate) async fn create_s3_bucket_acl(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_s3_bucket_acl(&self, resource: Resource) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_acl(&resource.id, &bucket, &resource)
             .await
@@ -157,7 +154,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_acl(&id, identifier, &to).await
     }
@@ -166,7 +163,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let acl_str = match resource.get_attr("acl") {
             // convert_enum_value normalizes namespaced/typed identifiers

--- a/carina-provider-aws/src/services/s3/bucket_cors.rs
+++ b/carina-provider-aws/src/services/s3/bucket_cors.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::{CorsConfiguration, CorsRule};
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -54,7 +54,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_cors_configuration(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_cors(&resource.id, &bucket, &resource)
@@ -66,7 +66,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_cors(&id, identifier, &to).await
     }
@@ -75,7 +75,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let rules = match resource.get_attr("cors_rules") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items,

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -5,7 +5,7 @@ use aws_sdk_s3::types::{
     ServerSideEncryptionRule,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -66,7 +66,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_server_side_encryption_configuration(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_encryption(&resource.id, &bucket, &resource)
@@ -78,7 +78,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_encryption(&id, identifier, &to).await
     }
@@ -87,7 +87,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let rules = match resource.get_attr("rules") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items,

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -7,7 +7,7 @@ use aws_sdk_s3::types::{
     TransitionStorageClass,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -66,7 +66,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_lifecycle_configuration(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_lifecycle(&resource.id, &bucket, &resource)
@@ -78,7 +78,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_lifecycle(&id, identifier, &to).await
     }
@@ -87,7 +87,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let rules = match resource.get_attr("rules") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items,

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -5,7 +5,7 @@ use aws_sdk_s3::types::{
     TargetObjectKeyFormat,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -69,7 +69,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_logging(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_logging(&resource.id, &bucket, &resource)
@@ -81,7 +81,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_logging(&id, identifier, &to).await
     }
@@ -90,7 +90,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let target_bucket = require_string_attr(resource, "target_bucket")?;
         let target_prefix = match resource.get_attr("target_prefix") {

--- a/carina-provider-aws/src/services/s3/bucket_notification.rs
+++ b/carina-provider-aws/src/services/s3/bucket_notification.rs
@@ -6,7 +6,7 @@ use aws_sdk_s3::types::{
     TopicConfiguration,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -97,7 +97,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_notification_configuration(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_notification(&resource.id, &bucket, &resource)
@@ -109,7 +109,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_notification(&id, identifier, &to).await
     }
@@ -118,7 +118,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let topics = match resource.get_attr("topic_configurations") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::{ObjectOwnership, OwnershipControls, OwnershipControlsRule};
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -63,7 +63,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_ownership_controls(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_ownership_controls(&resource.id, &bucket, &resource)
@@ -75,7 +75,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_ownership_controls(&id, identifier, &to)
             .await
@@ -85,7 +85,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let ownership_str = match resource.get_attr("object_ownership") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -66,7 +66,7 @@ impl AwsProvider {
     /// Create an S3 BucketPolicy via PutBucketPolicy.
     pub(crate) async fn create_s3_bucket_policy(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_policy(&resource.id, &bucket, &resource)
@@ -79,7 +79,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_policy(&id, identifier, &to).await
     }
@@ -88,7 +88,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let policy_json = resolve_iam_policy_attr(resource, "policy")?;
 

--- a/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use aws_sdk_s3::types::PublicAccessBlockConfiguration;
 use carina_core::provider::ProviderResult;
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -84,7 +84,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_public_access_block(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_public_access_block(&resource.id, &bucket, &resource)
@@ -96,7 +96,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_public_access_block(&id, identifier, &to)
             .await
@@ -106,7 +106,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let mut builder = PublicAccessBlockConfiguration::builder();
         if let Some(Value::Concrete(ConcreteValue::Bool(v))) =

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -6,7 +6,7 @@ use aws_sdk_s3::types::{
     StorageClass, Tag,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -71,7 +71,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_replication_configuration(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_replication(&resource.id, &bucket, &resource)
@@ -83,7 +83,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_replication(&id, identifier, &to).await
     }
@@ -92,7 +92,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let role = require_string_attr(resource, "role")?;
         let rules = match resource.get_attr("rules") {

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -6,7 +6,7 @@ use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 use aws_sdk_s3::types::{BucketVersioningStatus, MfaDelete, VersioningConfiguration};
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 impl AwsProvider {
     /// Read an S3 BucketVersioning.
@@ -68,7 +68,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_versioning(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_versioning(&resource.id, &bucket, &resource)
@@ -80,7 +80,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_versioning(&id, identifier, &to).await
     }
@@ -89,7 +89,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let status_str = match resource.get_attr("status") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),

--- a/carina-provider-aws/src/services/s3/bucket_website.rs
+++ b/carina-provider-aws/src/services/s3/bucket_website.rs
@@ -4,7 +4,7 @@ use aws_sdk_s3::types::{
     ErrorDocument, IndexDocument, Protocol, RedirectAllRequestsTo, WebsiteConfiguration,
 };
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
@@ -95,7 +95,7 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_website_configuration(
         &self,
-        resource: ManagedResource,
+        resource: Resource,
     ) -> ProviderResult<State> {
         let bucket = require_string_attr(&resource, "bucket")?;
         self.put_s3_bucket_website(&resource.id, &bucket, &resource)
@@ -107,7 +107,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         _from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         self.put_s3_bucket_website(&id, identifier, &to).await
     }
@@ -116,7 +116,7 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         bucket: &str,
-        resource: &ManagedResource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let mut config_builder = WebsiteConfiguration::builder();
 

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -12,7 +12,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -467,10 +467,7 @@ impl AwsProvider {
     }
 
     /// Create an SQS Queue and return its post-create state.
-    pub(crate) async fn create_sqs_queue(
-        &self,
-        resource: ManagedResource,
-    ) -> ProviderResult<State> {
+    pub(crate) async fn create_sqs_queue(&self, resource: Resource) -> ProviderResult<State> {
         let queue_name = require_string_attr(&resource, "queue_name")?;
 
         // Pack every writable attribute the user actually set.
@@ -515,7 +512,7 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: ManagedResource,
+        to: Resource,
     ) -> ProviderResult<State> {
         // Build a partial map of attributes whose value changed.
         // Create-only attributes (FifoQueue / FifoThroughputLimit /
@@ -652,7 +649,7 @@ impl AwsProvider {
 
 /// Extract a `tags = { ... }` block from the resource, dropping any
 /// non-string values. Returns `None` when no tags are set.
-fn resource_tags_map(resource: &ManagedResource) -> Option<HashMap<String, String>> {
+fn resource_tags_map(resource: &Resource) -> Option<HashMap<String, String>> {
     let Some(Value::Concrete(ConcreteValue::Map(tag_map))) = resource.get_attr("tags") else {
         return None;
     };


### PR DESCRIPTION
## Summary

Catches `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` pins up to the latest carina main (`83a9597b`, post carina#3314 — the fix for the ~20s S3 socket-idle stall on body-less DELETE via the WASM provider). Absorbs the breaking change from carina#3288 across the provider source.

## Changes

1. **Pins bumped** in `carina-aws-types/Cargo.toml` and `carina-provider-aws/Cargo.toml`: `ed0fa554` -> `83a9597b6848a911da06eb2f19acfacab9a2813f`. `Cargo.lock` updated.
2. **`ManagedResource` -> `Resource`** rename applied across all import sites and function signatures (~43 sites in ~40 files). The wire-level `carina_provider_protocol::SchemaKind::Managed` variant is intentionally unchanged for backwards compatibility on the WIT boundary; only the carina-core-side `SchemaKind::Managed` -> `SchemaKind::Resource` rename is followed.
3. **`convert.rs`** updated so `proto_to_core_schema_kind` / `core_to_proto_schema_kind` translate `ProtoSchemaKind::Managed <-> CoreSchemaKind::Resource`.
4. **`schemas/mod.rs`** test updated to match against `SchemaKind::Resource`.

The other commits between the two pins (carina#3289 VirtualResource->Composition, carina#3290 GraphNode owned umbrella, carina#3291 LeafNode, carina#3292-#3295 Composition typestate refinements, carina#3308 ResourceLike retired) did not require any source changes in this repo — they were either internal carina-core-only or addressed naming the aws repo does not use.

## Verify

- [x] `cargo check` (host) - clean
- [x] `cargo check --target wasm32-wasip2` - clean (this is the actual deployment target)
- [x] `cargo nextest run` - 458/458 pass
- [x] `cargo clippy --all-targets -- -D warnings` - clean
- [x] `bash scripts/check-carina-pin.sh` - pin ancestry confirmed
- [ ] Real-S3 acceptance smoke on the five suites blocked by carina#3254 (`s3_bucket_replication_configuration/{basic,with_filter}`, `s3_bucket_server_side_encryption_configuration/basic`, `s3_bucket_website_configuration/basic`, `s3_bucket_public_access_block/basic`) — pending user run with `CARINA_WASI_HTTP_TRACE=1`. Expected: `send_request_ms` for DELETE drops from ~20000ms to tens of ms.

A sibling absorption is needed in `carina-provider-awscc` before that repo can pick up the carina#3254 fix.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
