### PR TITLE
fix: migrate to Schema-aware validate (aws#386, carina#3345)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
+source = "git+https://github.com/carina-rs/carina?rev=66ba8ae737e0891fd1de7ef2e25788e335a9a790#66ba8ae737e0891fd1de7ef2e25788e335a9a790"
 dependencies = [
  "argon2",
  "futures",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
+source = "git+https://github.com/carina-rs/carina?rev=66ba8ae737e0891fd1de7ef2e25788e335a9a790#66ba8ae737e0891fd1de7ef2e25788e335a9a790"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
+source = "git+https://github.com/carina-rs/carina?rev=66ba8ae737e0891fd1de7ef2e25788e335a9a790#66ba8ae737e0891fd1de7ef2e25788e335a9a790"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "66ba8ae737e0891fd1de7ef2e25788e335a9a790" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -2515,7 +2515,9 @@ pub fn validate_condition_operators(value: &Value) -> Result<(), String> {
 
 /// Validate IAM policy document structure and condition operators.
 pub fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
-    iam_policy_document()
+    // The IAM policy schema is flat (no `AttributeType::Ref`), so an
+    // empty `defs` map is sound here (carina#3345).
+    carina_core::schema::Schema::flat(iam_policy_document())
         .validate(value)
         .map_err(|e| e.to_string())?;
     validate_condition_operators(value)
@@ -2604,28 +2606,32 @@ mod tests {
     fn validate_arn_type_with_value() {
         let t = arn();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "arn:aws:s3:::my-bucket".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "arn:aws:s3:::my-bucket".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "not-an-arn".to_string()
-            )))
-            .is_err()
-        );
-        assert!(
-            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "not-an-arn".to_string()
+                )))
                 .is_err()
         );
         assert!(
-            t.validate(&Value::resource_ref(
-                "role".to_string(),
-                "arn".to_string(),
-                vec![]
-            ))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::Int(42)))
+                .is_err()
+        );
+        assert!(
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::resource_ref(
+                    "role".to_string(),
+                    "arn".to_string(),
+                    vec![]
+                ))
+                .is_ok()
         );
     }
 
@@ -2654,26 +2660,30 @@ mod tests {
     fn validate_aws_resource_id_type_with_value() {
         let t = aws_resource_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "vpc-1a2b3c4d".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "vpc-1a2b3c4d".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String("vpc".to_string())))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String("vpc".to_string())))
                 .is_err()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::Int(42)))
                 .is_err()
         );
         assert!(
-            t.validate(&Value::resource_ref(
-                "my_vpc".to_string(),
-                "vpc_id".to_string(),
-                vec![]
-            ))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::resource_ref(
+                    "my_vpc".to_string(),
+                    "vpc_id".to_string(),
+                    vec![]
+                ))
+                .is_ok()
         );
     }
 
@@ -2681,16 +2691,18 @@ mod tests {
     fn validate_vpc_cidr_block_association_id_valid() {
         let t = vpc_cidr_block_association_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "vpc-cidr-assoc-12345678".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "vpc-cidr-assoc-12345678".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "vpc-cidr-assoc-0123456789abcdef0".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "vpc-cidr-assoc-0123456789abcdef0".to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -2698,16 +2710,18 @@ mod tests {
     fn validate_vpc_cidr_block_association_id_invalid() {
         let t = vpc_cidr_block_association_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "vpc-12345678".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "vpc-12345678".to_string()
+                )))
+                .is_err()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "invalid".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "invalid".to_string()
+                )))
+                .is_err()
         );
     }
 
@@ -2715,16 +2729,18 @@ mod tests {
     fn validate_tgw_route_table_id_valid() {
         let t = tgw_route_table_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "tgw-rtb-12345678".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "tgw-rtb-12345678".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "tgw-rtb-0123456789abcdef0".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "tgw-rtb-0123456789abcdef0".to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -2733,23 +2749,26 @@ mod tests {
         let t = tgw_route_table_id();
         // Regular route table ID should fail
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "rtb-12345678".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "rtb-12345678".to_string()
+                )))
+                .is_err()
         );
         // Transit gateway ID should fail
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "tgw-12345678".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "tgw-12345678".to_string()
+                )))
+                .is_err()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "invalid".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "invalid".to_string()
+                )))
+                .is_err()
         );
     }
 
