### PR TITLE
Fix tag_deletion/in_place_update destroy: rename cleanup() to destroy_work_dir() (closes #379)

### DIFF
--- a/acceptance-tests/in_place_update/run.sh
+++ b/acceptance-tests/in_place_update/run.sh
@@ -182,9 +182,12 @@ run_plan_verify() {
     return 0
 }
 
-# Cleanup helper: try to destroy with both step configs, then retry
+# destroy_work_dir: try to destroy with both step configs, then retry
 # Returns 0 if at least one destroy succeeded, 1 if ALL failed
-cleanup() {
+# (Named distinctly from `cleanup` so the EXIT trap in _helpers.sh keeps using
+# its own cleanup() — overriding it would call this with no args at exit and
+# emit "No .crn files found in .".)
+destroy_work_dir() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
@@ -244,7 +247,7 @@ run_test() {
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -253,7 +256,7 @@ run_test() {
 
     # Step 1b: Plan-verify initial state
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -266,7 +269,7 @@ run_test() {
 
     # Step 2: Apply modified config (in-place update)
     if ! run_step "$work_dir" "step2: apply in-place update" "apply" "$step2" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -279,7 +282,7 @@ run_test() {
 
     # Assert identifiers preserved (in-place update should NOT replace any resource)
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -288,15 +291,15 @@ run_test() {
 
     # Step 3: Plan-verify after update
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
-    # Step 4: Destroy (use cleanup to try both configs and retry)
-    if ! cleanup "$work_dir" "$step2" "$step1"; then
+    # Step 4: Destroy (use destroy_work_dir to try both configs and retry)
+    if ! destroy_work_dir "$work_dir" "$step2" "$step1"; then
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))

--- a/acceptance-tests/tag_deletion/run.sh
+++ b/acceptance-tests/tag_deletion/run.sh
@@ -233,7 +233,7 @@ run_test() {
     fi
 
     # Step 4: Destroy
-    if ! cleanup "$work_dir"; then
+    if ! destroy_work_dir "$work_dir"; then
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))


### PR DESCRIPTION
## Summary

Root-cause fix for #379. Commit 2c48af0 already renamed the per-test destroy helper from `cleanup()` to `destroy_work_dir()` in two multi-step suites to keep the EXIT-trap-bound `_helpers.sh:cleanup()` from clashing with a local override, but it missed:

- One happy-path call site in `tag_deletion/run.sh` (Step 4 destroy).
- The entire `in_place_update/run.sh` script, which has the same `cleanup()` shadow pattern (def + 6 calls).

## Symptom

Running `env AWS_PROFILE=carina-test-000 ./tag_deletion/run.sh` reported every test as `OK` but the Step 4 destroy was routed to `_helpers.sh:cleanup()` which:

1. Ignores its `$1` argument (uses `$ACTIVE_WORK_DIR`).
2. Runs `carina destroy` **without** `with_account_creds` — no AWS auth.
3. Pipes stderr to `/dev/null` and returns 0 unconditionally.
4. Removes `carina.state.json`.

End result: every passing test leaks its resources, and after ~5 tests the account hits `VpcLimitExceeded` (default 5 VPCs per region). `in_place_update/run.sh` did not surface the symptom only because its happy-path destroy issued no error on the test accounts during the most recent sweep, but the same shadowing race exists.

## Fix

Both scripts now define `destroy_work_dir()` instead of `cleanup()` (with the same "Named distinctly from `cleanup`..." doc-comment as the prior `2c48af0` rename) and route all call sites to it. The shared `_helpers.sh:cleanup()` keeps being the sole `cleanup` symbol, called only via the EXIT trap.

## Verification

Local end-to-end run on `carina-test-000`:

```
env AWS_PROFILE=carina-test-000 _TEST_AWS_WASM=... ./acceptance-tests/tag_deletion/run.sh
...
Total: 40 passed, 0 failed
```

Post-run `aws ec2 describe-vpcs --filters Name=isDefault,Values=false` returns empty.

A separate sibling PR will land the same rename in `carina-rs/carina-provider-awscc` (closes carina-rs/carina-provider-awscc#276) covering its three remaining shadowing scripts (`create_before_destroy`, `in_place_update`, `simhash_update`, `attribute_removal`).

## Test plan

- [x] `tag_deletion/run.sh` completes 10/10 tests on a single account with 0 leaked VPCs
- [x] `bash -n` syntax-check on all touched scripts
- [x] Pre-existing `shellcheck` warnings unchanged (no new findings introduced by the rename)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)