### PR TITLE
chore: switch convert.rs to RawShape for Ref-preserving transport (carina#3352)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=2c1bd0523a52f6b174e6e059eb11126b796d89a2#2c1bd0523a52f6b174e6e059eb11126b796d89a2"
+source = "git+https://github.com/carina-rs/carina?rev=2af9da677c235e042eca7dc59ea5a472063a2747#2af9da677c235e042eca7dc59ea5a472063a2747"
 dependencies = [
  "argon2",
  "futures",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=2c1bd0523a52f6b174e6e059eb11126b796d89a2#2c1bd0523a52f6b174e6e059eb11126b796d89a2"
+source = "git+https://github.com/carina-rs/carina?rev=2af9da677c235e042eca7dc59ea5a472063a2747#2af9da677c235e042eca7dc59ea5a472063a2747"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=2c1bd0523a52f6b174e6e059eb11126b796d89a2#2c1bd0523a52f6b174e6e059eb11126b796d89a2"
+source = "git+https://github.com/carina-rs/carina?rev=2af9da677c235e042eca7dc59ea5a472063a2747#2af9da677c235e042eca7dc59ea5a472063a2747"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "2c1bd0523a52f6b174e6e059eb11126b796d89a2" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "2af9da677c235e042eca7dc59ea5a472063a2747" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "2c1bd0523a52f6b174e6e059eb11126b796d89a2" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "2af9da677c235e042eca7dc59ea5a472063a2747" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "2c1bd0523a52f6b174e6e059eb11126b796d89a2" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "2c1bd0523a52f6b174e6e059eb11126b796d89a2" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "2af9da677c235e042eca7dc59ea5a472063a2747" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "2af9da677c235e042eca7dc59ea5a472063a2747" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -12,8 +12,9 @@ use carina_core::resource::{
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
-    OperationConfig as CoreOperationConfig, ResourceSchema as CoreResourceSchema,
-    SchemaKind as CoreSchemaKind, StructField as CoreStructField, noop_validator,
+    OperationConfig as CoreOperationConfig, RawShape as CoreRawShape,
+    ResourceSchema as CoreResourceSchema, SchemaKind as CoreSchemaKind,
+    StructField as CoreStructField, noop_validator,
 };
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
@@ -387,29 +388,25 @@ fn core_to_proto_schema_kind(k: CoreSchemaKind) -> ProtoSchemaKind {
 }
 
 fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
-    use carina_core::schema::{Shape, empty_defs};
-    // `core_to_proto_attribute_type` is called with `empty_defs()` because
-    // schema-level `defs` carry through `core_to_proto_schema` as their own
-    // wire field (`ProtoResourceSchema.defs`). Refs cannot appear inside a
-    // non-`defs` AttributeType tree on the producer side: codegen never
-    // emits `AttributeType::ref_(...)` in this provider repo — all cyclic
-    // structures are flat-expanded in the generated schemas. If a Ref does
-    // appear in `defs`, it is encoded directly via the wire-level
-    // `ProtoAttributeType::Ref { name }` arm below by special-casing the
-    // pre-shape inspection.
-    match t.shape(empty_defs()) {
-        Shape::String => ProtoAttributeType::String,
-        Shape::Int => ProtoAttributeType::Int,
-        Shape::Float => ProtoAttributeType::Float,
-        Shape::Bool => ProtoAttributeType::Bool,
+    // `raw_shape()` is the Ref-preserving projection (carina#3349 / #3352).
+    // `shape(defs)` would auto-resolve Ref and either flatten the
+    // structure (acyclic) or infinite-loop (cyclic CFN schemas like
+    // WAFv2 WebACL.Statement); the wire form must transmit Ref verbatim
+    // so the receiver can rebuild from its own copy of `defs`. Aligns
+    // this provider with awscc#284.
+    match t.raw_shape() {
+        CoreRawShape::String => ProtoAttributeType::String,
+        CoreRawShape::Int => ProtoAttributeType::Int,
+        CoreRawShape::Float => ProtoAttributeType::Float,
+        CoreRawShape::Bool => ProtoAttributeType::Bool,
         // `Duration` is now a first-class proto variant (carina#3166) so
         // providers can declare Duration-typed schema attributes and the
         // host's type checker accepts DSL literals like `30min` / `1h` /
         // `15s` against them. The WIT *value* boundary is still
         // integer-seconds (see carina-plugin-host wasm_convert.rs:60-76),
         // but the *type* boundary now round-trips faithfully.
-        Shape::Duration => ProtoAttributeType::Duration,
-        Shape::StringEnum {
+        CoreRawShape::Duration => ProtoAttributeType::Duration,
+        CoreRawShape::StringEnum {
             values,
             name,
             identity,
@@ -424,19 +421,19 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             namespace: identity.and_then(|id| id.dotted_prefix()),
             dsl_aliases: dsl_aliases.to_vec(),
         },
-        Shape::List { inner, ordered } => ProtoAttributeType::List {
+        CoreRawShape::List { inner, ordered } => ProtoAttributeType::List {
             inner: Box::new(core_to_proto_attribute_type(inner)),
             ordered,
         },
-        Shape::Map { key, value: inner } => ProtoAttributeType::Map {
+        CoreRawShape::Map { key, value: inner } => ProtoAttributeType::Map {
             inner: Box::new(core_to_proto_attribute_type(inner)),
             key: Box::new(core_to_proto_attribute_type(key)),
         },
-        Shape::Struct { name, fields } => ProtoAttributeType::Struct {
+        CoreRawShape::Struct { name, fields } => ProtoAttributeType::Struct {
             name: name.to_string(),
             fields: fields.iter().map(core_to_proto_struct_field).collect(),
         },
-        Shape::Custom { identity, base, .. } => ProtoAttributeType::Custom {
+        CoreRawShape::Custom { identity, base, .. } => ProtoAttributeType::Custom {
             // Serialize the structured identity to its dotted display
             // form for the wire. The host's `TypeIdentity::from_dotted`
             // parses it back on the other side, so the provider axis
@@ -448,13 +445,19 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         // fact (carina#3222); on the wire form it still travels as a
         // separate `CustomEnum` variant with the dotted prefix as a
         // flat string.
-        Shape::CustomEnum { identity, base, .. } => ProtoAttributeType::CustomEnum {
+        CoreRawShape::CustomEnum { identity, base, .. } => ProtoAttributeType::CustomEnum {
             name: identity.to_string(),
             base: Box::new(core_to_proto_attribute_type(base)),
             namespace: identity.dotted_prefix().unwrap_or_default(),
         },
-        Shape::Union(members) => ProtoAttributeType::Union {
+        CoreRawShape::Union(members) => ProtoAttributeType::Union {
             members: members.iter().map(core_to_proto_attribute_type).collect(),
+        },
+        // Cyclic CFN struct reference (carina#3340). Passes through
+        // unchanged so the host can reconstruct the structural Ref
+        // against its own copy of `ResourceSchema.defs`.
+        CoreRawShape::Ref(name) => ProtoAttributeType::Ref {
+            name: name.to_string(),
         },
     }
 }
@@ -559,9 +562,7 @@ mod tests {
             _ => panic!("Expected StringEnum"),
         }
         let roundtrip = proto_to_core_attribute_type(&proto_type);
-        if let carina_core::schema::Shape::StringEnum { name, values, .. } =
-            roundtrip.shape(carina_core::schema::empty_defs())
-        {
+        if let CoreRawShape::StringEnum { name, values, .. } = roundtrip.raw_shape() {
             assert_eq!(name, "VersioningStatus");
             assert_eq!(values, &["Enabled", "Suspended"]);
         } else {


### PR DESCRIPTION
## Summary

Bumps the four carina-core / carina-plugin-sdk / carina-provider-protocol git pins from `2c1bd052` to `2af9da67`, absorbing carina#3352 (RawShape view for transport sites), and migrates `core_to_proto_attribute_type` to the typed Ref-preserving API.

## What changed

1. **Pin bump** (4 sites): `carina-aws-types/Cargo.toml`, `carina-provider-aws/Cargo.toml` (three pins) → `2af9da677c235e042eca7dc59ea5a472063a2747`. Only one functional commit between the old and new pin (carina-rs/carina#3352 / 1d1fb5c6 adding `RawShape`).

2. **Migrate `core_to_proto_attribute_type`** in `carina-provider-aws/src/convert.rs` from `t.shape(empty_defs())` to `t.raw_shape()`:
   - Match arms now use `CoreRawShape::*` instead of `Shape::*`.
   - New `CoreRawShape::Ref(name)` arm forwards to `ProtoAttributeType::Ref { name }`. The counterpart `proto_to_core_attribute_type::Ref` arm has shipped since carina#3340.
   - The roundtrip test at the bottom of `convert.rs` also switches to `raw_shape()` since it exercises the same transport-site contract.

## Why

`core_to_proto_attribute_type` is a **transport site** (provider plugin -> protocol wire form). The previous `shape(empty_defs())` form was a stringly-typed workaround: it relied on the convention that aws codegen never emits `AttributeType::ref_(...)` at root sites, so the empty `defs` map never had to resolve a Ref. `shape()` panics on a Ref it cannot resolve via `defs`, so a future codegen change that introduces a root Ref (e.g. landing cyclic CFN schemas in aws like awscc has for WAFv2) would silently break at runtime.

`raw_shape()` is the typed API for this exact use case — it surfaces the `Ref` variant explicitly so the wire form can transmit it verbatim and the receiver can rebuild it against its own copy of `ResourceSchema.defs`. Same factoring as carina-provider-awscc#284 (the load-bearing fix on the awscc side).

Walk-sites (validation, normalization, e.g. `carina-aws-types/src/lib.rs`, `carina-provider-aws/src/normalizer.rs`) deliberately stay on `shape(defs)` — those want auto-resolution.

## Verify

- [x] `cargo nextest run --workspace`: 458/458 passing
- [x] `cargo test --doc`: clean (carina-aws-types disables doctests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean
- [x] `cargo fmt --all --check`: clean
- [x] `cargo build --release`: clean
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`: clean
- [x] `bash scripts/check-carina-pin.sh`: all 4 pins on `2af9da67`, ancestor of `.carina-core-min-rev`

Refs: carina-rs/carina#3352, carina-rs/carina-provider-awscc#284