@@ -2819,28 +2838,32 @@ mod tests {
     fn validate_availability_zone_id_type_with_value() {
         let t = availability_zone_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "use1-az1".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "use1-az1".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "us-east-1a".to_string()
-            )))
-            .is_err()
-        );
-        assert!(
-            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "us-east-1a".to_string()
+                )))
                 .is_err()
         );
         assert!(
-            t.validate(&Value::resource_ref(
-                "subnet".to_string(),
-                "availability_zone_id".to_string(),
-                vec![]
-            ))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::Int(42)))
+                .is_err()
+        );
+        assert!(
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::resource_ref(
+                    "subnet".to_string(),
+                    "availability_zone_id".to_string(),
+                    vec![]
+                ))
+                .is_ok()
         );
     }
 
@@ -3186,7 +3209,11 @@ mod tests {
             .into_iter()
             .collect(),
         ));
-        assert!(t.validate(&valid_doc).is_ok());
+        assert!(
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&valid_doc)
+                .is_ok()
+        );
     }
 
     #[test]
@@ -3240,9 +3267,11 @@ mod tests {
             .collect(),
         ));
         assert!(
-            t.validate(&doc_with_principal_map).is_ok(),
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&doc_with_principal_map)
+                .is_ok(),
             "principal as map (struct) should be valid: {:?}",
-            t.validate(&doc_with_principal_map)
+            carina_core::schema::Schema::flat(t.clone()).validate(&doc_with_principal_map)
         );
     }
 
@@ -3288,9 +3317,11 @@ mod tests {
             .collect(),
         ));
         assert!(
-            t.validate(&doc_with_principal_string).is_ok(),
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&doc_with_principal_string)
+                .is_ok(),
             "principal as string should be valid: {:?}",
-            t.validate(&doc_with_principal_string)
+            carina_core::schema::Schema::flat(t.clone()).validate(&doc_with_principal_string)
         );
     }
 

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "66ba8ae737e0891fd1de7ef2e25788e335a9a790" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "66ba8ae737e0891fd1de7ef2e25788e335a9a790" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "66ba8ae737e0891fd1de7ef2e25788e335a9a790" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -257,7 +257,7 @@ mod tests {
     fn region_accepts_aws_format() {
         let region_type = aws_region();
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "ap-northeast-1".to_string()
                 )))
@@ -269,7 +269,7 @@ mod tests {
     fn region_accepts_dsl_format() {
         let region_type = aws_region();
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "aws.Region.ap_northeast_1".to_string()
                 )))
@@ -281,7 +281,7 @@ mod tests {
     fn region_accepts_dsl_format_without_aws_prefix() {
         let region_type = aws_region();
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "Region.ap_northeast_1".to_string()
                 )))
