### PR TITLE
deps: bump carina rev to 8003d7eb (AttributeType::Ref + ResourceSchema.defs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
+source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
 dependencies = [
  "argon2",
  "futures",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
+source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
+source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
 dependencies = [
  "serde",
  "serde_json",
@@ -1116,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2034,7 +2034,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -291,6 +291,11 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             validate: noop_validator(),
             to_dsl: None,
         },
+        // Cyclic CFN struct reference (carina#3340). The host's
+        // structural counterpart is `AttributeType::Ref`; the matching
+        // `ResourceSchema.defs` map is converted alongside in
+        // `proto_to_core_schema` so resolution at walk-sites succeeds.
+        ProtoAttributeType::Ref { name } => CoreAttributeType::Ref(name.clone()),
     }
 }
 
@@ -354,6 +359,12 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
         exclusive_required: s.exclusive_required.clone(),
         default_wait_timeout: None,
         default_wait_interval: None,
+        // Cyclic CFN struct definitions reachable via Ref (carina#3340).
+        defs: s
+            .defs
+            .iter()
+            .map(|(k, v)| (k.clone(), proto_to_core_attribute_type(v)))
+            .collect(),
     }
 }
 
@@ -434,6 +445,9 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Union(members) => ProtoAttributeType::Union {
             members: members.iter().map(core_to_proto_attribute_type).collect(),
         },
+        // Cyclic CFN struct reference (carina#3340). Passes through
+        // unchanged so the host can reconstruct the structural Ref.
+        CoreAttributeType::Ref(name) => ProtoAttributeType::Ref { name: name.clone() },
     }
 }
 
@@ -485,6 +499,12 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
         }),
         validators: vec![],
         exclusive_required: s.exclusive_required.clone(),
+        // Cyclic CFN struct definitions reachable via Ref (carina#3340).
+        defs: s
+            .defs
+            .iter()
+            .map(|(k, v)| (k.clone(), core_to_proto_attribute_type(v)))
+            .collect(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Bump carina-core pin to `8003d7eb` (carina-rs/carina#3343 / carina#3340).
- Convert the new `ProtoAttributeType::Ref { name }` ↔ `CoreAttributeType::Ref(name)` in both directions in `convert.rs`.
- Carry the new `defs: BTreeMap<String, AttributeType>` field across `proto_to_core_schema` / `core_to_proto_schema` so cyclic struct definitions survive the WIT boundary intact.

No aws-side resource currently uses cyclic struct definitions, so no resource schema changes here. The codegen template (`carina-codegen-aws/src/main.rs`) emits via `ResourceSchema::new(...)` + builder methods, so the new `defs` field defaults to empty without any template edit.

## Test plan

- [x] `cargo nextest run --workspace` — 458 tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green.
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` — green.

## PR chain

This is PR 2 of a 3-PR chain.

- PR 1 (merged): [carina-rs/carina#3343](https://github.com/carina-rs/carina/pull/3343) — `AttributeType::Ref` + `Schema { root, defs }` + walk-site sweep.
- PR 3 (carina-provider-awscc): rev-bump + codegen recursion guard (closes [awscc#196](https://github.com/carina-rs/carina-provider-awscc/issues/196)) + add `AWS::WAFv2::WebACL` (closes [awscc#197](https://github.com/carina-rs/carina-provider-awscc/issues/197)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)