### PR TITLE
fix: derive StringEnum DSL aliases via a single-source helper (closes #390)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,17 @@ jobs:
       # pinned rev is consistent and >= .carina-core-min-rev.
       - run: ./scripts/check-carina-pin.sh
 
+  string-enum-aliases:
+    name: Check StringEnum Aliases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Enforces #390: hand-written StringEnum sites in
+      # carina-aws-types/src/lib.rs must build their alias table from
+      # the canonical values via string_enum_with_dsl_aliases, not
+      # ship an empty `vec![]`.
+      - run: ./scripts/check-string-enum-aliases.sh
+
   wasm-build:
     name: WASM Build
     runs-on: ubuntu-latest

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -98,6 +98,34 @@ fn dsl_aliases_for(values: &[&str]) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Build a `StringEnum` `AttributeType` whose DSL alias table is
+/// derived from `values` via [`dsl_aliases_for`]. Hand-written
+/// `carina-aws-types` enum sites must call this constructor instead of
+/// the raw [`AttributeType::string_enum`] so that aliases cannot be
+/// silently omitted — every call site sources the alias table from the
+/// same `values` slice that defines the canonical AWS API values, making
+/// "StringEnum with empty `dsl_aliases`" impossible by construction.
+///
+/// `AwsNormalizer::api_canonicalize_recursive` relies on this alias
+/// table to rewrite DSL spellings (e.g. `aes256`) to the AWS canonical
+/// (`AES256`) before the wire call. A `StringEnum` whose alias table is
+/// empty silently forwards the raw alias spelling to the AWS SDK and
+/// triggers `MalformedXML` / `Unknown(...)` errors.
+/// See `carina-rs/carina-provider-aws#390`.
+///
+/// The raw [`AttributeType::string_enum`] constructor remains in use
+/// only for the `ConditionOperator` site, which derives its alias table
+/// dynamically from a different source.
+fn string_enum_with_dsl_aliases(
+    name: &str,
+    values: &[&str],
+    identity: Option<carina_core::schema::TypeIdentity>,
+) -> AttributeType {
+    let owned_values: Vec<String> = values.iter().map(|v| v.to_string()).collect();
+    let aliases = dsl_aliases_for(values);
+    AttributeType::string_enum(name.to_string(), owned_values, identity, aliases)
+}
+
 /// Check if `input` matches any of `valid_values` using enum matching rules:
 /// exact match, case-insensitive, or underscore-to-hyphen (case-insensitive).
 /// Returns the matched valid value if found.
@@ -1322,14 +1350,13 @@ fn string_or_principal_struct() -> AttributeType {
 /// `type_name` is the trailing `Effect` segment and `namespace` is
 /// `aws.iam.PolicyDocument`.
 fn iam_policy_effect() -> AttributeType {
-    AttributeType::string_enum(
-        "Effect".to_string(),
-        vec!["Allow".to_string(), "Deny".to_string()],
+    string_enum_with_dsl_aliases(
+        "Effect",
+        &["Allow", "Deny"],
         Some(carina_core::schema::string_enum_identity(
             "Effect",
             Some("aws.iam.PolicyDocument"),
         )),
-        dsl_aliases_for(&["Allow", "Deny"]),
     )
 }
 
@@ -1344,14 +1371,13 @@ fn iam_policy_effect() -> AttributeType {
 /// `<namespace>.<type_name>.<value>`, so `type_name` is the trailing
 /// `Version` segment and `namespace` is `aws.iam.PolicyDocument`.
 fn iam_policy_version() -> AttributeType {
-    AttributeType::string_enum(
-        "Version".to_string(),
-        vec!["2012-10-17".to_string(), "2008-10-17".to_string()],
+    string_enum_with_dsl_aliases(
+        "Version",
+        &["2012-10-17", "2008-10-17"],
         Some(carina_core::schema::string_enum_identity(
             "Version",
             Some("aws.iam.PolicyDocument"),
         )),
-        dsl_aliases_for(&["2012-10-17", "2008-10-17"]),
     )
 }
 
@@ -1451,18 +1477,13 @@ pub fn sqs_redrive_policy() -> AttributeType {
 
 /// `redrive_permission` enum used inside `sqs_redrive_allow_policy`.
 fn sqs_redrive_permission() -> AttributeType {
-    AttributeType::string_enum(
-        "SqsRedrivePermission".to_string(),
-        vec![
-            "allowAll".to_string(),
-            "denyAll".to_string(),
-            "byQueue".to_string(),
-        ],
+    string_enum_with_dsl_aliases(
+        "SqsRedrivePermission",
+        &["allowAll", "denyAll", "byQueue"],
         Some(carina_core::schema::string_enum_identity(
             "SqsRedrivePermission",
             Some("aws.sqs.Queue"),
         )),
-        dsl_aliases_for(&["allowAll", "denyAll", "byQueue"]),
     )
 }
 
@@ -1487,18 +1508,13 @@ pub fn sqs_redrive_allow_policy() -> AttributeType {
 
 /// SSE algorithm enum for `aws.s3.BucketServerSideEncryptionConfiguration`.
 fn s3_sse_algorithm() -> AttributeType {
-    AttributeType::string_enum(
-        "SseAlgorithm".to_string(),
-        vec![
-            "AES256".to_string(),
-            "aws:kms".to_string(),
-            "aws:kms:dsse".to_string(),
-        ],
+    string_enum_with_dsl_aliases(
+        "SseAlgorithm",
+        &["AES256", "aws:kms", "aws:kms:dsse"],
         Some(carina_core::schema::string_enum_identity(
             "SseAlgorithm",
             Some("aws.s3.BucketServerSideEncryptionConfiguration"),
         )),
-        vec![],
     )
 }
 
@@ -1551,23 +1567,9 @@ fn s3_replication_destination() -> AttributeType {
             StructField::new("account", AttributeType::string()).with_provider_name("Account"),
             StructField::new(
                 "storage_class",
-                AttributeType::string_enum(
-                    "ReplicationStorageClass".to_string(),
-                    vec![
-                        "STANDARD".to_string(),
-                        "REDUCED_REDUNDANCY".to_string(),
-                        "STANDARD_IA".to_string(),
-                        "ONEZONE_IA".to_string(),
-                        "INTELLIGENT_TIERING".to_string(),
-                        "GLACIER".to_string(),
-                        "DEEP_ARCHIVE".to_string(),
-                        "GLACIER_IR".to_string(),
-                    ],
-                    Some(carina_core::schema::string_enum_identity(
-                        "ReplicationStorageClass",
-                        Some("aws.s3.BucketReplicationConfiguration"),
-                    )),
-                    dsl_aliases_for(&[
+                string_enum_with_dsl_aliases(
+                    "ReplicationStorageClass",
+                    &[
                         "STANDARD",
                         "REDUCED_REDUNDANCY",
                         "STANDARD_IA",
@@ -1576,7 +1578,11 @@ fn s3_replication_destination() -> AttributeType {
                         "GLACIER",
                         "DEEP_ARCHIVE",
                         "GLACIER_IR",
-                    ]),
+                    ],
+                    Some(carina_core::schema::string_enum_identity(
+                        "ReplicationStorageClass",
+                        Some("aws.s3.BucketReplicationConfiguration"),
+                    )),
                 ),
             )
             .with_provider_name("StorageClass"),
@@ -1585,14 +1591,13 @@ fn s3_replication_destination() -> AttributeType {
 }
 
 fn s3_replication_status() -> AttributeType {
-    AttributeType::string_enum(
-        "ReplicationRuleStatus".to_string(),
-        vec!["Enabled".to_string(), "Disabled".to_string()],
+    string_enum_with_dsl_aliases(
+        "ReplicationRuleStatus",
+        &["Enabled", "Disabled"],
         Some(carina_core::schema::string_enum_identity(
             "ReplicationRuleStatus",
             Some("aws.s3.BucketReplicationConfiguration"),
         )),
-        dsl_aliases_for(&["Enabled", "Disabled"]),
     )
 }
 
@@ -1638,14 +1643,13 @@ fn s3_delete_marker_replication() -> AttributeType {
         vec![
             StructField::new(
                 "status",
-                AttributeType::string_enum(
-                    "DeleteMarkerReplicationStatus".to_string(),
-                    vec!["Enabled".to_string(), "Disabled".to_string()],
+                string_enum_with_dsl_aliases(
+                    "DeleteMarkerReplicationStatus",
+                    &["Enabled", "Disabled"],
                     Some(carina_core::schema::string_enum_identity(
                         "DeleteMarkerReplicationStatus",
                         Some("aws.s3.BucketReplicationConfiguration"),
                     )),
-                    dsl_aliases_for(&["Enabled", "Disabled"]),
                 ),
             )
             .with_provider_name("Status")
@@ -1683,41 +1687,32 @@ pub fn bucket_replication_rules() -> AttributeType {
 
 /// Lifecycle rule status (Enabled / Disabled).
 fn s3_lifecycle_status() -> AttributeType {
-    AttributeType::string_enum(
-        "LifecycleRuleStatus".to_string(),
-        vec!["Enabled".to_string(), "Disabled".to_string()],
+    string_enum_with_dsl_aliases(
+        "LifecycleRuleStatus",
+        &["Enabled", "Disabled"],
         Some(carina_core::schema::string_enum_identity(
             "LifecycleRuleStatus",
             Some("aws.s3.BucketLifecycleConfiguration"),
         )),
-        dsl_aliases_for(&["Enabled", "Disabled"]),
     )
 }
 
 /// Storage class for lifecycle transitions (Glacier / IA / etc.).
 fn s3_transition_storage_class() -> AttributeType {
-    AttributeType::string_enum(
-        "TransitionStorageClass".to_string(),
-        vec![
-            "GLACIER".to_string(),
-            "STANDARD_IA".to_string(),
-            "ONEZONE_IA".to_string(),
-            "INTELLIGENT_TIERING".to_string(),
-            "DEEP_ARCHIVE".to_string(),
-            "GLACIER_IR".to_string(),
-        ],
-        Some(carina_core::schema::string_enum_identity(
-            "TransitionStorageClass",
-            Some("aws.s3.BucketLifecycleConfiguration"),
-        )),
-        dsl_aliases_for(&[
+    string_enum_with_dsl_aliases(
+        "TransitionStorageClass",
+        &[
             "GLACIER",
             "STANDARD_IA",
             "ONEZONE_IA",
             "INTELLIGENT_TIERING",
             "DEEP_ARCHIVE",
             "GLACIER_IR",
-        ]),
+        ],
+        Some(carina_core::schema::string_enum_identity(
+            "TransitionStorageClass",
+            Some("aws.s3.BucketLifecycleConfiguration"),
+        )),
     )
 }
 
@@ -2012,14 +2007,13 @@ pub fn bucket_event_bridge_configuration() -> AttributeType {
 }
 
 fn s3_partition_date_source() -> AttributeType {
-    AttributeType::string_enum(
-        "PartitionDateSource".to_string(),
-        vec!["EventTime".to_string(), "DeliveryTime".to_string()],
+    string_enum_with_dsl_aliases(
+        "PartitionDateSource",
+        &["EventTime", "DeliveryTime"],
         Some(carina_core::schema::string_enum_identity(
             "PartitionDateSource",
             Some("aws.s3.BucketLogging"),
         )),
-        dsl_aliases_for(&["EventTime", "DeliveryTime"]),
     )
 }
 
@@ -2080,14 +2074,13 @@ pub fn s3_redirect_all_requests_to() -> AttributeType {
                 .required(),
             StructField::new(
                 "protocol",
-                AttributeType::string_enum(
-                    "Protocol".to_string(),
-                    vec!["http".to_string(), "https".to_string()],
+                string_enum_with_dsl_aliases(
+                    "Protocol",
+                    &["http", "https"],
                     Some(carina_core::schema::string_enum_identity(
                         "Protocol",
                         Some("aws.s3.BucketWebsiteConfiguration"),
                     )),
-                    vec![],
                 ),
             )
             .with_provider_name("Protocol"),
@@ -3882,5 +3875,87 @@ mod tests {
         } else {
             panic!("expected StringEnum");
         }
+    }
+
+    /// Regression: `s3_sse_algorithm` must register DSL aliases for every
+    /// value so `AwsNormalizer::api_canonicalize_recursive` rewrites the
+    /// DSL alias spelling (e.g. `aes256`) to the AWS API canonical
+    /// (`AES256`) before the apply path forwards it to S3. Without
+    /// aliases the literal alias string flows on the wire and
+    /// `PutBucketEncryption` returns `MalformedXML`. See
+    /// `carina-rs/carina-provider-aws#390`.
+    #[test]
+    fn s3_sse_algorithm_has_dsl_aliases() {
+        let sse = super::s3_sse_algorithm();
+        if let carina_core::schema::Shape::StringEnum {
+            name,
+            values,
+            identity,
+            dsl_aliases,
+        } = sse.shape(carina_core::schema::empty_defs())
+        {
+            assert_eq!(name, "SseAlgorithm");
+            assert_eq!(
+                values,
+                &[
+                    "AES256".to_string(),
+                    "aws:kms".to_string(),
+                    "aws:kms:dsse".to_string(),
+                ]
+            );
+            assert_eq!(
+                identity.and_then(|id| id.dotted_prefix()),
+                Some("aws.s3.BucketServerSideEncryptionConfiguration".to_string())
+            );
+            // `dsl_enum_value` passes `aws:kms` / `aws:kms:dsse` through
+            // unchanged: the colon is not in its known-separators set,
+            // so identity pairs are emitted for those rows. The
+            // load-bearing case for #390 is the `AES256 → aes256`
+            // rewrite; identity rows are present so the strict-DSL
+            // validator (carina#2980) treats the variant set uniformly.
+            assert_eq!(
+                dsl_aliases,
+                &[
+                    ("AES256".to_string(), "aes256".to_string()),
+                    ("aws:kms".to_string(), "aws:kms".to_string()),
+                    ("aws:kms:dsse".to_string(), "aws:kms:dsse".to_string()),
+                ]
+            );
+        } else {
+            panic!("expected StringEnum");
+        }
+    }
+
+    /// Sibling regression flagged in #390: the `protocol` field of
+    /// `RedirectAllRequestsTo` on `aws.s3.BucketWebsiteConfiguration`
+    /// suffers the same missing-aliases bug. Latent today (no fixture
+    /// exercises it) but the test pins the contract.
+    #[test]
+    fn s3_redirect_protocol_has_dsl_aliases() {
+        let redirect = super::s3_redirect_all_requests_to();
+        let shape = redirect.shape(carina_core::schema::empty_defs());
+        let carina_core::schema::Shape::Struct { fields, .. } = shape else {
+            panic!("expected Struct shape");
+        };
+        let protocol = fields
+            .iter()
+            .find(|f| f.name == "protocol")
+            .expect("RedirectAllRequestsTo must have a `protocol` field")
+            .field_type
+            .clone();
+        let carina_core::schema::Shape::StringEnum {
+            name, dsl_aliases, ..
+        } = protocol.shape(carina_core::schema::empty_defs())
+        else {
+            panic!("expected protocol to be a StringEnum");
+        };
+        assert_eq!(name, "Protocol");
+        assert_eq!(
+            dsl_aliases,
+            &[
+                ("http".to_string(), "http".to_string()),
+                ("https".to_string(), "https".to_string()),
+            ]
+        );
     }
 }

--- a/scripts/check-string-enum-aliases.sh
+++ b/scripts/check-string-enum-aliases.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Guard against the `carina-rs/carina-provider-aws#390` bug class:
+# hand-written `AttributeType::string_enum(...)` calls in
+# `carina-aws-types/src/lib.rs` that ship with an empty `dsl_aliases`
+# argument (`vec![]`).
+#
+# `AwsNormalizer::api_canonicalize_recursive` relies on the alias table
+# to rewrite DSL spellings (e.g. `aes256`) to the AWS API canonical
+# (`AES256`) before the wire call. A StringEnum whose alias table is
+# empty silently forwards the raw alias spelling to the AWS SDK and
+# triggers `MalformedXML` / `Unknown(...)` errors at apply time —
+# unit tests pass, acceptance tests fail against real AWS.
+#
+# The fix is to construct hand-written StringEnums via the
+# `string_enum_with_dsl_aliases(name, values, identity)` helper in
+# `carina-aws-types/src/lib.rs`, which derives the alias table from
+# `values` so "empty by accident" is impossible by construction.
+#
+# Why this script exists at all: the helper is a *convention*, not a
+# type-system gate — the underlying `AttributeType::string_enum`
+# constructor in carina-core still accepts an empty alias vec. This
+# script enforces the convention at CI time. See the PR that closes
+# #390 for the full reasoning.
+#
+# The script only checks `carina-aws-types/src/lib.rs`. The two
+# string_enum sites outside that file (`factory.rs` region,
+# `schemas/types.rs` cloudfront_hosted_zone_id) are explicitly
+# reviewed: region builds non-empty aliases dynamically, and
+# cloudfront_hosted_zone_id uses a single hand-curated alias
+# (`Z2FDTNDATAQYW2 → global`) that the derivation rule cannot produce.
+#
+# Exit 0 = OK, non-zero = found a problem (message explains the fix).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="$REPO_ROOT/carina-aws-types/src/lib.rs"
+
+if [ ! -f "$TARGET" ]; then
+    echo "check-string-enum-aliases: ERROR: $TARGET not found" >&2
+    exit 2
+fi
+
+# Allow-list: line ranges in $TARGET where a raw `AttributeType::string_enum`
+# call with `vec![]` or a dynamic alias source is intentional.
+#
+# Currently:
+#   - `condition_type` (IAM condition operator map key): builds a
+#     dynamic alias table from `all_condition_operator_snake_forms()` /
+#     `dsl_enum_value` and may emit an empty filtered vec. The site
+#     uses the raw constructor because the alias source is not the
+#     `values` slice.
+#
+# Add new exceptions sparingly. Each one is a bug-class admission.
+#
+# The pattern is anchored with `\(` so sibling names like
+# `fn condition_type_v2` / `fn condition_type_helper` do NOT inherit the
+# exception by accident.
+ALLOWLIST_PATTERN='fn condition_type\('
+
+# Find every `AttributeType::string_enum(` call in $TARGET and report any
+# whose closing `)` appears with `vec![]` as the last positional arg.
+#
+# Approach: pull out the rough 12-line window starting at each
+# `AttributeType::string_enum(` line, then look for the `vec![],?\s*\)`
+# closing shape. Cross-check against the allow-list by walking up to
+# the nearest `fn <name>(` declaration above the call.
+
+violations=0
+report=""
+
+while IFS=: read -r lineno _; do
+    [ -z "$lineno" ] && continue
+
+    # Window: 15 lines starting at the call site is enough for every
+    # current call in this file (longest is `s3_transition_storage_class`,
+    # 11 lines). The 4-line headroom absorbs future enums with one or two
+    # extra values without needing to revisit this script.
+    window=$(sed -n "${lineno},$((lineno + 14))p" "$TARGET")
+
+    # The call must close within the window. Reconstruct the body of
+    # the `string_enum(...)` call by joining lines until the paren
+    # depth that opened at the `string_enum(` returns to zero, then
+    # inspect the joined body. This catches both multi-line layouts
+    # (where `vec![]` sits on its own line) AND single-line layouts
+    # (where rustfmt collapses the call onto one line) — round-4
+    # review flagged the single-line case as a prior false-negative.
+    #
+    # An "empty-aliases" call is one whose **last positional argument**
+    # — the substring after the final top-level `,` and before the
+    # closing `)` — is exactly `vec![]`. The depth tracker is needed
+    # to ignore commas / closing parens inside nested calls like
+    # `string_enum_identity("X", Some("Y"))`.
+    if printf '%s\n' "$window" | awk '
+        BEGIN { depth = 0; body = ""; found_close = 0; started = 0 }
+        {
+            line = $0
+            # On the first line of the window, skip past anything
+            # before the literal `AttributeType::string_enum(` so we
+            # start paren tracking at the right `(`. Without this, a
+            # call inlined into a `fn name() -> AttributeType { ... }`
+            # body would trip the `(` of the fn header first.
+            if (!started) {
+                pos = index(line, "AttributeType::string_enum(")
+                if (pos == 0) next
+                line = substr(line, pos + length("AttributeType::string_enum"))
+                started = 1
+            }
+            for (i = 1; i <= length(line); i++) {
+                c = substr(line, i, 1)
+                if (c == "(") {
+                    depth++
+                    if (depth == 1) {
+                        # Skip the opening `(` itself in the body.
+                        continue
+                    }
+                } else if (c == ")") {
+                    if (depth == 1) {
+                        found_close = 1
+                        # Body now holds the args of the `string_enum`
+                        # call. The last positional arg is whatever
+                        # comes after the final top-level `,` once
+                        # any trailing-comma + whitespace is stripped.
+                        # See END block.
+                        exit 0
+                    }
+                    depth--
+                }
+                if (depth >= 1) {
+                    body = body c
+                }
+            }
+            body = body " "  # newline → space
+        }
+        END {
+            if (!found_close) exit 1
+            # Strip trailing whitespace.
+            sub(/[ \t]+$/, "", body)
+            # Strip a single trailing top-level comma (rustfmt always
+            # emits one on multi-line calls).
+            sub(/,$/, "", body)
+            sub(/[ \t]+$/, "", body)
+            # If the body now ends with `vec![]`, the last positional
+            # argument was empty-aliases. We do not need to find the
+            # exact last comma position: nested calls like
+            # `dsl_aliases_for(&[...])` end with `)`, and
+            # `string_enum_identity(...)` ends with `))`, so an
+            # endswith-`vec![]` check is sufficient for any current
+            # carina-aws-types StringEnum signature.
+            if (length(body) >= 6 && substr(body, length(body) - 5) == "vec![]") {
+                exit 0
+            }
+            exit 1
+        }
+    '; then
+        # Walk back to find the enclosing `fn <name>(` to check the
+        # allow-list. Look at the 100 lines before the call site.
+        ctx_start=$((lineno > 100 ? lineno - 100 : 1))
+        enclosing_fn=$(sed -n "${ctx_start},${lineno}p" "$TARGET" |
+            grep -E '^(pub )?fn [a-z_][a-z0-9_]*' |
+            tail -1)
+        if printf '%s' "$enclosing_fn" | grep -qE "$ALLOWLIST_PATTERN"; then
+            continue
+        fi
+        violations=$((violations + 1))
+        report+="  $TARGET:$lineno (in ${enclosing_fn:-<unknown fn>})"$'\n'
+    fi
+done < <(grep -n 'AttributeType::string_enum(' "$TARGET")
+
+if [ "$violations" -gt 0 ]; then
+    echo "check-string-enum-aliases: FAIL: found $violations call site(s) with empty dsl_aliases:" >&2
+    printf '%s' "$report" >&2
+    echo "" >&2
+    echo "Use string_enum_with_dsl_aliases(name, values, identity) instead." >&2
+    echo "It derives the alias table from values via dsl_aliases_for, making" >&2
+    echo "the carina-rs/carina-provider-aws#390 bug class impossible by construction." >&2
+    echo "If the call really needs a dynamic alias source, add it to the" >&2
+    echo "ALLOWLIST_PATTERN in this script with a short justification." >&2
+    exit 1
+fi
+
+echo "check-string-enum-aliases OK: 0 hand-written StringEnums in carina-aws-types with empty dsl_aliases."


### PR DESCRIPTION
## Summary

- Adds `string_enum_with_dsl_aliases(name, values, identity)` helper in `carina-aws-types/src/lib.rs`; routes all 10 hand-written `StringEnum` sites in that file through it (2 bug fixes + 8 byte-identical refactors). The only remaining raw constructor call is `condition_type` (dynamic alias source).
- Fixes acceptance test `s3_bucket_server_side_encryption_configuration/basic.crn`: `sse_algorithm: "aes256"` → `"AES256"` on the wire; `PutBucketEncryption` no longer returns `MalformedXML`. Latent sibling fix on `RedirectAllRequestsTo.protocol`.
- New `scripts/check-string-enum-aliases.sh` + `string-enum-aliases` CI job enforce the convention so the bug class cannot recur.
- Adds 2 regression tests pinning the alias tables.

## Root-cause framing

The naive fix is "add `dsl_aliases_for(&[...])` to the two bug sites." That works today but the same future-caller-tomorrow trap stays open: any new hand-written `StringEnum` in this file can forget the alias arg and silently break `apply` at runtime (unit tests pass, acceptance tests fail). Per `CLAUDE.md` "Long-term view alongside root-cause", the helper is the factoring tool: `values` is the single source of truth, and "StringEnum without aliases" is unreachable through it by construction.

`carina-core::AttributeType::string_enum` itself still permits an empty alias vec (changing it would cascade to ~162 codegen-emitted sites for zero gain). The CI lint script closes the residual gap: it greps the one file where hand-written sites live, joins each call's multi-line body via paren-depth tracking, and fails if the last positional argument is literally `vec![]`. Verified to catch both rustfmt-collapsed single-line and multi-line bug shapes; verified that sibling function names (`condition_type_v2`, `condition_type_helper`) do not inherit the allow-list exception.

## Test plan

- [x] `cargo nextest run --workspace` — 460/460 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --workspace --doc` passes
- [x] `scripts/check-carina-pin.sh` passes
- [x] `scripts/check-string-enum-aliases.sh` passes; verified catches injected inline + multi-line bugs and rejects sibling-fn-name allow-list bypass
- [x] End-to-end against real AWS (carina-test-001): `apply` succeeds with plan rendering `sse_algorithm: "AES256"`; `destroy` succeeds and is idempotent
- [x] Cross-repo sibling check: `carina-provider-awscc/carina-aws-types/src/lib.rs` has 3 `AttributeType::string_enum` sites, all correct — no sibling bug

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)