@@ -292,9 +292,9 @@ mod tests {
     #[test]
     fn region_rejects_invalid_region() {
         let region_type = aws_region();
-        let result = region_type.validate(&Value::Concrete(ConcreteValue::String(
-            "invalid-region".to_string(),
-        )));
+        let result = carina_core::schema::Schema::flat(region_type.clone()).validate(
+            &Value::Concrete(ConcreteValue::String("invalid-region".to_string())),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Invalid region"));
@@ -306,7 +306,7 @@ mod tests {
         let region_type = aws_region();
         // ap-northeast-1a is an AZ, not a region
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "ap-northeast-1a".to_string()
                 )))
@@ -319,7 +319,7 @@ mod tests {
         let region_type = aws_region();
         for (region, _) in REGIONS {
             assert!(
-                region_type
+                carina_core::schema::Schema::flat(region_type.clone())
                     .validate(&Value::Concrete(ConcreteValue::String(region.to_string())))
                     .is_ok(),
                 "Region {} should be valid",
@@ -334,7 +334,7 @@ mod tests {
     fn az_accepts_aws_format() {
         let az_type = availability_zone();
         assert!(
-            az_type
+            carina_core::schema::Schema::flat(az_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "us-east-1a".to_string()
                 )))
@@ -349,7 +349,7 @@ mod tests {
         // `ZoneName` kind segment — `aws.AvailabilityZone.ZoneName.<v>` —
         // matching the structured identity's dotted display.
         assert!(
-            az_type
+            carina_core::schema::Schema::flat(az_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "aws.AvailabilityZone.ZoneName.us_east_1a".to_string()
                 )))
@@ -361,7 +361,7 @@ mod tests {
     fn az_accepts_shorthand_format() {
         let az_type = availability_zone();
         assert!(
-            az_type
+            carina_core::schema::Schema::flat(az_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "us_east_1a".to_string()
                 )))
@@ -373,7 +373,7 @@ mod tests {
     fn az_rejects_invalid_az() {
         let az_type = availability_zone();
         assert!(
-            az_type
+            carina_core::schema::Schema::flat(az_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "invalid-zone".to_string()
                 )))
@@ -385,7 +385,7 @@ mod tests {
     fn az_rejects_wrong_namespace() {
         let az_type = availability_zone();
         assert!(
-            az_type
+            carina_core::schema::Schema::flat(az_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "gcp.AvailabilityZone.us_east_1a".to_string()
                 )))
@@ -427,11 +427,12 @@ mod tests {
     fn grantee_accepts_id_format() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "id=\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\""
-                    .to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "id=\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\""
+                        .to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -439,10 +440,11 @@ mod tests {
     fn grantee_accepts_email_format() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "emailAddress=\"user@example.com\"".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "emailAddress=\"user@example.com\"".to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -450,10 +452,11 @@ mod tests {
     fn grantee_accepts_uri_format() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "uri=\"http://acs.amazonaws.com/groups/global/AllUsers\"".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "uri=\"http://acs.amazonaws.com/groups/global/AllUsers\"".to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -461,10 +464,11 @@ mod tests {
     fn grantee_accepts_multiple_specs() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "id=\"abc123\", emailAddress=\"user@example.com\"".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "id=\"abc123\", emailAddress=\"user@example.com\"".to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -472,7 +476,8 @@ mod tests {
     fn grantee_rejects_empty_string() {
         let t = s3_grantee();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String("".to_string())))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String("".to_string())))
                 .is_err()
         );
     }
@@ -480,9 +485,9 @@ mod tests {
     #[test]
     fn grantee_rejects_invalid_prefix() {
         let t = s3_grantee();
-        let result = t.validate(&Value::Concrete(ConcreteValue::String(
-            "foo=\"bar\"".to_string(),
-        )));
+        let result = carina_core::schema::Schema::flat(t.clone()).validate(&Value::Concrete(
+            ConcreteValue::String("foo=\"bar\"".to_string()),
+        ));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("must start with id=, emailAddress=, or uri="));
@@ -492,28 +497,28 @@ mod tests {
     fn region_rejects_wrong_namespace() {
         let region_type = aws_region();
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "gcp.Region.ap_northeast_1".to_string()
                 )))
                 .is_err()
         );
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "aws.Location.ap_northeast_1".to_string()
                 )))
                 .is_err()
         );
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "foo.bar.baz.ap_northeast_1".to_string()
                 )))
                 .is_err()
         );
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "Location.ap_northeast_1".to_string()
                 )))

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -1639,34 +1639,30 @@ fn test_organization_feature_set_validates_snake_case_alias() {
     // to `StringLiteralExpectedEnum`. Both the API form (`ALL`) and the
     // DSL form (`all`) are identifier-shape inputs in real DSL — the
     // parser would emit `EnumIdentifier` for both. Mirror that here.
-    feature_set
-        .attr_type
+    let schema = carina_core::schema::Schema::flat(feature_set.attr_type.clone());
+    schema
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "ALL".to_string(),
         )))
         .expect("API spelling ALL should be accepted");
