### PR TITLE
docs: replace git wt with standard git worktree commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,12 +67,10 @@ cargo run -p carina-codegen-aws -- <smithy-model-path>
 
 ### Worktree-Based Development
 
-**IMPORTANT: Use `git wt` (NOT `git worktree`).** `git wt` is a separate tool with its own syntax.
-
 ```bash
-git wt <branch-name> main    # Create worktree
-git wt                       # List worktrees
-git wt -d <branch-name>      # Delete worktree (from main worktree)
+git worktree add .worktrees/<branch-name> -b <branch-name> main   # Create worktree
+git worktree list                                                  # List worktrees
+git worktree remove .worktrees/<branch-name>                       # Delete worktree (from the main worktree)
 ```
 
 ### Submodule Initialization

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -61,7 +61,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # `carina` host binary live next to *this* repo in a flat carina-rs
 # checkout. We resolve their base by walking up from the repo's
 # canonical git directory rather than from `$PROJECT_ROOT/..`, because
-# when the script is invoked from a `git wt` worktree under
+# when the script is invoked from a `git worktree` worktree under
 # `.worktrees/`, the parent of `$PROJECT_ROOT` is the `.worktrees/`
 # directory — not the carina-rs root (carina-rs/carina-provider-aws#360).
 #

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -15,7 +15,7 @@ fi
 PROJECT_ROOT="$(cd "$HELPERS_DIR/../.." && pwd)"
 
 # See run-tests.sh for the rationale: `$PROJECT_ROOT/..` breaks when
-# the script is invoked from a `git wt` worktree
+# the script is invoked from a `git worktree` worktree
 # (carina-rs/carina-provider-aws#360). Resolve the carina-rs sibling
 # base via the canonical .git directory so worktree and main checkouts
 # both produce the same path.


### PR DESCRIPTION
## Summary

`git wt` is a local-only wrapper tool that has been dropped repo-wide in favor of the standard `git worktree` commands. This updates the documentation and comments to use the standard commands. The worktree-based development *workflow* itself is unchanged — only the command spellings change.

Follows carina#3361.

## Changes

- **`CLAUDE.md`** — rewrite the "Worktree-Based Development" section to use `git worktree add/list/remove` and drop the `git wt`-specific IMPORTANT line.
- **`acceptance-tests/run-tests.sh`** — comment: `git wt` worktree → `git worktree` worktree.
- **`acceptance-tests/shared/_helpers.sh`** — comment: `git wt` worktree → `git worktree` worktree.

Docs/scripts-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)