### PR TITLE
deps: bump carina rev to 63e88c37 (wasi_http handle-before-write)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
+source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
 dependencies = [
  "argon2",
  "futures",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
+source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
+source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
 dependencies = [
  "serde",
  "serde_json",
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2034,7 +2034,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

- Bumps carina-core / carina-plugin-sdk / carina-provider-protocol from `f8dafdc5` to `63e88c37`.
- The single upstream change in that window is carina-rs/carina#3321: `wasi_http::make_request` now calls `outgoing_handler::handle` **before** shipping the body, so the hyper consumer is live by the time `blocking_write_and_flush` starts filling the host-side mpsc channel. Without it, multi-chunk bodies (any request body >4096 bytes after carina-rs/carina#3318) blocked forever on the trailing `write_ready().await`, surfacing as the 20-minute `WASM plugin operation 'update' exceeded 1200s` hard-timeout described in carina-rs/carina#3320.
- This rev bump is what makes the upstream fix reach the aws provider artifact. No source changes follow from it.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo nextest run --workspace` — 458 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Real-AWS acceptance run (driven by user)

Refs carina-rs/carina#3320.