### PR TITLE
acceptance-tests: resolve sibling repos via git-common-dir, not PROJECT_ROOT/..

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -55,6 +55,26 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# ── Sibling-repo base for cross-provider lookups ──────────────────────
+#
+# Sibling provider repos (e.g. `carina-provider-awscc`) and the
+# `carina` host binary live next to *this* repo in a flat carina-rs
+# checkout. We resolve their base by walking up from the repo's
+# canonical git directory rather than from `$PROJECT_ROOT/..`, because
+# when the script is invoked from a `git wt` worktree under
+# `.worktrees/`, the parent of `$PROJECT_ROOT` is the `.worktrees/`
+# directory — not the carina-rs root (carina-rs/carina-provider-aws#360).
+#
+# `git rev-parse --git-common-dir` returns the *main* repo's `.git`
+# path even from inside a linked worktree, so `dirname` of that gives
+# the repo root, and one more `dirname` gives the carina-rs root.
+# `cd && pwd` canonicalizes both relative (`.git` from the main
+# checkout) and absolute (full path from a worktree) forms into the
+# same absolute path.
+GIT_COMMON_DIR="$(cd "$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir)" && pwd)"
+REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
+SIBLING_BASE="$(dirname "$REPO_ROOT")"
+
 # ── Parse options ─────────────────────────────────────────────────────
 ACCOUNT_START=""
 ACCOUNT_END=""
@@ -430,10 +450,10 @@ echo ""
 # CARINA_BIN can be set externally (e.g., when running from the monorepo).
 if [ -z "$CARINA_BIN" ]; then
     # Prefer release build (WASM JIT is much faster with release)
-    if [ -f "$PROJECT_ROOT/../carina/target/release/carina" ]; then
-        CARINA_BIN="$PROJECT_ROOT/../carina/target/release/carina"
-    elif [ -f "$PROJECT_ROOT/../carina/target/debug/carina" ]; then
-        CARINA_BIN="$PROJECT_ROOT/../carina/target/debug/carina"
+    if [ -f "$SIBLING_BASE/carina/target/release/carina" ]; then
+        CARINA_BIN="$SIBLING_BASE/carina/target/release/carina"
+    elif [ -f "$SIBLING_BASE/carina/target/debug/carina" ]; then
+        CARINA_BIN="$SIBLING_BASE/carina/target/debug/carina"
     elif command -v carina &>/dev/null; then
         CARINA_BIN="$(command -v carina)"
     else
@@ -449,7 +469,7 @@ fi
 
 # ── Provider source injection ────────────────────────────────────────
 _TEST_AWS_WASM="${_TEST_AWS_WASM:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
-_TEST_AWSCC_WASM="${_TEST_AWSCC_WASM:-$PROJECT_ROOT/../carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
+_TEST_AWSCC_WASM="${_TEST_AWSCC_WASM:-$SIBLING_BASE/carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 
 # Read provider version from workspace Cargo.toml to avoid hardcoding
 PROVIDER_VERSION=$(grep '^version = ' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -14,9 +14,17 @@ if [ -z "$SCRIPT_DIR" ]; then
 fi
 PROJECT_ROOT="$(cd "$HELPERS_DIR/../.." && pwd)"
 
+# See run-tests.sh for the rationale: `$PROJECT_ROOT/..` breaks when
+# the script is invoked from a `git wt` worktree
+# (carina-rs/carina-provider-aws#360). Resolve the carina-rs sibling
+# base via the canonical .git directory so worktree and main checkouts
+# both produce the same path.
+GIT_COMMON_DIR="$(cd "$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir)" && pwd)"
+SIBLING_BASE="$(dirname "$(dirname "$GIT_COMMON_DIR")")"
+
 if [ -z "$CARINA_BIN" ]; then
-    if [ -f "$PROJECT_ROOT/../carina/target/debug/carina" ]; then
-        CARINA_BIN="$PROJECT_ROOT/../carina/target/debug/carina"
+    if [ -f "$SIBLING_BASE/carina/target/debug/carina" ]; then
+        CARINA_BIN="$SIBLING_BASE/carina/target/debug/carina"
     elif command -v carina &>/dev/null; then
         CARINA_BIN="$(command -v carina)"
     else
@@ -29,7 +37,7 @@ fi
 # Use WASM provider binaries (carina CLI only supports WASM providers)
 # Build with: cargo build -p carina-provider-aws --target wasm32-wasip2 --release
 _TEST_AWS_WASM="${_TEST_AWS_WASM:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
-_TEST_AWSCC_WASM="${_TEST_AWSCC_WASM:-$PROJECT_ROOT/../carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
+_TEST_AWSCC_WASM="${_TEST_AWSCC_WASM:-$SIBLING_BASE/carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 PROVIDER_VERSION=$(grep '^version = ' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
 
 # inject_provider_source: Create a temp directory containing a .crn file with


### PR DESCRIPTION
## Summary

Cross-provider acceptance tests failed to find the sibling `carina-provider-awscc` WASM when `run-tests.sh` was invoked from a `git wt` worktree. The path was computed as `$PROJECT_ROOT/../carina-provider-awscc/...`, which from a worktree under `.worktrees/` resolves to `.worktrees/carina-provider-awscc/...` — wrong.

## Root cause

`$PROJECT_ROOT/..` assumed the repo lives directly under `carina-rs/`. In a linked worktree, `$PROJECT_ROOT` is under `.worktrees/`, so the parent is `.worktrees/` rather than the carina-rs root.

## Fix

Compute a `SIBLING_BASE` from `git rev-parse --git-common-dir`, which returns the **main** repo's `.git` path even from a linked worktree. Two `dirname` calls give the carina-rs root. `cd && pwd` canonicalizes both relative (`.git` from the main checkout) and absolute (full path from a worktree) forms into the same absolute path.

Every `$PROJECT_ROOT/..` lookup is replaced:

- `acceptance-tests/run-tests.sh` — `CARINA_BIN` (release + debug) and `_TEST_AWSCC_WASM`.
- `acceptance-tests/shared/_helpers.sh` — same pattern, three more sites (`CARINA_BIN` debug + `_TEST_AWSCC_WASM`).

The `${VAR:-default}` construct around `_TEST_AWSCC_WASM` / `CARINA_BIN` is unchanged, so explicit env overrides from CI or developers still win.

### Why not `git rev-parse --show-superproject-working-tree`?

The issue body suggested that. It only works for git submodules; carina-rs is polyrepo (sibling clones, not submodules), so `--show-superproject-working-tree` returns empty. `--git-common-dir` is the right primitive for "main repo from inside a linked worktree".

## Verify

- [x] `bash -n` syntax check on both files
- [x] `shellcheck` clean for the changed lines (pre-existing warnings unrelated)
- [x] Functional smoke: `SIBLING_BASE` resolves to the same `/Users/.../carina-rs` from both the main checkout and from a worktree under `.worktrees/`
- [x] Functional smoke: `_TEST_AWSCC_WASM=/custom/path bash ...` still overrides the default

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
