### PR TITLE
refactor(types): rename pre-namespacing IAM/SQS struct type names (carina#3385)

### DIFF
--- a/acceptance-tests/ec2_flow_log/basic.crn
+++ b/acceptance-tests/ec2_flow_log/basic.crn
@@ -30,7 +30,7 @@ let flow_log_role = aws.iam.Role {
   assume_role_policy_document = {
     version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.IamPolicyStatement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/iam_role/basic.crn
+++ b/acceptance-tests/iam_role/basic.crn
@@ -11,7 +11,7 @@ aws.iam.Role {
   assume_role_policy_document = {
     version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.IamPolicyStatement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
       principal = {
         service = 'ec2.amazonaws.com'
       }

--- a/acceptance-tests/s3_bucket_notification_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_notification_configuration/basic.crn
@@ -20,7 +20,7 @@ let queue = aws.sqs.Queue {
     statement = [
       {
         sid = 'AllowS3SendMessage'
-        effect = aws.iam.PolicyDocument.IamPolicyStatement.Effect.allow
+        effect = aws.iam.PolicyDocument.Statement.Effect.allow
         principal = {
           service = ['s3.amazonaws.com']
         }

--- a/acceptance-tests/s3_bucket_policy/basic.crn
+++ b/acceptance-tests/s3_bucket_policy/basic.crn
@@ -19,7 +19,7 @@ aws.s3.BucketPolicy {
     version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
       sid    = 'DenyInsecureTransport'
-      effect = aws.iam.PolicyDocument.IamPolicyStatement.Effect.deny
+      effect = aws.iam.PolicyDocument.Statement.Effect.deny
       principal = {
         aws = '*'
       }

--- a/acceptance-tests/s3_bucket_replication_configuration/basic.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/basic.crn
@@ -32,7 +32,7 @@ let role = aws.iam.Role {
   assume_role_policy_document = {
     version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.IamPolicyStatement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
       principal = {
         service = 's3.amazonaws.com'
       }

--- a/acceptance-tests/s3_bucket_replication_configuration/with_filter.crn
+++ b/acceptance-tests/s3_bucket_replication_configuration/with_filter.crn
@@ -32,7 +32,7 @@ let role = aws.iam.Role {
   assume_role_policy_document = {
     version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.IamPolicyStatement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
       principal = {
         service = 's3.amazonaws.com'
       }

--- a/acceptance-tests/sqs_queue/basic.crn
+++ b/acceptance-tests/sqs_queue/basic.crn
@@ -21,7 +21,7 @@ aws.sqs.Queue {
     statement = [
       {
         sid    = 'AllowSelf'
-        effect = aws.iam.PolicyDocument.IamPolicyStatement.Effect.allow
+        effect = aws.iam.PolicyDocument.Statement.Effect.allow
         principal = {
           aws = ['*']
         }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1325,7 +1325,7 @@ fn string_or_principal_struct() -> AttributeType {
     // Value::Map against String incorrectly.
     AttributeType::union(vec![
         AttributeType::struct_(
-            "IamPolicyPrincipal".to_string(),
+            "Principal".to_string(),
             vec![
                 StructField::new("service", string_or_list_of_strings())
                     .with_provider_name("Service"),
@@ -1345,7 +1345,7 @@ fn string_or_principal_struct() -> AttributeType {
 /// `effect = allow` as a bare identifier — matching the bare-identifier
 /// convention used by every other enum field in the same `.crn` file.
 /// The namespace also makes the fully-qualified form
-/// `aws.iam.PolicyDocument.IamPolicyStatement.Effect.allow` parse and
+/// `aws.iam.PolicyDocument.Statement.Effect.allow` parse and
 /// resolve: the resolver's canonical shape is
 /// `<namespace>.<type_name>.<value>`, so `type_name` is the trailing
 /// `Effect` segment and `namespace` carries the containing structs.
@@ -1355,7 +1355,7 @@ fn iam_policy_effect() -> AttributeType {
         &["Allow", "Deny"],
         Some(carina_core::schema::string_enum_identity(
             "Effect",
-            Some("aws.iam.PolicyDocument.IamPolicyStatement"),
+            Some("aws.iam.PolicyDocument.Statement"),
         )),
     )
 }
@@ -1415,7 +1415,7 @@ fn condition_type() -> AttributeType {
 /// IAM Policy Statement struct type
 fn iam_policy_statement() -> AttributeType {
     AttributeType::struct_(
-        "IamPolicyStatement".to_string(),
+        "Statement".to_string(),
         vec![
             StructField::new("sid", AttributeType::string()).with_provider_name("Sid"),
             StructField::new("effect", iam_policy_effect()).with_provider_name("Effect"),
@@ -1443,7 +1443,7 @@ fn iam_policy_statement() -> AttributeType {
 /// (e.g., `version` <-> `Version`, `statement` <-> `Statement`).
 pub fn iam_policy_document() -> AttributeType {
     AttributeType::struct_(
-        "IamPolicyDocument".to_string(),
+        "PolicyDocument".to_string(),
         vec![
             StructField::new("version", iam_policy_version()).with_provider_name("Version"),
             StructField::new("id", AttributeType::string()).with_provider_name("Id"),
@@ -1461,7 +1461,7 @@ pub fn iam_policy_document() -> AttributeType {
 /// reusing `iam_policy_document()`.
 pub fn sqs_redrive_policy() -> AttributeType {
     AttributeType::struct_(
-        "SqsRedrivePolicy".to_string(),
+        "RedrivePolicy".to_string(),
         vec![
             StructField::new("dead_letter_target_arn", arn())
                 .with_provider_name("deadLetterTargetArn")
@@ -1482,7 +1482,7 @@ fn sqs_redrive_permission() -> AttributeType {
         &["allowAll", "denyAll", "byQueue"],
         Some(carina_core::schema::string_enum_identity(
             "RedrivePermission",
-            Some("aws.sqs.Queue.SqsRedriveAllowPolicy"),
+            Some("aws.sqs.Queue.RedriveAllowPolicy"),
         )),
     )
 }
@@ -1493,7 +1493,7 @@ fn sqs_redrive_permission() -> AttributeType {
 /// not a generic IAM statement list.
 pub fn sqs_redrive_allow_policy() -> AttributeType {
     AttributeType::struct_(
-        "SqsRedriveAllowPolicy".to_string(),
+        "RedriveAllowPolicy".to_string(),
         vec![
             StructField::new("redrive_permission", sqs_redrive_permission())
                 .with_provider_name("redrivePermission")
@@ -2538,6 +2538,24 @@ mod tests {
         inner
     }
 
+    fn struct_name(attr: &AttributeType) -> &str {
+        let carina_core::schema::Shape::Struct { name, .. } =
+            attr.shape_ref_free().expect("test schema is Ref-free")
+        else {
+            panic!("expected Struct shape");
+        };
+        name
+    }
+
+    fn union_member(attr: &AttributeType, index: usize) -> &AttributeType {
+        let carina_core::schema::Shape::Union(members) =
+            attr.shape_ref_free().expect("test schema is Ref-free")
+        else {
+            panic!("expected Union shape");
+        };
+        &members[index]
+    }
+
     fn string_enum_identity(attr: &AttributeType) -> String {
         let carina_core::schema::Shape::StringEnum {
             identity: Some(identity),
@@ -2547,6 +2565,30 @@ mod tests {
             panic!("expected StringEnum shape with identity");
         };
         identity.to_string()
+    }
+
+    #[test]
+    fn iam_policy_document_struct_names_are_plain_and_effect_identity_is_structural() {
+        let policy_document = iam_policy_document();
+        let policy_statement = list_inner(field_type(&policy_document, "statement"));
+        let principal = union_member(field_type(policy_statement, "principal"), 0);
+
+        assert_eq!(struct_name(&policy_document), "PolicyDocument");
+        assert_eq!(struct_name(policy_statement), "Statement");
+        assert_eq!(struct_name(principal), "Principal");
+        assert_eq!(
+            string_enum_identity(&iam_policy_effect()),
+            "aws.iam.PolicyDocument.Statement.Effect"
+        );
+    }
+
+    #[test]
+    fn sqs_redrive_policy_struct_names_are_plain() {
+        assert_eq!(struct_name(&sqs_redrive_policy()), "RedrivePolicy");
+        assert_eq!(
+            struct_name(&sqs_redrive_allow_policy()),
+            "RedriveAllowPolicy"
+        );
     }
 
     #[test]
@@ -2627,7 +2669,7 @@ mod tests {
         let expected = vec![
             (
                 "iam_policy_effect",
-                "aws.iam.PolicyDocument.IamPolicyStatement.Effect".to_string(),
+                "aws.iam.PolicyDocument.Statement.Effect".to_string(),
             ),
             (
                 "iam_policy_version",
@@ -2635,7 +2677,7 @@ mod tests {
             ),
             (
                 "sqs_redrive_permission",
-                "aws.sqs.Queue.SqsRedriveAllowPolicy.RedrivePermission".to_string(),
+                "aws.sqs.Queue.RedriveAllowPolicy.RedrivePermission".to_string(),
             ),
             (
                 "s3_sse_algorithm",
@@ -3998,7 +4040,7 @@ mod tests {
             assert_eq!(values, &["Allow".to_string(), "Deny".to_string()]);
             assert_eq!(
                 identity.and_then(|id| id.dotted_prefix()),
-                Some("aws.iam.PolicyDocument.IamPolicyStatement".to_string())
+                Some("aws.iam.PolicyDocument.Statement".to_string())
             );
             assert_eq!(
                 dsl_aliases,

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -3725,7 +3725,7 @@ fn type_code_to_display(type_code: &str) -> String {
         s if s.contains("iam_role_arn") => "IamRoleArn".to_string(),
         s if s.contains("iam_role_id") => "IamRoleId".to_string(),
         s if s.contains("iam_policy_arn") => "IamPolicyArn".to_string(),
-        s if s.contains("iam_policy_document") => "IamPolicyDocument".to_string(),
+        s if s.contains("iam_policy_document") => "PolicyDocument".to_string(),
         s if s.contains("kms_key_arn") => "KmsKeyArn".to_string(),
         s if s.contains("kms_key_id") => "KmsKeyId".to_string(),
         s if s.contains("vpc_id") => "VpcId".to_string(),

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -1021,7 +1021,7 @@ mod tests {
         // `string_equals` is the StringEnum value.
         let mut condition = IndexMap::new();
         condition.insert(
-            "aws.iam.IamPolicyStatement.ConditionOperator.string_equals".to_string(),
+            "aws.iam.Statement.ConditionOperator.string_equals".to_string(),
             Value::Concrete(ConcreteValue::Map(cond_body)),
         );
         let mut stmt = IndexMap::new();
@@ -1070,7 +1070,7 @@ mod tests {
             cond.keys().collect::<Vec<_>>()
         );
         assert!(
-            !cond.contains_key("aws.iam.IamPolicyStatement.ConditionOperator.string_equals"),
+            !cond.contains_key("aws.iam.Statement.ConditionOperator.string_equals"),
             "the namespaced key must not survive"
         );
     }
@@ -1099,7 +1099,7 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(m))
         };
         let bare = "string_equals";
-        let nsd = "aws.iam.IamPolicyStatement.ConditionOperator.string_equals";
+        let nsd = "aws.iam.Statement.ConditionOperator.string_equals";
 
         // Run the same malformed condition in both key orderings.
         for (first, second) in [(bare, nsd), (nsd, bare)] {

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -306,7 +306,7 @@ fn redrive_allow_policy_to_json_string(value: &Value) -> Option<String> {
         Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
         Some(Value::Concrete(ConcreteValue::EnumIdentifier(s))) => {
             // Strip any namespace prefix (e.g.
-            // aws.sqs.Queue.SqsRedriveAllowPolicy.RedrivePermission.allowAll
+            // aws.sqs.Queue.RedriveAllowPolicy.RedrivePermission.allowAll
             // -> allowAll); the enum surface is the trailing segment.
             s.rsplit('.').next().unwrap_or(s.as_str()).to_string()
         }

--- a/generated-docs/aws/iam/role.md
+++ b/generated-docs/aws/iam/role.md
@@ -12,7 +12,7 @@ Contains information about an IAM role. This structure is returned as a response
 
 ### `assume_role_policy_document`
 
-- **Type:** IamPolicyDocument
+- **Type:** PolicyDocument
 - **Required:** Yes
 
 The trust relationship policy document that grants an entity permission to assume the role. In IAM, you must provide a JSON policy that has been converted to a string. However, for CloudFormation templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to IAM. The regex pattern used to validate this parameter is a string of characters consisting of the following: Any printable ASCII character ranging from the space character (\u0020) through the end of the ASCII character range The printable characters in the Basic Latin and Latin-1 Supplement character set (through \u00FF) The special characters tab (\u0009), line feed (\u000A), and carriage return (\u000D) Upon success, the response includes the same trust policy in JSON format.


### PR DESCRIPTION
Part of carina-rs/carina#3385 (IAM PolicyDocument enum structural identity).

## Root cause

Since carina#3378, hand-written struct type names are emitted **verbatim** into
enum canonical identities (and shown in `TypeMismatch` diagnostics + generated
docs). Several IAM and SQS struct types carry redundant prefixes that duplicate
their namespace — pre-namespacing leftovers, inconsistent with every S3 struct
which uses a plain structural name (`SseByDefault`, `ReplicationDestination`,
`LifecycleRule`). The verbose names leaked into the identities:

```
aws.iam.PolicyDocument.IamPolicyStatement.Effect        (IamPolicy* dup of aws.iam.PolicyDocument)
aws.sqs.Queue.SqsRedriveAllowPolicy.RedrivePermission   (Sqs dup of aws.sqs.Queue)
```

The earlier attempt patched the identity string only; the correct root-cause fix
is to rename the struct types so the identity follows the verbatim rule naturally.

## Fix — rename the struct types

```
IamPolicyStatement    -> Statement
IamPolicyDocument     -> PolicyDocument
IamPolicyPrincipal    -> Principal
SqsRedrivePolicy      -> RedrivePolicy
SqsRedriveAllowPolicy -> RedriveAllowPolicy
```

Resulting identities:

```
aws.iam.PolicyDocument.Statement.Effect
aws.sqs.Queue.RedriveAllowPolicy.RedrivePermission
```

`Version` is a direct field of `PolicyDocument` and stays
`aws.iam.PolicyDocument.Version`.

## Changes

- `carina-aws-types/src/lib.rs`: 5 struct renames; Effect + RedrivePermission identity namespaces; struct-name tests; updated structural-identity test expectations.
- `carina-codegen-aws/src/main.rs`: `type_code_to_display` `iam_policy_document` label -> `PolicyDocument`.
- `carina-provider-aws/src/normalizer.rs`: ConditionOperator synthetic test keys.
- `carina-provider-aws/src/services/sqs/queue.rs`: enum-path code comment.
- 7 acceptance `.crn` references; `generated-docs/aws/iam/role.md` Type label.

## Verify

`cargo nextest run -p carina-aws-types` (94) + `-p carina-provider-aws` (288), doctests, `cargo clippy --workspace --all-targets -- -D warnings`, fmt — all green. Codegen Check exercises the generated output on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)