### PR TITLE
docs(scripts): use git worktree in pre-commit branch hint

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -9,7 +9,7 @@
 current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
 if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
     echo "ERROR: Direct commits to '$current_branch' are not allowed."
-    echo "Create a feature branch first: git wt <branch-name> main"
+    echo "Create a feature branch first: git worktree add .worktrees/<branch-name> -b <branch-name> main"
     exit 1
 fi
 


### PR DESCRIPTION
The `scripts/pre-commit` branch-protection hint pointed users at
`git wt <branch-name> main`, which relies on a local `git wt` alias
that is not defined by default. Replace it with the explicit
`git worktree add .worktrees/<branch-name> -b <branch-name> main`
command so the hint works out of the box.

This mirrors the same change in the carina repo (#3361/#3362).

🤖 Generated with [Claude Code](https://claude.com/claude-code)