### PR TITLE
chore: bump carina-core to post-shim-removal rev (carina#3371 PR4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
+source = "git+https://github.com/carina-rs/carina?rev=0d7cd724af787cd28dcf8838f8941f0bca68c230#0d7cd724af787cd28dcf8838f8941f0bca68c230"
 dependencies = [
  "argon2",
  "futures",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
+source = "git+https://github.com/carina-rs/carina?rev=0d7cd724af787cd28dcf8838f8941f0bca68c230#0d7cd724af787cd28dcf8838f8941f0bca68c230"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -891,7 +891,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
+source = "git+https://github.com/carina-rs/carina?rev=0d7cd724af787cd28dcf8838f8941f0bca68c230#0d7cd724af787cd28dcf8838f8941f0bca68c230"
 dependencies = [
  "serde",
  "serde_json",
@@ -2035,7 +2035,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2300,7 +2300,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0d7cd724af787cd28dcf8838f8941f0bca68c230" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0d7cd724af787cd28dcf8838f8941f0bca68c230" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0d7cd724af787cd28dcf8838f8941f0bca68c230" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0d7cd724af787cd28dcf8838f8941f0bca68c230" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

Bump carina-core to the carina#3371 PR4 merge commit (`0d7cd724af787cd`), which **removed** the deprecated `shape(defs)` / `resolve_refs(defs)` / `empty_defs()` shims.

This repo already migrated to the new `shape_of` / `resolve_of` / `shape_ref_free` API (the type-ref projection PR), so it compiles clean against the shim-free rev. This bump completes the seal: the deprecated foot-gun is now absent from this repo's dependency too.

## Verify

- `cargo check` — clean
- `cargo nextest run` — all tests pass
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `scripts/check-carina-pin.sh` — all 4 pins on the new rev

Refs carina-rs/carina#3371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
