### PR TITLE
feat: schema-bound type-ref projection, bump carina-core (carina#3371 PR2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=730f705473eba4985f9b067b8f71552be42f61c3#730f705473eba4985f9b067b8f71552be42f61c3"
+source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
 dependencies = [
  "argon2",
  "futures",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=730f705473eba4985f9b067b8f71552be42f61c3#730f705473eba4985f9b067b8f71552be42f61c3"
+source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=730f705473eba4985f9b067b8f71552be42f61c3#730f705473eba4985f9b067b8f71552be42f61c3"
+source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "730f705473eba4985f9b067b8f71552be42f61c3" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -2525,7 +2525,7 @@ mod tests {
             length,
             to_dsl: None,
             ..
-        } = t.shape(carina_core::schema::empty_defs())
+        } = t.shape_ref_free().expect("test schema is Ref-free")
         {
             assert_eq!(
                 identity.map(|id| id.to_string()).as_deref(),
@@ -2546,7 +2546,7 @@ mod tests {
             pattern,
             to_dsl: None,
             ..
-        } = t.shape(carina_core::schema::empty_defs())
+        } = t.shape_ref_free().expect("test schema is Ref-free")
         {
             assert_eq!(
                 identity.map(|id| id.to_string()).as_deref(),
@@ -3593,11 +3593,14 @@ mod tests {
         // `_if_exists` suffixed, and the combination — so that `validate` does
         // not reject inputs that the conversion layer already handles.
         let cond = condition_type();
-        let defs = carina_core::schema::empty_defs();
-        let carina_core::schema::Shape::Map { key, .. } = cond.shape(defs) else {
+        let carina_core::schema::Shape::Map { key, .. } =
+            cond.shape_ref_free().expect("test schema is Ref-free")
+        else {
             panic!("condition_type() should be a Map");
         };
-        let carina_core::schema::Shape::StringEnum { values, .. } = key.shape(defs) else {
+        let carina_core::schema::Shape::StringEnum { values, .. } =
+            key.shape_ref_free().expect("test schema is Ref-free")
+        else {
             panic!("condition_type() key should be a StringEnum");
         };
         for expected in [
@@ -3826,7 +3829,7 @@ mod tests {
             values,
             identity,
             dsl_aliases,
-        } = effect.shape(carina_core::schema::empty_defs())
+        } = effect.shape_ref_free().expect("test schema is Ref-free")
         {
             assert_eq!(name, "Effect");
             assert_eq!(values, &["Allow".to_string(), "Deny".to_string()]);
@@ -3854,7 +3857,7 @@ mod tests {
             values,
             identity,
             dsl_aliases,
-        } = version.shape(carina_core::schema::empty_defs())
+        } = version.shape_ref_free().expect("test schema is Ref-free")
         {
             assert_eq!(name, "Version");
             assert_eq!(
@@ -3892,7 +3895,7 @@ mod tests {
             values,
             identity,
             dsl_aliases,
-        } = sse.shape(carina_core::schema::empty_defs())
+        } = sse.shape_ref_free().expect("test schema is Ref-free")
         {
             assert_eq!(name, "SseAlgorithm");
             assert_eq!(
@@ -3933,7 +3936,7 @@ mod tests {
     #[test]
     fn s3_redirect_protocol_has_dsl_aliases() {
         let redirect = super::s3_redirect_all_requests_to();
-        let shape = redirect.shape(carina_core::schema::empty_defs());
+        let shape = redirect.shape_ref_free().expect("test schema is Ref-free");
         let carina_core::schema::Shape::Struct { fields, .. } = shape else {
             panic!("expected Struct shape");
         };
@@ -3945,7 +3948,7 @@ mod tests {
             .clone();
         let carina_core::schema::Shape::StringEnum {
             name, dsl_aliases, ..
-        } = protocol.shape(carina_core::schema::empty_defs())
+        } = protocol.shape_ref_free().expect("test schema is Ref-free")
         else {
             panic!("expected protocol to be a StringEnum");
         };

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "730f705473eba4985f9b067b8f71552be42f61c3" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "730f705473eba4985f9b067b8f71552be42f61c3" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "730f705473eba4985f9b067b8f71552be42f61c3" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 
 use carina_core::provider::{self, BoxFuture, ProviderNormalizer, SavedAttrs, ready_noop};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
-use carina_core::schema::{AttributeType, SchemaRegistry};
+use carina_core::schema::{AttributeType, ResourceSchema, SchemaRegistry};
 
 /// Schema extension for the AWS provider.
 ///
@@ -100,7 +100,8 @@ pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
                 carina_core::utils::resolve_enum_value_recursive(value, &attr_schema.attr_type);
             // Pass 2: DSL spelling → API canonical at every nested enum position.
             let base = after_dsl.as_ref().unwrap_or(value);
-            let after_api = api_canonicalize_recursive(base, &attr_schema.attr_type);
+            let after_api =
+                api_canonicalize_recursive(base, &attr_schema.attr_type, &config.schema);
 
             match (after_dsl, after_api) {
                 (_, Some(v)) => {
@@ -134,7 +135,11 @@ pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
 /// Returns `None` when nothing was rewritten, mirroring the
 /// `resolve_enum_value_recursive` contract so callers can compose the
 /// two passes without redundant clones.
-fn api_canonicalize_recursive(value: &Value, attr_type: &AttributeType) -> Option<Value> {
+fn api_canonicalize_recursive(
+    value: &Value,
+    attr_type: &AttributeType,
+    schema: &ResourceSchema,
+) -> Option<Value> {
     // Leaf: StringEnum (with or without namespace). We canonicalize via
     // the alias table regardless of whether the input was namespaced —
     // `extract_enum_value_with_values` handles both shapes (including
@@ -167,8 +172,8 @@ fn api_canonicalize_recursive(value: &Value, attr_type: &AttributeType) -> Optio
         return Some(Value::Concrete(ConcreteValue::String(api)));
     }
 
-    use carina_core::schema::{Shape, empty_defs};
-    match attr_type.shape(empty_defs()) {
+    use carina_core::schema::Shape;
+    match schema.shape_of(attr_type) {
         Shape::Struct { fields, .. } => {
             let Value::Concrete(ConcreteValue::Map(map)) = value else {
                 return None;
@@ -178,7 +183,7 @@ fn api_canonicalize_recursive(value: &Value, attr_type: &AttributeType) -> Optio
             for field in fields {
                 if let Some(field_value) = map.get(&field.name)
                     && let Some(new_field) =
-                        api_canonicalize_recursive(field_value, &field.field_type)
+                        api_canonicalize_recursive(field_value, &field.field_type, schema)
                 {
                     rewritten.insert(field.name.clone(), new_field);
                     changed = true;
@@ -193,7 +198,7 @@ fn api_canonicalize_recursive(value: &Value, attr_type: &AttributeType) -> Optio
             let mut rewritten = items.clone();
             let mut changed = false;
             for (i, item) in items.iter().enumerate() {
-                if let Some(new_item) = api_canonicalize_recursive(item, inner) {
+                if let Some(new_item) = api_canonicalize_recursive(item, inner, schema) {
                     rewritten[i] = new_item;
                     changed = true;
                 }
@@ -253,7 +258,7 @@ fn api_canonicalize_recursive(value: &Value, attr_type: &AttributeType) -> Optio
                     }
                     ck
                 };
-                let new_v = match api_canonicalize_recursive(v, inner) {
+                let new_v = match api_canonicalize_recursive(v, inner, schema) {
                     Some(nv) => {
                         changed = true;
                         nv
@@ -304,9 +309,8 @@ pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMa
                 }
             }
             // Normalize enum fields within struct (Map) values
-            if let carina_core::schema::Shape::Struct { fields, .. } = attr_schema
-                .attr_type
-                .shape(carina_core::schema::empty_defs())
+            if let carina_core::schema::Shape::Struct { fields, .. } =
+                config.schema.shape_of(&attr_schema.attr_type)
                 && let Value::Concrete(ConcreteValue::Map(map_fields)) = value
             {
                 let mut normalized_map = map_fields.clone();

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -400,7 +400,7 @@ mod tests {
         // structured identity via `dotted_prefix()`.
         let az_type = availability_zone();
         if let carina_core::schema::Shape::CustomEnum { identity, .. } =
-            az_type.shape(carina_core::schema::empty_defs())
+            az_type.shape_ref_free().expect("test schema is Ref-free")
         {
             assert_eq!(
                 identity.dotted_prefix().as_deref(),
@@ -415,7 +415,7 @@ mod tests {
     fn az_has_to_dsl() {
         let az_type = availability_zone();
         if let carina_core::schema::Shape::CustomEnum { to_dsl, .. } =
-            az_type.shape(carina_core::schema::empty_defs())
+            az_type.shape_ref_free().expect("test schema is Ref-free")
         {
             assert!(to_dsl.is_some());
             let convert = to_dsl.unwrap();

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -471,9 +471,11 @@ fn dsl_value_to_iam_json(
         }
     }
 
-    use carina_core::schema::{Shape, empty_defs};
-    let defs = empty_defs();
-    match attr_type.shape(defs) {
+    use carina_core::schema::Shape;
+    let Ok(shape) = attr_type.shape_ref_free() else {
+        return scalar_to_json(value);
+    };
+    match shape {
         Shape::Union(members) => {
             // Try each member; first whose *input* value-shape matches
             // wins. Gating on the input shape (not the output JSON)
@@ -483,14 +485,17 @@ fn dsl_value_to_iam_json(
             // `string_or_principal_struct`) so a Map principal is not
             // matched against the String arm.
             for member in members {
-                let value_matches_member = match member.shape(defs) {
-                    Shape::Struct { .. } => {
-                        matches!(value, Value::Concrete(ConcreteValue::Map(_)))
-                    }
-                    Shape::List { .. } => {
-                        matches!(value, Value::Concrete(ConcreteValue::List(_)))
-                    }
-                    _ => true,
+                let value_matches_member = match member.shape_ref_free() {
+                    Ok(shape) => match shape {
+                        Shape::Struct { .. } => {
+                            matches!(value, Value::Concrete(ConcreteValue::Map(_)))
+                        }
+                        Shape::List { .. } => {
+                            matches!(value, Value::Concrete(ConcreteValue::List(_)))
+                        }
+                        _ => true,
+                    },
+                    Err(_) => true,
                 };
                 if value_matches_member {
                     return dsl_value_to_iam_json(value, member, attr_name);

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -1453,9 +1453,8 @@ fn test_organizations_organization_schema_feature_set_enum() {
         .attributes
         .get("feature_set")
         .expect("feature_set attribute not found");
-    if let carina_core::schema::Shape::StringEnum { values, .. } = feature_set
-        .attr_type
-        .shape(carina_core::schema::empty_defs())
+    if let carina_core::schema::Shape::StringEnum { values, .. } =
+        config.schema.shape_of(&feature_set.attr_type)
     {
         assert!(values.contains(&"ALL".to_string()));
         assert!(values.contains(&"CONSOLIDATED_BILLING".to_string()));
@@ -1587,9 +1586,8 @@ fn test_security_group_egress_schema_includes_all_variant() {
         .attributes
         .get("ip_protocol")
         .expect("ip_protocol attribute not found");
-    if let carina_core::schema::Shape::StringEnum { values, .. } = ip_protocol
-        .attr_type
-        .shape(carina_core::schema::empty_defs())
+    if let carina_core::schema::Shape::StringEnum { values, .. } =
+        config.schema.shape_of(&ip_protocol.attr_type)
     {
         assert!(
             values.contains(&"all".to_string()),
@@ -1610,9 +1608,8 @@ fn test_security_group_ingress_schema_includes_all_variant() {
         .attributes
         .get("ip_protocol")
         .expect("ip_protocol attribute not found");
-    if let carina_core::schema::Shape::StringEnum { values, .. } = ip_protocol
-        .attr_type
-        .shape(carina_core::schema::empty_defs())
+    if let carina_core::schema::Shape::StringEnum { values, .. } =
+        config.schema.shape_of(&ip_protocol.attr_type)
     {
         assert!(
             values.contains(&"all".to_string()),


### PR DESCRIPTION
## Summary

PR2 of the carina#3371 chain (the carina-provider-aws side). Bumps carina-core to the PR1 merge commit and migrates every site off the deprecated type-ref API.

carina-core PR1 (carina-rs/carina#3372, merged) added `Schema::shape_of` / `ResourceSchema::shape_of` / `resolve_of` and `AttributeType::shape_ref_free() -> Result<Shape, RefEncountered>`, and deprecated `AttributeType::shape(defs)` / `resolve_refs(defs)` / `empty_defs()`. This repo's CI runs `cargo clippy -- -D warnings`, so any remaining use of the deprecated API fails CI.

## Change

- Bump `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` rev `730f705…` → `6fdcff64457a…` (the PR1 merge commit) in `carina-aws-types/Cargo.toml` and `carina-provider-aws/Cargo.toml`.
- Migrate all sites off the deprecated API. `api_canonicalize_recursive` now threads `&ResourceSchema` and uses `schema.shape_of(ty)` (so a `Ref` would resolve through the schema that owns its defs rather than panic against an empty map); `normalize_state_enums` uses `config.schema.shape_of(...)`; `carina-aws-types` / `schemas/types.rs` / `iam/role.rs` follow the same pattern.
- Post-migration grep for the deprecated API is empty.

## Verify

- `cargo check -p carina-provider-aws -p carina-aws-types` — clean
- `cargo nextest run --workspace` — 462 passed, 0 skipped
- `cargo clippy --all-targets -- -D warnings` — clean (no deprecated use)
- `cargo fmt --check` — clean
- `scripts/check-carina-pin.sh` (4 pins consistent) / `check-examples.sh` / `check-string-enum-aliases.sh` — OK

## Scope

PR2 of the carina#3371 chain. Depends on PR1 (merged). Independent of the awscc PR3. `Refs carina-rs/carina#3371`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