-    feature_set
-        .attr_type
+    schema
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "all".to_string(),
         )))
         .expect("DSL spelling all should be accepted");
-    feature_set
-        .attr_type
+    schema
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "CONSOLIDATED_BILLING".to_string(),
         )))
         .expect("API spelling CONSOLIDATED_BILLING should be accepted");
-    feature_set
-        .attr_type
+    schema
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "consolidated_billing".to_string(),
         )))
         .expect("DSL spelling consolidated_billing should be accepted");
     // Bogus values still rejected.
     assert!(
-        feature_set
-            .attr_type
+        schema
             .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
                 "not_a_value".to_string()
             )))
@@ -1692,26 +1688,23 @@ fn test_route53_record_type_validates_snake_case_alias() {
     // Phase 4 of carina#2986: use `EnumIdentifier` shape to reach the
     // variant-match path. A `ConcreteValue::String` here would route
     // to `StringLiteralExpectedEnum`.
-    type_attr
-        .attr_type
+    let schema = carina_core::schema::Schema::flat(type_attr.attr_type.clone());
+    schema
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "A".to_string(),
         )))
         .expect("API spelling A should be accepted");
-    type_attr
-        .attr_type
+    schema
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "a".to_string(),
         )))
         .expect("DSL spelling a should be accepted");
-    type_attr
-        .attr_type
+    schema
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "CNAME".to_string(),
         )))
         .expect("API spelling CNAME should be accepted");
-    type_attr
-        .attr_type
+    schema
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "cname".to_string(),
         )))


### PR DESCRIPTION
## Summary

Closes #386. carina#3345 (PR carina-rs/carina#3346, merged 2026-05-29) deleted the defs-less public wrappers `AttributeType::validate(&Value)` etc. from carina-core. This repo's `.validate(value)` call sites would fail to compile when the carina-core pin is bumped past `aa031165`. carina#3347 (PR carina-rs/carina#3348, merged 2026-05-29) additionally fixed a latent `Schema::validate_attr` Map-key lift bug.

This PR bumps the `carina-core` / `-plugin-sdk` / `-provider-protocol` pins to the carina#3348 merge (`66ba8ae7`, includes both #3346 and #3347) and migrates every caller to the Schema-aware API. Mirrors the carina-rs/carina-provider-awscc#283 migration for the sibling `carina-aws-types` copy.

## Key changes

- **`carina-aws-types/src/lib.rs`**: production `iam_policy_document().validate(value)` (line 2517) wrapped in `Schema::flat(...)`; ~27 test sites `t.validate(...)` switched to `Schema::flat(t.clone()).validate(...)`.
- **`carina-provider-aws/src/schemas/types.rs`**: ~21 test sites `region_type.validate(...)` / `az_type.validate(...)` migrated.
- **`carina-provider-aws/src/tests.rs`**: 9 sites `feature_set.attr_type.validate(...)` / `type_attr.attr_type.validate(...)` migrated by hoisting `let schema = Schema::flat(<var>.attr_type.clone())` once per test and reusing.

## Pin check

`66ba8ae7` is the carina#3348 merge (lineage: `66ba8ae7` ← `a7565eb6` carina#3347 ← `0cf9c70a` carina#3346 ← `aa031165` carina#3345). `scripts/check-carina-pin.sh` confirms ancestry.

## Test plan

- [x] `cargo nextest run --workspace` — 458 tests, all passing.
- [x] `cargo test --workspace --doc` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo build --release -p carina-provider-aws` — green.
- [x] `bash scripts/check-carina-pin.sh` — pass.
- [x] `bash scripts/check-examples.sh` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
