### PR TITLE
deps: bump carina rev to f8dafdc5 (wasi_http chunked write_body)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
+source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
 dependencies = [
  "argon2",
  "futures",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
+source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
+source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
 dependencies = [
  "serde",
  "serde_json",
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2034,7 +2034,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

- Bumps carina-core / carina-plugin-sdk / carina-provider-protocol from `83a9597b` to `f8dafdc5`.
- The single upstream change in that window is carina-rs/carina#3319: `wasi_http::write_body` now splits SDK-buffered bodies into ≤4096-byte chunks before each `blocking_write_and_flush` call, restoring the wasi:io WIT contract the host enforces via `StreamError::trap`. Without this, any AWS SDK request body >4096 bytes traps the WASM instance and cascades into `cannot enter component instance` on the next guest entry — the carina-rs/carina#3318 failure mode.
- This rev bump is what makes the upstream fix reach the aws provider artifact. No source changes follow from it.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo nextest run --workspace` — 458 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Real-AWS acceptance run (driven by user)

Refs carina-rs/carina#3318.