### PR TITLE
Per-resource ARN newtypes owned by resource schemas

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -9,6 +9,8 @@ use carina_core::schema::{
     AttributeType, CompletionValue, StructField, TypeIdentity, legacy_validator,
 };
 
+const PROVIDER_NAME: &str = "aws";
+
 /// Structured identity for an AWS resource-scoped custom type.
 ///
 /// `service` + `resource` become the namespace segments and `kind` the
@@ -17,8 +19,8 @@ use carina_core::schema::{
 /// the type distinct from any same-named type a future non-AWS provider
 /// might define; the service/resource axis distinguishes, say,
 /// `aws.iam.Role.Arn` from `aws.acm.Certificate.Arn`.
-fn aws_type(service: &str, resource: &str, kind: &str) -> TypeIdentity {
-    TypeIdentity::new(Some("aws"), [service, resource], kind)
+pub fn provider_type(service: &str, resource: &str, kind: &str) -> TypeIdentity {
+    TypeIdentity::new(Some(PROVIDER_NAME), [service, resource], kind)
 }
 
 /// Structured identity for an AWS custom type with no service axis.
@@ -27,8 +29,8 @@ fn aws_type(service: &str, resource: &str, kind: &str) -> TypeIdentity {
 /// single service — `aws.AvailabilityZone.ZoneId`) and for the
 /// fully-generic provider-scoped types (`aws.Arn`, `aws.ResourceId`,
 /// `aws.AccountId`), which pass an empty `segments` slice.
-fn aws_bare_type(segments: &[&str], kind: &str) -> TypeIdentity {
-    TypeIdentity::new(Some("aws"), segments.iter().copied(), kind)
+pub fn provider_bare_type(segments: &[&str], kind: &str) -> TypeIdentity {
+    TypeIdentity::new(Some(PROVIDER_NAME), segments.iter().copied(), kind)
 }
 
 // ========== Enum helpers ==========
@@ -320,7 +322,7 @@ pub fn validate_prefixed_resource_id(id: &str, expected_prefix: &str) -> Result<
 #[allow(dead_code)]
 pub fn aws_resource_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_bare_type(&[], "ResourceId")),
+        Some(provider_bare_type(&[], "ResourceId")),
         AttributeType::string(),
         Some("^[a-z-]+-[0-9a-f]{8,}$".to_string()),
         None,
@@ -339,7 +341,7 @@ pub fn aws_resource_id() -> AttributeType {
 /// VPC ID type (e.g., "vpc-1a2b3c4d")
 pub fn vpc_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "Vpc", "Id")),
+        Some(provider_type("ec2", "Vpc", "Id")),
         aws_resource_id(),
         Some("^vpc-[0-9a-f]{8,}$".to_string()),
         None,
@@ -358,7 +360,7 @@ pub fn vpc_id() -> AttributeType {
 /// Subnet ID type (e.g., "subnet-0123456789abcdef0")
 pub fn subnet_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "Subnet", "Id")),
+        Some(provider_type("ec2", "Subnet", "Id")),
         aws_resource_id(),
         Some("^subnet-[0-9a-f]{8,}$".to_string()),
         None,
@@ -377,7 +379,7 @@ pub fn subnet_id() -> AttributeType {
 /// Security Group ID type (e.g., "sg-12345678")
 pub fn security_group_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "SecurityGroup", "Id")),
+        Some(provider_type("ec2", "SecurityGroup", "Id")),
         aws_resource_id(),
         Some("^sg-[0-9a-f]{8,}$".to_string()),
         None,
@@ -396,7 +398,7 @@ pub fn security_group_id() -> AttributeType {
 /// Internet Gateway ID type (e.g., "igw-12345678")
 pub fn internet_gateway_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "InternetGateway", "Id")),
+        Some(provider_type("ec2", "InternetGateway", "Id")),
         aws_resource_id(),
         Some("^igw-[0-9a-f]{8,}$".to_string()),
         None,
@@ -415,7 +417,7 @@ pub fn internet_gateway_id() -> AttributeType {
 /// Route Table ID type (e.g., "rtb-abcdef12")
 pub fn route_table_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "RouteTable", "Id")),
+        Some(provider_type("ec2", "RouteTable", "Id")),
         aws_resource_id(),
         Some("^rtb-[0-9a-f]{8,}$".to_string()),
         None,
@@ -434,7 +436,7 @@ pub fn route_table_id() -> AttributeType {
 /// NAT Gateway ID type (e.g., "nat-12345678")
 pub fn nat_gateway_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "NatGateway", "Id")),
+        Some(provider_type("ec2", "NatGateway", "Id")),
         aws_resource_id(),
         Some("^nat-[0-9a-f]{8,}$".to_string()),
         None,
@@ -453,7 +455,7 @@ pub fn nat_gateway_id() -> AttributeType {
 /// VPC Peering Connection ID type (e.g., "pcx-12345678")
 pub fn vpc_peering_connection_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "VpcPeeringConnection", "Id")),
+        Some(provider_type("ec2", "VpcPeeringConnection", "Id")),
         aws_resource_id(),
         Some("^pcx-[0-9a-f]{8,}$".to_string()),
         None,
@@ -473,7 +475,7 @@ pub fn vpc_peering_connection_id() -> AttributeType {
 /// Transit Gateway ID type (e.g., "tgw-12345678")
 pub fn transit_gateway_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "TransitGateway", "Id")),
+        Some(provider_type("ec2", "TransitGateway", "Id")),
         aws_resource_id(),
         Some("^tgw-[0-9a-f]{8,}$".to_string()),
         None,
@@ -492,7 +494,7 @@ pub fn transit_gateway_id() -> AttributeType {
 /// VPC CIDR Block Association ID type (e.g., "vpc-cidr-assoc-12345678")
 pub fn vpc_cidr_block_association_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "VpcCidrBlockAssociation", "Id")),
+        Some(provider_type("ec2", "VpcCidrBlockAssociation", "Id")),
         aws_resource_id(),
         Some("^vpc-cidr-assoc-[0-9a-f]{8,}$".to_string()),
         None,
@@ -512,7 +514,7 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
 /// Transit Gateway Route Table ID type (e.g., "tgw-rtb-12345678")
 pub fn tgw_route_table_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "TransitGatewayRouteTable", "Id")),
+        Some(provider_type("ec2", "TransitGatewayRouteTable", "Id")),
         aws_resource_id(),
         Some("^tgw-rtb-[0-9a-f]{8,}$".to_string()),
         None,
@@ -531,7 +533,7 @@ pub fn tgw_route_table_id() -> AttributeType {
 /// VPN Gateway ID type (e.g., "vgw-12345678")
 pub fn vpn_gateway_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "VpnGateway", "Id")),
+        Some(provider_type("ec2", "VpnGateway", "Id")),
         aws_resource_id(),
         Some("^vgw-[0-9a-f]{8,}$".to_string()),
         None,
@@ -555,7 +557,7 @@ pub fn gateway_id() -> AttributeType {
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
 pub fn egress_only_internet_gateway_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "EgressOnlyInternetGateway", "Id")),
+        Some(provider_type("ec2", "EgressOnlyInternetGateway", "Id")),
         aws_resource_id(),
         Some("^eigw-[0-9a-f]{8,}$".to_string()),
         None,
@@ -578,7 +580,7 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
 /// VPC Endpoint ID type (e.g., "vpce-12345678")
 pub fn vpc_endpoint_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "VpcEndpoint", "Id")),
+        Some(provider_type("ec2", "VpcEndpoint", "Id")),
         aws_resource_id(),
         Some("^vpce-[0-9a-f]{8,}$".to_string()),
         None,
@@ -597,7 +599,7 @@ pub fn vpc_endpoint_id() -> AttributeType {
 /// Instance ID type (e.g., "i-0123456789abcdef0")
 pub fn instance_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "Instance", "Id")),
+        Some(provider_type("ec2", "Instance", "Id")),
         aws_resource_id(),
         Some("^i-[0-9a-f]{8,}$".to_string()),
         None,
@@ -616,7 +618,7 @@ pub fn instance_id() -> AttributeType {
 /// Network Interface ID type (e.g., "eni-0123456789abcdef0")
 pub fn network_interface_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "NetworkInterface", "Id")),
+        Some(provider_type("ec2", "NetworkInterface", "Id")),
         aws_resource_id(),
         Some("^eni-[0-9a-f]{8,}$".to_string()),
         None,
@@ -636,7 +638,7 @@ pub fn network_interface_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn allocation_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "Eip", "AllocationId")),
+        Some(provider_type("ec2", "Eip", "AllocationId")),
         aws_resource_id(),
         Some("^eipalloc-[0-9a-f]{8,}$".to_string()),
         None,
@@ -655,7 +657,7 @@ pub fn allocation_id() -> AttributeType {
 /// Prefix List ID type (e.g., "pl-0123456789abcdef0")
 pub fn prefix_list_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "PrefixList", "Id")),
+        Some(provider_type("ec2", "PrefixList", "Id")),
         aws_resource_id(),
         Some("^pl-[0-9a-f]{8,}$".to_string()),
         None,
@@ -674,7 +676,7 @@ pub fn prefix_list_id() -> AttributeType {
 /// Carrier Gateway ID type (e.g., "cagw-0123456789abcdef0")
 pub fn carrier_gateway_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "CarrierGateway", "Id")),
+        Some(provider_type("ec2", "CarrierGateway", "Id")),
         aws_resource_id(),
         Some("^cagw-[0-9a-f]{8,}$".to_string()),
         None,
@@ -693,7 +695,7 @@ pub fn carrier_gateway_id() -> AttributeType {
 /// Local Gateway ID type (e.g., "lgw-0123456789abcdef0")
 pub fn local_gateway_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "LocalGateway", "Id")),
+        Some(provider_type("ec2", "LocalGateway", "Id")),
         aws_resource_id(),
         Some("^lgw-[0-9a-f]{8,}$".to_string()),
         None,
@@ -713,7 +715,7 @@ pub fn local_gateway_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn network_acl_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "NetworkAcl", "Id")),
+        Some(provider_type("ec2", "NetworkAcl", "Id")),
         aws_resource_id(),
         Some("^acl-[0-9a-f]{8,}$".to_string()),
         None,
@@ -732,7 +734,7 @@ pub fn network_acl_id() -> AttributeType {
 /// Transit Gateway Attachment ID type (e.g., "tgw-attach-0123456789abcdef0")
 pub fn transit_gateway_attachment_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "TransitGatewayAttachment", "Id")),
+        Some(provider_type("ec2", "TransitGatewayAttachment", "Id")),
         aws_resource_id(),
         Some("^tgw-attach-[0-9a-f]{8,}$".to_string()),
         None,
@@ -752,7 +754,7 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
 /// Flow Log ID type (e.g., "fl-0123456789abcdef0")
 pub fn flow_log_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "FlowLog", "Id")),
+        Some(provider_type("ec2", "FlowLog", "Id")),
         aws_resource_id(),
         Some("^fl-[0-9a-f]{8,}$".to_string()),
         None,
@@ -771,7 +773,7 @@ pub fn flow_log_id() -> AttributeType {
 /// IPAM ID type (e.g., "ipam-0123456789abcdef0")
 pub fn ipam_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "Ipam", "Id")),
+        Some(provider_type("ec2", "Ipam", "Id")),
         aws_resource_id(),
         Some("^ipam-[0-9a-f]{8,}$".to_string()),
         None,
@@ -790,7 +792,7 @@ pub fn ipam_id() -> AttributeType {
 /// Subnet Route Table Association ID type (e.g., "rtbassoc-0123456789abcdef0")
 pub fn subnet_route_table_association_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "SubnetRouteTableAssociation", "Id")),
+        Some(provider_type("ec2", "SubnetRouteTableAssociation", "Id")),
         aws_resource_id(),
         Some("^rtbassoc-[0-9a-f]{8,}$".to_string()),
         None,
@@ -813,7 +815,7 @@ pub fn subnet_route_table_association_id() -> AttributeType {
 /// Security Group Rule ID type (e.g., "sgr-0123456789abcdef0")
 pub fn security_group_rule_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "SecurityGroupRule", "Id")),
+        Some(provider_type("ec2", "SecurityGroupRule", "Id")),
         aws_resource_id(),
         Some("^sgr-[0-9a-f]{8,}$".to_string()),
         None,
@@ -846,7 +848,7 @@ pub fn validate_iam_role_id(id: &str) -> Result<(), String> {
 /// IAM Role ID type (e.g., "AROAEXAMPLEID")
 pub fn iam_role_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("iam", "Role", "Id")),
+        Some(provider_type("iam", "Role", "Id")),
         aws_resource_id(),
         Some("^AROA[A-Z0-9]+$".to_string()),
         None,
@@ -881,7 +883,7 @@ pub fn validate_aws_account_id(id: &str) -> Result<(), String> {
 /// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
 pub fn aws_account_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_bare_type(&[], "AccountId")),
+        Some(provider_bare_type(&[], "AccountId")),
         AttributeType::string(),
         Some("^\\d{12}$".to_string()),
         Some((Some(12), Some(12))),
@@ -1019,73 +1021,13 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
 /// ARN type (e.g., "arn:aws:s3:::my-bucket")
 pub fn arn() -> AttributeType {
     AttributeType::custom(
-        Some(aws_bare_type(&[], "Arn")),
+        Some(provider_bare_type(&[], "Arn")),
         AttributeType::string(),
         Some("^arn:(aws|aws-cn|aws-us-gov):[^:]+:.*$".to_string()),
         None,
         legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_arn(s).map_err(|reason| format!("Invalid ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
-}
-
-/// IAM Role ARN type (e.g., "arn:aws:iam::123456789012:role/MyRole")
-#[allow(dead_code)]
-pub fn iam_role_arn() -> AttributeType {
-    AttributeType::custom(
-        Some(aws_type("iam", "Role", "Arn")),
-        arn(),
-        Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_iam_arn(s, "role/")
-                    .map_err(|reason| format!("Invalid IAM Role ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
-}
-
-/// IAM Policy ARN type (e.g., "arn:aws:iam::123456789012:policy/MyPolicy")
-#[allow(dead_code)]
-pub fn iam_policy_arn() -> AttributeType {
-    AttributeType::custom(
-        Some(aws_type("iam", "Policy", "Arn")),
-        arn(),
-        Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_iam_arn(s, "policy/")
-                    .map_err(|reason| format!("Invalid IAM Policy ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
-}
-
-/// KMS Key ARN type (e.g., "arn:aws:kms:us-east-1:123456789012:key/...")
-#[allow(dead_code)]
-pub fn kms_key_arn() -> AttributeType {
-    AttributeType::custom(
-        Some(aws_type("kms", "Key", "Arn")),
-        arn(),
-        Some("^arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:key/.+$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_service_arn(s, "kms", Some("key/"))
-                    .map_err(|reason| format!("Invalid KMS Key ARN '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
@@ -1139,30 +1081,6 @@ pub fn validate_kms_key_id(value: &str) -> Result<(), String> {
     )
 }
 
-/// KMS Key ID type - accepts multiple formats:
-/// - Key ARN: "arn:aws:kms:us-east-1:123456789012:key/..."
-/// - Key alias ARN: "arn:aws:kms:us-east-1:123456789012:alias/my-key"
-/// - Key alias: "alias/my-key"
-/// - Key ID: "1234abcd-12ab-34cd-56ef-1234567890ab"
-#[allow(dead_code)]
-pub fn kms_key_id() -> AttributeType {
-    AttributeType::custom(
-        Some(aws_type("kms", "Key", "Id")),
-        aws_resource_id(),
-        None,
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_kms_key_id(s)
-                    .map_err(|reason| format!("Invalid KMS key identifier '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
-}
-
 // ========== IPAM types ==========
 
 /// Validate IPAM Pool ID format: `ipam-pool-{hex}` where hex is 8+ hex digits.
@@ -1182,7 +1100,7 @@ pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
 /// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
 pub fn ipam_pool_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_type("ec2", "IpamPool", "Id")),
+        Some(provider_type("ec2", "IpamPool", "Id")),
         aws_resource_id(),
         Some("^ipam-pool-[0-9a-f]{8,}$".to_string()),
         None,
@@ -1290,7 +1208,7 @@ pub fn validate_availability_zone_id(az_id: &str) -> Result<(), String> {
 /// Availability Zone ID type (e.g., "use1-az1", "usw2-az2", "apne1-az4")
 pub fn availability_zone_id() -> AttributeType {
     AttributeType::custom(
-        Some(aws_bare_type(&["AvailabilityZone"], "ZoneId")),
+        Some(provider_bare_type(&["AvailabilityZone"], "ZoneId")),
         AttributeType::string(),
         Some("^[a-z]+[0-9]+-az[0-9]+$".to_string()),
         None,

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -45,7 +45,7 @@ struct Args {
 #[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]
 enum TypeOverride {
-    /// Override to a specific string type (e.g., "super::iam_role_arn()")
+    /// Override to a specific string type (e.g., "super::super::iam::role::arn()")
     StringType(&'static str),
     /// Override to an enum with specific values
     Enum(Vec<&'static str>),
@@ -62,6 +62,230 @@ struct EnumInfo {
     type_name: String,
     /// Valid enum values (e.g., ["default", "dedicated", "host"])
     values: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArnEmitChoice {
+    PerKind(&'static ArnValidation),
+    ServicePrefix(&'static str),
+    Generic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ArnValidation {
+    service: &'static str,
+    resource: &'static str,
+    regex: &'static str,
+    validator: ArnValidator,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArnValidator {
+    Iam {
+        prefix: &'static str,
+        label: &'static str,
+    },
+    Service {
+        service: &'static str,
+        prefix: Option<&'static str>,
+        label: &'static str,
+    },
+}
+
+static ARN_VALIDATIONS: &[ArnValidation] = &[
+    ArnValidation {
+        service: "iam",
+        resource: "Role",
+        regex: "^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$",
+        validator: ArnValidator::Iam {
+            prefix: "role/",
+            label: "IAM Role",
+        },
+    },
+    ArnValidation {
+        service: "iam",
+        resource: "Policy",
+        regex: "^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$",
+        validator: ArnValidator::Iam {
+            prefix: "policy/",
+            label: "IAM Policy",
+        },
+    },
+    ArnValidation {
+        service: "kms",
+        resource: "Key",
+        regex: "^arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:key/.+$",
+        validator: ArnValidator::Service {
+            service: "kms",
+            prefix: Some("key/"),
+            label: "KMS Key",
+        },
+    },
+    ArnValidation {
+        service: "s3",
+        resource: "Bucket",
+        regex: "^arn:(aws|aws-cn|aws-us-gov):s3:::.+$",
+        validator: ArnValidator::Service {
+            service: "s3",
+            prefix: None,
+            label: "s3",
+        },
+    },
+    ArnValidation {
+        service: "cloudfront",
+        resource: "Distribution",
+        regex: "^arn:(aws|aws-cn|aws-us-gov):cloudfront::[^:]*:distribution/.+$",
+        validator: ArnValidator::Service {
+            service: "cloudfront",
+            prefix: Some("distribution/"),
+            label: "cloudfront",
+        },
+    },
+    ArnValidation {
+        service: "ecs",
+        resource: "Cluster",
+        regex: "^arn:(aws|aws-cn|aws-us-gov):ecs:[^:]*:[^:]*:cluster/.+$",
+        validator: ArnValidator::Service {
+            service: "ecs",
+            prefix: Some("cluster/"),
+            label: "ecs",
+        },
+    },
+    ArnValidation {
+        service: "dynamodb",
+        resource: "Table",
+        regex: "^arn:(aws|aws-cn|aws-us-gov):dynamodb:[^:]*:[^:]*:table/.+$",
+        validator: ArnValidator::Service {
+            service: "dynamodb",
+            prefix: Some("table/"),
+            label: "dynamodb",
+        },
+    },
+    ArnValidation {
+        service: "logs",
+        resource: "LogGroup",
+        regex: "^arn:(aws|aws-cn|aws-us-gov):logs:[^:]*:[^:]*:log-group:.+$",
+        validator: ArnValidator::Service {
+            service: "logs",
+            prefix: Some("log-group:"),
+            label: "logs",
+        },
+    },
+];
+
+static KNOWN_SERVICES: &[&str] = &[
+    "cloudfront",
+    "dynamodb",
+    "ec2",
+    "ecs",
+    "iam",
+    "kms",
+    "logs",
+    "organizations",
+    "s3",
+    "sts",
+    "wafv2",
+];
+
+fn arn_emit_choice(service: &str, resource: &str) -> ArnEmitChoice {
+    if let Some(entry) = ARN_VALIDATIONS
+        .iter()
+        .find(|v| v.service == service && v.resource == resource)
+    {
+        ArnEmitChoice::PerKind(entry)
+    } else if let Some(&known) = KNOWN_SERVICES.iter().find(|&&known| known == service) {
+        ArnEmitChoice::ServicePrefix(known)
+    } else {
+        ArnEmitChoice::Generic
+    }
+}
+
+fn resource_identity_parts(name: &str) -> Option<(&str, &str)> {
+    name.split_once('.')
+}
+
+fn arn_validator_for(validator: ArnValidator) -> String {
+    match validator {
+        ArnValidator::Iam { prefix, label } => format!(
+            r#"|value| {{
+            if let Value::Concrete(ConcreteValue::String(s)) = value {{
+                super::validate_iam_arn(s, {prefix:?})
+                    .map_err(|reason| format!("Invalid {label} ARN '{{}}': {{}}", s, reason))
+            }} else {{
+                Err("Expected string".to_string())
+            }}
+        }}"#
+        ),
+        ArnValidator::Service {
+            service,
+            prefix,
+            label,
+        } => {
+            let prefix_expr = match prefix {
+                Some(prefix) => format!("Some({prefix:?})"),
+                None => "None".to_string(),
+            };
+            format!(
+                r#"|value| {{
+            if let Value::Concrete(ConcreteValue::String(s)) = value {{
+                super::validate_service_arn(s, {service:?}, {prefix_expr})
+                    .map_err(|reason| format!("Invalid {label} ARN '{{}}': {{}}", s, reason))
+            }} else {{
+                Err("Expected string".to_string())
+            }}
+        }}"#
+            )
+        }
+    }
+}
+
+fn arn_validator_expression(choice: ArnEmitChoice) -> String {
+    match choice {
+        ArnEmitChoice::PerKind(entry) => arn_validator_for(entry.validator),
+        ArnEmitChoice::ServicePrefix(service) => format!(
+            r#"|value| {{
+            if let Value::Concrete(ConcreteValue::String(s)) = value {{
+                super::validate_service_arn(s, {service:?}, None)
+                    .map_err(|reason| format!("Invalid {service} ARN '{{}}': {{}}", s, reason))
+            }} else {{
+                Err("Expected string".to_string())
+            }}
+        }}"#
+        ),
+        ArnEmitChoice::Generic => unreachable!("generic ARN helper has no validator expression"),
+    }
+}
+
+fn emit_arn_helper(service: &str, resource: &str, choice: ArnEmitChoice) -> String {
+    if matches!(choice, ArnEmitChoice::Generic) {
+        return "pub fn arn() -> AttributeType {\n    super::arn()\n}\n\n".to_string();
+    }
+
+    let regex_expr = match choice {
+        ArnEmitChoice::PerKind(entry) => format!("Some({:?}.to_string())", entry.regex),
+        ArnEmitChoice::ServicePrefix(service) => {
+            format!(
+                "Some(\"^arn:(aws|aws-cn|aws-us-gov):{}:.*$\".to_string())",
+                service
+            )
+        }
+        ArnEmitChoice::Generic => unreachable!("handled above"),
+    };
+    let validator_expr = arn_validator_expression(choice);
+    format!(
+        r#"pub fn arn() -> AttributeType {{
+    AttributeType::custom(
+        Some(super::provider_type("{service}", "{resource}", "Arn")),
+        super::arn(),
+        {regex_expr},
+        None,
+        legacy_validator({validator_expr}),
+        None,
+    )
+}}
+
+"#
+    )
 }
 
 /// Build the `dsl_aliases: ...` Rust source code for a `StringEnum`'s
@@ -333,6 +557,8 @@ fn main() -> Result<()> {
                     is_data_source: true,
                 });
             }
+
+            generate_virtual_helper_modules(&args.output_dir, &mut generated_modules)?;
 
             // Generate per-service mod.rs files
             generate_service_mod_files(&args.output_dir, &generated_modules)?;
@@ -864,11 +1090,23 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     if needs_types {
         schema_imports.push("types");
     }
+    let arn_helper = resource_identity_parts(res.name).and_then(|(service, resource)| {
+        attrs
+            .iter()
+            .any(|a| a.snake_name == "arn")
+            .then(|| emit_arn_helper(service, resource, arn_emit_choice(service, resource)))
+    });
+    let has_arn_helper = arn_helper.is_some();
+    if has_arn_helper && !schema_imports.contains(&"AttributeType") {
+        schema_imports.insert(1, "AttributeType");
+    }
     if has_ranged_ints {
         schema_imports.push("legacy_validator");
     }
+    if has_arn_helper && !schema_imports.contains(&"legacy_validator") {
+        schema_imports.push("legacy_validator");
+    }
     let schema_imports_str = schema_imports.join(", ");
-
     code.push_str(&format!(
         "//! {} schema definition for AWS Cloud Control\n\
          //!\n\
@@ -883,7 +1121,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         code.push_str("use super::tags_type;\n");
         code.push_str("use super::validate_tags_map;\n");
     }
-    if has_ranged_ints {
+    if has_ranged_ints || has_arn_helper {
         code.push_str("use carina_core::resource::{ConcreteValue, Value};\n");
     }
     code.push_str(&format!(
@@ -950,6 +1188,9 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
              }}\n\n",
             fn_name, condition, display
         ));
+    }
+    if let Some(helper) = &arn_helper {
+        code.push_str(helper);
     }
 
     // Generate config function
@@ -1027,6 +1268,12 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             )
         } else {
             attr.type_code.clone()
+        };
+
+        let type_code = if has_arn_helper && attr.snake_name == "arn" {
+            "self::arn()".to_string()
+        } else {
+            type_code
         };
 
         let mut attr_code = format!(
@@ -1523,6 +1770,77 @@ struct GeneratedModule {
     is_data_source: bool,
 }
 
+fn generate_virtual_helper_modules(
+    output_dir: &std::path::Path,
+    modules: &mut Vec<GeneratedModule>,
+) -> Result<()> {
+    let iam_dir = output_dir.join("iam");
+    std::fs::create_dir_all(&iam_dir)
+        .with_context(|| format!("Failed to create {}", iam_dir.display()))?;
+    let iam_policy = format!(
+        "//! Auto-generated helper schema module for AWS IAM Policy identifiers\n\
+         //!\n\
+         //! DO NOT EDIT MANUALLY - regenerate with:\n\
+         //!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh\n\n\
+         use carina_core::resource::{{ConcreteValue, Value}};\n\
+         use carina_core::schema::{{AttributeType, legacy_validator}};\n\n{}",
+        emit_arn_helper("iam", "Policy", arn_emit_choice("iam", "Policy"))
+    );
+    let iam_policy_path = iam_dir.join("policy.rs");
+    std::fs::write(&iam_policy_path, iam_policy)
+        .with_context(|| format!("Failed to write {}", iam_policy_path.display()))?;
+
+    let kms_dir = output_dir.join("kms");
+    std::fs::create_dir_all(&kms_dir)
+        .with_context(|| format!("Failed to create {}", kms_dir.display()))?;
+    let kms_key = format!(
+        "//! Auto-generated helper schema module for AWS KMS Key identifiers\n\
+         //!\n\
+         //! DO NOT EDIT MANUALLY - regenerate with:\n\
+         //!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh\n\n\
+         use carina_core::resource::{{ConcreteValue, Value}};\n\
+         use carina_core::schema::{{AttributeType, legacy_validator}};\n\n{}\
+         pub fn id() -> AttributeType {{\n\
+         \x20   AttributeType::custom(\n\
+         \x20       Some(super::provider_type(\"kms\", \"Key\", \"Id\")),\n\
+         \x20       super::aws_resource_id(),\n\
+         \x20       None,\n\
+         \x20       None,\n\
+         \x20       legacy_validator(|value| {{\n\
+         \x20           if let Value::Concrete(ConcreteValue::String(s)) = value {{\n\
+         \x20               super::validate_kms_key_id(s)\n\
+         \x20                   .map_err(|reason| format!(\"Invalid KMS key identifier '{{}}': {{}}\", s, reason))\n\
+         \x20           }} else {{\n\
+         \x20               Err(\"Expected string\".to_string())\n\
+         \x20           }}\n\
+         \x20       }}),\n\
+         \x20       None,\n\
+         \x20   )\n\
+         }}\n",
+        emit_arn_helper("kms", "Key", arn_emit_choice("kms", "Key"))
+    );
+    let kms_key_path = kms_dir.join("key.rs");
+    std::fs::write(&kms_key_path, kms_key)
+        .with_context(|| format!("Failed to write {}", kms_key_path.display()))?;
+
+    modules.push(GeneratedModule {
+        dsl_name: "iam.Policy".to_string(),
+        service: "iam".to_string(),
+        file_stem: "policy".to_string(),
+        config_fn: String::new(),
+        is_data_source: false,
+    });
+    modules.push(GeneratedModule {
+        dsl_name: "kms.Key".to_string(),
+        service: "kms".to_string(),
+        file_stem: "key".to_string(),
+        config_fn: String::new(),
+        is_data_source: false,
+    });
+
+    Ok(())
+}
+
 fn generate_service_mod_files(
     output_dir: &std::path::Path,
     modules: &[GeneratedModule],
@@ -1705,6 +2023,9 @@ fn generate_mod_rs(modules: &[GeneratedModule], output_dir: &std::path::Path) ->
          \x20   vec![\n",
     );
     for e in &entries {
+        if e.config_fn.is_empty() {
+            continue;
+        }
         code.push_str(&format!(
             "\x20       {}::{}::{}(),\n",
             e.service, e.file_stem, e.config_fn
@@ -1727,6 +2048,9 @@ fn generate_mod_rs(modules: &[GeneratedModule], output_dir: &std::path::Path) ->
          \x20   let modules: &[(&str, &[(&str, &[&str])])] = &[\n",
     );
     for e in &entries {
+        if e.config_fn.is_empty() {
+            continue;
+        }
         code.push_str(&format!(
             "\x20       {}::{}::enum_valid_values(),\n",
             e.service, e.file_stem
@@ -1757,7 +2081,7 @@ fn generate_mod_rs(modules: &[GeneratedModule], output_dir: &std::path::Path) ->
          pub fn get_enum_alias_reverse(resource_type: &str, attr_name: &str, value: &str) -> Option<&'static str> {\n",
     );
     for e in &entries {
-        if e.is_data_source {
+        if e.is_data_source || e.config_fn.is_empty() {
             continue;
         }
         code.push_str(&format!(
@@ -1778,7 +2102,7 @@ fn generate_mod_rs(modules: &[GeneratedModule], output_dir: &std::path::Path) ->
          \x20   let mut map = std::collections::HashMap::new();\n",
     );
     for e in &entries {
-        if e.is_data_source {
+        if e.is_data_source || e.config_fn.is_empty() {
             continue;
         }
         code.push_str(&format!(
@@ -3407,7 +3731,26 @@ fn generate_data_source(
     if needs_types {
         schema_imports.push("types");
     }
+    let arn_helper = resource_identity_parts(ds.name).and_then(|(service, resource)| {
+        ds_attrs
+            .iter()
+            .any(|a| a.name == "arn")
+            .then(|| emit_arn_helper(service, resource, arn_emit_choice(service, resource)))
+    });
+    let has_arn_helper = arn_helper.is_some();
+    if has_arn_helper && !schema_imports.contains(&"AttributeType") {
+        schema_imports.insert(1, "AttributeType");
+    }
+    if has_arn_helper && !schema_imports.contains(&"legacy_validator") {
+        schema_imports.push("legacy_validator");
+    }
     let schema_imports_str = schema_imports.join(", ");
+    let resource_import = if has_arn_helper {
+        "use carina_core::resource::{ConcreteValue, Value};\n"
+    } else {
+        ""
+    };
+    let arn_helper_code = arn_helper.unwrap_or_default();
 
     let mut code = String::new();
     code.push_str(&format!(
@@ -3417,7 +3760,9 @@ fn generate_data_source(
          //!\n\
          //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen\n\n\
          use super::AwsSchemaConfig;\n\
+         {resource_import}\
          use carina_core::schema::{{{}}};\n\n\
+         {arn_helper_code}\
          /// Returns the schema config for {} (Smithy: {})\n\
          pub fn {}() -> AwsSchemaConfig {{\n\
          \x20   AwsSchemaConfig {{\n\
@@ -3439,6 +3784,11 @@ fn generate_data_source(
 
     // Emit attributes.
     for attr in &ds_attrs {
+        let type_str = if has_arn_helper && attr.name == "arn" {
+            "self::arn()"
+        } else {
+            attr.type_str.as_str()
+        };
         if attr.read_only {
             code.push_str(&format!(
                 "\x20       .attribute(\n\
@@ -3446,7 +3796,7 @@ fn generate_data_source(
                  \x20               .with_description(\"{}\")\n\
                  \x20               .with_provider_name(\"{}\"),\n\
                  \x20       )\n",
-                attr.name, attr.type_str, attr.description, attr.provider_name,
+                attr.name, type_str, attr.description, attr.provider_name,
             ));
         } else {
             let required = if attr.required {
@@ -3460,7 +3810,7 @@ fn generate_data_source(
                  \x20               .with_description(\"{}\")\n\
                  \x20               .with_provider_name(\"{}\"),\n\
                  \x20       )\n",
-                attr.name, attr.type_str, required, attr.description, attr.provider_name,
+                attr.name, type_str, required, attr.description, attr.provider_name,
             ));
         }
     }
@@ -3726,8 +4076,8 @@ fn type_code_to_display(type_code: &str) -> String {
         s if s.contains("iam_role_id") => "IamRoleId".to_string(),
         s if s.contains("iam_policy_arn") => "IamPolicyArn".to_string(),
         s if s.contains("iam_policy_document") => "PolicyDocument".to_string(),
-        s if s.contains("kms_key_arn") => "KmsKeyArn".to_string(),
-        s if s.contains("kms_key_id") => "KmsKeyId".to_string(),
+        s if s.contains("kms_key_arn") || s.contains("kms::key::arn") => "KmsKeyArn".to_string(),
+        s if s.contains("kms_key_id") || s.contains("kms::key::id") => "KmsKeyId".to_string(),
         s if s.contains("vpc_id") => "VpcId".to_string(),
         s if s.contains("subnet_id") => "SubnetId".to_string(),
         s if s.contains("security_group_rule_id") => "SecurityGroupRuleId".to_string(),
@@ -3844,15 +4194,16 @@ fn known_string_type_overrides() -> &'static HashMap<&'static str, &'static str>
         m.insert("DefaultNetworkAcl", "super::network_acl_id()");
         m.insert("AccountId", "super::aws_account_id()");
         m.insert("GatewayId", "super::gateway_id()");
-        m.insert("DeliverCrossAccountRole", "super::iam_role_arn()");
-        m.insert("DeliverLogsPermissionArn", "super::iam_role_arn()");
-        m.insert("PeerRoleArn", "super::iam_role_arn()");
-        m.insert("PermissionsBoundary", "super::iam_policy_arn()");
-        m.insert("ManagedPolicyArns", "super::iam_policy_arn()");
-        m.insert("KmsKeyId", "super::kms_key_arn()");
-        m.insert("KMSMasterKeyID", "super::kms_key_id()");
-        m.insert("ReplicaKmsKeyID", "super::kms_key_id()");
-        m.insert("KmsKeyArn", "super::kms_key_arn()");
+        m.insert("DeliverCrossAccountRole", "super::super::iam::role::arn()");
+        m.insert("DeliverLogsPermissionArn", "super::super::iam::role::arn()");
+        m.insert("PeerRoleArn", "super::super::iam::role::arn()");
+        m.insert("PermissionsBoundary", "super::super::iam::policy::arn()");
+        m.insert("ManagedPolicyArns", "super::super::iam::policy::arn()");
+        m.insert("KmsKeyId", "super::super::kms::key::id()");
+        m.insert("kmsKeyId", "super::super::kms::key::id()");
+        m.insert("KMSMasterKeyID", "super::super::kms::key::id()");
+        m.insert("ReplicaKmsKeyID", "super::super::kms::key::id()");
+        m.insert("KmsKeyArn", "super::super::kms::key::arn()");
         m.insert("SecurityGroupRuleId", "super::security_group_rule_id()");
         m.insert("Locale", "super::aws_region()");
         m.insert("BucketAccountId", "super::aws_account_id()");
@@ -4325,7 +4676,7 @@ mod tests {
             "account_id must use aws_account_id(): {generated}"
         );
         assert!(
-            generated.contains(r#"AttributeSchema::new("arn", super::arn())"#),
+            generated.contains(r#"AttributeSchema::new("arn", self::arn())"#),
             "arn must use arn(): {generated}"
         );
         assert!(
@@ -4417,7 +4768,7 @@ mod tests {
         // arns is List<iam_role_arn>
         assert!(
             generated.contains(
-                "AttributeSchema::new(\"arns\", AttributeType::unordered_list(super::iam_role_arn()))"
+                "AttributeSchema::new(\"arns\", AttributeType::unordered_list(super::super::iam::role::arn()))"
             ),
             "arns must be List(iam_role_arn): {generated}"
         );

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -2391,7 +2391,7 @@ pub fn iam_data_sources() -> Vec<DataSourceDef> {
                 DataSourceListOutput {
                     name: "arns",
                     description: "Set of ARNs of the matched IAM roles.",
-                    item_type: "super::iam_role_arn()",
+                    item_type: "super::super::iam::role::arn()",
                 },
                 DataSourceListOutput {
                     name: "names",
@@ -2420,7 +2420,7 @@ pub fn iam_resources() -> Vec<ResourceDef> {
         has_tags: true,
         type_overrides: vec![
             ("AssumeRolePolicyDocument", "super::iam_policy_document()"),
-            ("Arn", "super::iam_role_arn()"),
+            ("Arn", "super::super::iam::role::arn()"),
             ("RoleId", "super::iam_role_id()"),
         ],
         exclude_fields: vec![
@@ -2465,7 +2465,10 @@ pub fn logs_resources() -> Vec<ResourceDef> {
         }],
         identifier: "LogGroupName",
         has_tags: true,
-        type_overrides: vec![("KmsKeyId", "super::kms_key_id()"), ("Arn", "super::arn()")],
+        type_overrides: vec![
+            ("kmsKeyId", "super::super::kms::key::id()"),
+            ("Arn", "super::arn()"),
+        ],
         exclude_fields: vec![
             "CreationTime",
             "StoredBytes",
@@ -2547,7 +2550,7 @@ pub fn sqs_resources() -> Vec<ResourceDef> {
         has_tags: true,
         type_overrides: vec![
             ("QueueArn", "super::arn()"),
-            ("KmsMasterKeyId", "super::kms_key_id()"),
+            ("KmsMasterKeyId", "super::super::kms::key::id()"),
             ("Policy", "super::iam_policy_document()"),
             ("RedrivePolicy", "super::sqs_redrive_policy()"),
             ("RedriveAllowPolicy", "super::sqs_redrive_allow_policy()"),
@@ -2839,7 +2842,10 @@ mod tests {
         };
         let names: Vec<&str> = aggregated_outputs.iter().map(|o| o.name).collect();
         assert_eq!(names, vec!["arns", "names"]);
-        assert_eq!(aggregated_outputs[0].item_type, "super::iam_role_arn()");
+        assert_eq!(
+            aggregated_outputs[0].item_type,
+            "super::super::iam::role::arn()"
+        );
         assert_eq!(aggregated_outputs[1].item_type, "AttributeType::string()");
     }
 

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -43,7 +43,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
         schema: ResourceSchema::new("ec2.FlowLog")
         .with_description("Describes a flow log.")
         .attribute(
-            AttributeSchema::new("deliver_logs_permission_arn", super::iam_role_arn())
+            AttributeSchema::new("deliver_logs_permission_arn", super::super::iam::role::arn())
                 .create_only()
                 .with_description("The ARN of the IAM role that allows Amazon EC2 to publish flow logs to the log destination. This parameter is required if the destination type is clou...")
                 .with_provider_name("DeliverLogsPermissionArn"),

--- a/carina-provider-aws/src/schemas/generated/iam/policy.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/policy.rs
@@ -1,0 +1,25 @@
+//! Auto-generated helper schema module for AWS IAM Policy identifiers
+//!
+//! DO NOT EDIT MANUALLY - regenerate with:
+//!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh
+
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{AttributeType, legacy_validator};
+
+pub fn arn() -> AttributeType {
+    AttributeType::custom(
+        Some(super::provider_type("iam", "Policy", "Arn")),
+        super::arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
+        None,
+        legacy_validator(|value| {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                super::validate_iam_arn(s, "policy/")
+                    .map_err(|reason| format!("Invalid IAM Policy ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        None,
+    )
+}

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -22,6 +22,24 @@ fn validate_max_session_duration_range(value: &Value) -> Result<(), String> {
     }
 }
 
+pub fn arn() -> AttributeType {
+    AttributeType::custom(
+        Some(super::provider_type("iam", "Role", "Arn")),
+        super::arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$".to_string()),
+        None,
+        legacy_validator(|value| {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                super::validate_iam_arn(s, "role/")
+                    .map_err(|reason| format!("Invalid IAM Role ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        None,
+    )
+}
+
 /// Returns the schema config for iam.Role (Smithy: com.amazonaws.iam)
 pub fn iam_role_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
@@ -70,7 +88,7 @@ pub fn iam_role_config() -> AwsSchemaConfig {
                 .with_provider_name("RoleName"),
         )
         .attribute(
-            AttributeSchema::new("arn", super::iam_role_arn())
+            AttributeSchema::new("arn", self::arn())
                 .read_only()
                 .with_description("The Amazon Resource Name (ARN) specifying the role. For more information about ARNs and how to use them in policies, see IAM identifiers in the IAM Us... (read-only)")
                 .with_provider_name("Arn"),

--- a/carina-provider-aws/src/schemas/generated/iam/roles.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/roles.rs
@@ -26,7 +26,7 @@ pub fn iam_roles_config() -> AwsSchemaConfig {
                 .with_provider_name(""),
         )
         .attribute(
-            AttributeSchema::new("arns", AttributeType::unordered_list(super::iam_role_arn()))
+            AttributeSchema::new("arns", AttributeType::unordered_list(super::super::iam::role::arn()))
                 .with_description("Set of ARNs of the matched IAM roles.")
                 .with_provider_name(""),
         )

--- a/carina-provider-aws/src/schemas/generated/kms/key.rs
+++ b/carina-provider-aws/src/schemas/generated/kms/key.rs
@@ -1,0 +1,43 @@
+//! Auto-generated helper schema module for AWS KMS Key identifiers
+//!
+//! DO NOT EDIT MANUALLY - regenerate with:
+//!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh
+
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{AttributeType, legacy_validator};
+
+pub fn arn() -> AttributeType {
+    AttributeType::custom(
+        Some(super::provider_type("kms", "Key", "Arn")),
+        super::arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:key/.+$".to_string()),
+        None,
+        legacy_validator(|value| {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                super::validate_service_arn(s, "kms", Some("key/"))
+                    .map_err(|reason| format!("Invalid KMS Key ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        None,
+    )
+}
+
+pub fn id() -> AttributeType {
+    AttributeType::custom(
+        Some(super::provider_type("kms", "Key", "Id")),
+        super::aws_resource_id(),
+        None,
+        None,
+        legacy_validator(|value| {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                super::validate_kms_key_id(s)
+                    .map_err(|reason| format!("Invalid KMS key identifier '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        None,
+    )
+}

--- a/carina-provider-aws/src/schemas/generated/kms/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/kms/mod.rs
@@ -6,6 +6,4 @@
 // Re-export parent types so resource modules can use `super::` to access them.
 pub use super::*;
 
-pub mod policy;
-pub mod role;
-pub mod roles;
+pub mod key;

--- a/carina-provider-aws/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-aws/src/schemas/generated/logs/log_group.rs
@@ -33,7 +33,7 @@ pub fn logs_log_group_config() -> AwsSchemaConfig {
                 .with_provider_name("deletionProtectionEnabled"),
         )
         .attribute(
-            AttributeSchema::new("kms_key_id", AttributeType::string())
+            AttributeSchema::new("kms_key_id", super::super::kms::key::id())
                 .create_only()
                 .with_description("The Amazon Resource Name (ARN) of the KMS key to use when encrypting log data. For more information, see Amazon Resource Names.")
                 .with_provider_name("kmsKeyId"),

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -11,6 +11,7 @@ pub mod acm;
 pub mod ec2;
 pub mod iam;
 pub mod identitystore;
+pub mod kms;
 pub mod logs;
 pub mod organizations;
 pub mod route53;

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -7,7 +7,10 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
+};
 
 const VALID_IAM_USER_ACCESS_TO_BILLING: &[&str] = &["ALLOW", "DENY", "allow", "deny"];
 
@@ -21,6 +24,24 @@ const VALID_STATUS: &[&str] = &[
     "pending_closure",
     "suspended",
 ];
+
+pub fn arn() -> AttributeType {
+    AttributeType::custom(
+        Some(super::provider_type("organizations", "Account", "Arn")),
+        super::arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):organizations:.*$".to_string()),
+        None,
+        legacy_validator(|value| {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                super::validate_service_arn(s, "organizations", None)
+                    .map_err(|reason| format!("Invalid organizations ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        None,
+    )
+}
 
 /// Returns the schema config for organizations.Account (Smithy: com.amazonaws.organizations)
 pub fn organizations_account_config() -> AwsSchemaConfig {
@@ -62,7 +83,7 @@ pub fn organizations_account_config() -> AwsSchemaConfig {
                 .with_provider_name("RoleName"),
         )
         .attribute(
-            AttributeSchema::new("arn", super::arn())
+            AttributeSchema::new("arn", self::arn())
                 .read_only()
                 .with_description("The Amazon Resource Name (ARN) of the account. For more information about ARNs in Organizations, see ARN Formats Supported by Organizations in the Ama... (read-only)")
                 .with_provider_name("Arn"),

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -5,9 +5,30 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
+};
 
 const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING", "all", "consolidated_billing"];
+
+pub fn arn() -> AttributeType {
+    AttributeType::custom(
+        Some(super::provider_type("organizations", "Organization", "Arn")),
+        super::arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):organizations:.*$".to_string()),
+        None,
+        legacy_validator(|value| {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                super::validate_service_arn(s, "organizations", None)
+                    .map_err(|reason| format!("Invalid organizations ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        None,
+    )
+}
 
 /// Returns the schema config for organizations.Organization (Smithy: com.amazonaws.organizations)
 pub fn organizations_organization_config() -> AwsSchemaConfig {
@@ -29,7 +50,7 @@ pub fn organizations_organization_config() -> AwsSchemaConfig {
                 .with_provider_name("FeatureSet"),
         )
         .attribute(
-            AttributeSchema::new("arn", super::arn())
+            AttributeSchema::new("arn", self::arn())
                 .read_only()
                 .with_description("The Amazon Resource Name (ARN) of an organization. For more information about ARNs in Organizations, see ARN Formats Supported by Organizations in the... (read-only)")
                 .with_provider_name("Arn"),

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_data_source.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_data_source.rs
@@ -5,7 +5,26 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
+
+pub fn arn() -> AttributeType {
+    AttributeType::custom(
+        Some(super::provider_type("s3", "Bucket", "Arn")),
+        super::arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):s3:::.+$".to_string()),
+        None,
+        legacy_validator(|value| {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                super::validate_service_arn(s, "s3", None)
+                    .map_err(|reason| format!("Invalid s3 ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        None,
+    )
+}
 
 /// Returns the schema config for s3.Bucket (Smithy: com.amazonaws.s3)
 pub fn s3_bucket_data_source_config() -> AwsSchemaConfig {
@@ -22,7 +41,7 @@ pub fn s3_bucket_data_source_config() -> AwsSchemaConfig {
                 .with_provider_name("Bucket"),
         )
         .attribute(
-            AttributeSchema::new("arn", super::arn())
+            AttributeSchema::new("arn", self::arn())
                 .with_description("ARN of the bucket.")
                 .with_provider_name(""),
         )

--- a/carina-provider-aws/src/schemas/generated/sqs/queue.rs
+++ b/carina-provider-aws/src/schemas/generated/sqs/queue.rs
@@ -94,7 +94,7 @@ pub fn sqs_queue_config() -> AwsSchemaConfig {
                 .with_provider_name("FifoThroughputLimit"),
         )
         .attribute(
-            AttributeSchema::new("kms_master_key_id", super::kms_key_id())
+            AttributeSchema::new("kms_master_key_id", super::super::kms::key::id())
                 .with_description("The ID of an AWS KMS customer master key (CMK) to use for server-side encryption (SSE-KMS). Use `alias/aws/sqs` for the AWS-managed key.")
                 .with_provider_name("KmsMasterKeyId"),
         )

--- a/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
+++ b/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
@@ -5,7 +5,26 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
+
+pub fn arn() -> AttributeType {
+    AttributeType::custom(
+        Some(super::provider_type("sts", "CallerIdentity", "Arn")),
+        super::arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):sts:.*$".to_string()),
+        None,
+        legacy_validator(|value| {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                super::validate_service_arn(s, "sts", None)
+                    .map_err(|reason| format!("Invalid sts ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        None,
+    )
+}
 
 /// Returns the schema config for sts.CallerIdentity (Smithy: com.amazonaws.sts)
 pub fn sts_caller_identity_config() -> AwsSchemaConfig {
@@ -21,7 +40,7 @@ pub fn sts_caller_identity_config() -> AwsSchemaConfig {
                 .with_provider_name("Account"),
         )
         .attribute(
-            AttributeSchema::new("arn", super::arn())
+            AttributeSchema::new("arn", self::arn())
                 .with_description("The Amazon Web Services ARN associated with the calling entity.")
                 .with_provider_name("Arn"),
         )

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -8,7 +8,7 @@ pub use carina_aws_types::*;
 use std::collections::HashMap;
 
 use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, ResourceSchema, TypeIdentity, legacy_validator};
+use carina_core::schema::{AttributeType, ResourceSchema, legacy_validator};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 
 /// AWS schema configuration
@@ -61,11 +61,11 @@ pub fn cloudfront_hosted_zone_id() -> AttributeType {
 /// - Shorthand: ap_northeast_1
 pub fn aws_region() -> AttributeType {
     AttributeType::custom_enum(
-        TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region"),
+        provider_bare_type(&[], "Region"),
         AttributeType::string(),
         legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
-                let id = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region");
+                let id = provider_bare_type(&[], "Region");
                 validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
                 // Normalize the input to AWS format (hyphens)
@@ -94,11 +94,11 @@ pub fn aws_region() -> AttributeType {
 /// - Shorthand: us_east_1a
 pub fn availability_zone() -> AttributeType {
     AttributeType::custom_enum(
-        TypeIdentity::new(Some("aws"), ["AvailabilityZone"], "ZoneName"),
+        provider_bare_type(&["AvailabilityZone"], "ZoneName"),
         AttributeType::string(),
         legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
-                let id = TypeIdentity::new(Some("aws"), ["AvailabilityZone"], "ZoneName");
+                let id = provider_bare_type(&["AvailabilityZone"], "ZoneName");
                 validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 let extracted = extract_enum_value(s);
@@ -123,7 +123,7 @@ pub fn availability_zone() -> AttributeType {
 /// Multiple grantees can be comma-separated.
 pub fn s3_grantee() -> AttributeType {
     AttributeType::custom(
-        Some(TypeIdentity::new(Some("aws"), ["s3"], "Grantee")),
+        Some(provider_bare_type(&["s3"], "Grantee")),
         AttributeType::string(),
         None,
         None,
@@ -235,7 +235,7 @@ pub fn aws_validators() -> HashMap<String, CustomValidatorFn> {
             // present, then convert underscores to hyphens before validating.
             availability_zone => |s: &str| {
                 if s.contains('.') {
-                    let id = TypeIdentity::new(Some("aws"), ["AvailabilityZone"], "ZoneName");
+                    let id = provider_bare_type(&["AvailabilityZone"], "ZoneName");
                     carina_core::utils::validate_enum_namespace(s, &id)
                         .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 }

--- a/carina-provider-aws/tests/iam_policy_arn.rs
+++ b/carina-provider-aws/tests/iam_policy_arn.rs
@@ -1,0 +1,27 @@
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::RawShape;
+use carina_provider_aws::schemas::generated::iam;
+
+#[test]
+fn policy_arn_identity_is_provider_scoped() {
+    let t = iam::policy::arn();
+    let RawShape::Custom { identity, .. } = t.raw_shape() else {
+        panic!("iam::policy::arn() should be Custom");
+    };
+    assert_eq!(
+        identity.map(|id| id.to_string()).as_deref(),
+        Some("aws.iam.Policy.Arn")
+    );
+}
+
+#[test]
+fn policy_arn_rejects_role_arn() {
+    let t = iam::policy::arn();
+    let RawShape::Custom { validate, .. } = t.raw_shape() else {
+        panic!("iam::policy::arn() should be Custom");
+    };
+    let v = Value::Concrete(ConcreteValue::String(
+        "arn:aws:iam::123456789012:role/MyRole".to_string(),
+    ));
+    assert!(validate(&v).is_err());
+}

--- a/carina-provider-aws/tests/iam_role_arn.rs
+++ b/carina-provider-aws/tests/iam_role_arn.rs
@@ -1,0 +1,41 @@
+use carina_core::resource::{ConcreteValue, Value};
+
+#[test]
+fn arn_rejects_non_role_iam_arn() {
+    let t = carina_provider_aws::schemas::generated::iam::role::arn();
+    let carina_core::schema::RawShape::Custom { validate, .. } = t.raw_shape() else {
+        panic!("arn() should be custom");
+    };
+    let v = Value::Concrete(ConcreteValue::String(
+        "arn:aws:iam::123456789012:policy/Foo".to_string(),
+    ));
+    assert!(validate(&v).is_err());
+}
+
+#[test]
+fn arn_identity_is_provider_scoped() {
+    let t = carina_provider_aws::schemas::generated::iam::role::arn();
+    let carina_core::schema::RawShape::Custom { identity, .. } = t.raw_shape() else {
+        panic!("arn() should be custom");
+    };
+    assert_eq!(
+        identity.map(|id| id.to_string()).as_deref(),
+        Some("aws.iam.Role.Arn")
+    );
+}
+
+#[test]
+fn arn_accepts_valid_role_arn() {
+    let t = carina_provider_aws::schemas::generated::iam::role::arn();
+    let carina_core::schema::RawShape::Custom { validate, .. } = t.raw_shape() else {
+        panic!("arn() should be Custom");
+    };
+    let v = Value::Concrete(ConcreteValue::String(
+        "arn:aws:iam::123456789012:role/MyRole".to_string(),
+    ));
+    assert!(
+        validate(&v).is_ok(),
+        "should accept valid role ARN: {:?}",
+        validate(&v)
+    );
+}

--- a/carina-provider-aws/tests/kms_key_arn.rs
+++ b/carina-provider-aws/tests/kms_key_arn.rs
@@ -1,0 +1,69 @@
+use carina_core::resource::{ConcreteValue, Value};
+
+fn assert_accepts(t: carina_core::schema::AttributeType, value: &str) {
+    let carina_core::schema::RawShape::Custom { validate, .. } = t.raw_shape() else {
+        panic!("type should be custom");
+    };
+    let value = Value::Concrete(ConcreteValue::String(value.to_string()));
+    assert!(validate(&value).is_ok());
+}
+
+fn assert_rejects(t: carina_core::schema::AttributeType, value: &str) {
+    let carina_core::schema::RawShape::Custom { validate, .. } = t.raw_shape() else {
+        panic!("type should be custom");
+    };
+    let value = Value::Concrete(ConcreteValue::String(value.to_string()));
+    assert!(validate(&value).is_err());
+}
+
+#[test]
+fn arn_accepts_only_kms_key_arn() {
+    assert_accepts(
+        carina_provider_aws::schemas::generated::kms::key::arn(),
+        "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+    );
+    assert_rejects(
+        carina_provider_aws::schemas::generated::kms::key::arn(),
+        "arn:aws:kms:us-east-1:123456789012:alias/my-key",
+    );
+    assert_rejects(
+        carina_provider_aws::schemas::generated::kms::key::arn(),
+        "alias/my-key",
+    );
+    assert_rejects(
+        carina_provider_aws::schemas::generated::kms::key::arn(),
+        "1234abcd-12ab-34cd-56ef-1234567890ab",
+    );
+}
+
+#[test]
+fn id_accepts_kms_key_identifier_forms() {
+    assert_accepts(
+        carina_provider_aws::schemas::generated::kms::key::id(),
+        "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+    );
+    assert_accepts(
+        carina_provider_aws::schemas::generated::kms::key::id(),
+        "arn:aws:kms:us-east-1:123456789012:alias/my-key",
+    );
+    assert_accepts(
+        carina_provider_aws::schemas::generated::kms::key::id(),
+        "alias/my-key",
+    );
+    assert_accepts(
+        carina_provider_aws::schemas::generated::kms::key::id(),
+        "1234abcd-12ab-34cd-56ef-1234567890ab",
+    );
+}
+
+#[test]
+fn arn_identity_is_provider_scoped() {
+    let t = carina_provider_aws::schemas::generated::kms::key::arn();
+    let carina_core::schema::RawShape::Custom { identity, .. } = t.raw_shape() else {
+        panic!("kms::key::arn() should be Custom");
+    };
+    assert_eq!(
+        identity.map(|id| id.to_string()).as_deref(),
+        Some("aws.kms.Key.Arn")
+    );
+}

--- a/carina-provider-aws/tests/organizations_arn.rs
+++ b/carina-provider-aws/tests/organizations_arn.rs
@@ -1,0 +1,26 @@
+use carina_core::schema::RawShape;
+use carina_provider_aws::schemas::generated::organizations;
+
+#[test]
+fn account_arn_identity_is_provider_scoped() {
+    let t = organizations::account::arn();
+    let RawShape::Custom { identity, .. } = t.raw_shape() else {
+        panic!("organizations::account::arn() should be Custom");
+    };
+    assert_eq!(
+        identity.map(|id| id.to_string()).as_deref(),
+        Some("aws.organizations.Account.Arn")
+    );
+}
+
+#[test]
+fn organization_arn_identity_is_provider_scoped() {
+    let t = organizations::organization::arn();
+    let RawShape::Custom { identity, .. } = t.raw_shape() else {
+        panic!("organizations::organization::arn() should be Custom");
+    };
+    assert_eq!(
+        identity.map(|id| id.to_string()).as_deref(),
+        Some("aws.organizations.Organization.Arn")
+    );
+}

--- a/carina-provider-aws/tests/s3_bucket_data_source_arn.rs
+++ b/carina-provider-aws/tests/s3_bucket_data_source_arn.rs
@@ -1,0 +1,14 @@
+use carina_core::schema::RawShape;
+use carina_provider_aws::schemas::generated::s3;
+
+#[test]
+fn bucket_data_source_arn_identity_is_provider_scoped() {
+    let t = s3::bucket_data_source::arn();
+    let RawShape::Custom { identity, .. } = t.raw_shape() else {
+        panic!("s3::bucket_data_source::arn() should be Custom");
+    };
+    assert_eq!(
+        identity.map(|id| id.to_string()).as_deref(),
+        Some("aws.s3.Bucket.Arn")
+    );
+}

--- a/carina-provider-aws/tests/sts_arn.rs
+++ b/carina-provider-aws/tests/sts_arn.rs
@@ -1,0 +1,14 @@
+use carina_core::schema::RawShape;
+use carina_provider_aws::schemas::generated::sts;
+
+#[test]
+fn caller_identity_arn_identity_is_provider_scoped() {
+    let t = sts::caller_identity::arn();
+    let RawShape::Custom { identity, .. } = t.raw_shape() else {
+        panic!("sts::caller_identity::arn() should be Custom");
+    };
+    assert_eq!(
+        identity.map(|id| id.to_string()).as_deref(),
+        Some("aws.sts.CallerIdentity.Arn")
+    );
+}


### PR DESCRIPTION
## Summary

- Move ARN newtype helpers from cross-service `carina-aws-types` into each resource's own generated schema module.
- Migrate the DSL type identity from a hard-coded `aws` provider axis to a `PROVIDER_NAME` constant, so every emitted identity threads through one rename point.
- Add a three-stage ARN lookup in codegen (per-kind table → service-prefix fallback → generic) so every `arn` attribute lands as a typed newtype, not as the generic `aws.Arn`.
- Delete the four hand-written helpers (`iam_role_arn`, `iam_policy_arn`, `kms_key_arn`, `kms_key_id`) from `carina-aws-types`. The deletion is the long-term guard: a future caller of those symbols gets a compile error rather than silently re-introducing the layering violation.

This is PR-A of the carina#3392 + carina#3256 series. The AWSCC counterpart (PR-B) and the `carina-rs/infra` namespace flip (PR-C) follow in lockstep.

## Design

Full design and plan live in `carina-rs/carina#3395` (already merged):

- Design: `docs/specs/2026-06-05-per-resource-arn-newtypes-design.md`
- Plan: `docs/plans/2026-06-05-per-resource-arn-newtypes.md` (Task A1-A8 + AWS regen + AWS verify cycle)

Core principle: a resource's ARN newtype is a property of that resource's schema, not of a cross-service utility crate. After this change, `iam::role::arn()` lives next to the IAM Role schema; other resources reference it via `super::super::iam::role::arn()`. IAM Policy and KMS Key aren't managed resources in this provider but are referenced by override-map entries (`PermissionsBoundary`, `ManagedPolicyArns`, `KmsKeyArn`, `KmsKeyId`, ...). The codegen emits them as **virtual helper modules** so the override-map symbols resolve; the virtual modules are deliberately not in `configs()`.

The KMS split deserves a callout: `kms::key::arn()` is strict (only `key/` ARNs), `kms::key::id()` is lenient (key ARN, alias ARN, bare alias, UUID — what `validate_kms_key_id` always accepted). The override map dispatches `KmsKeyArn` → `arn()` and `KmsKeyId` / `KMSMasterKeyID` / `ReplicaKmsKeyID` / `kmsKeyId` → `id()`. This preserves the old `kms_key_id()` acceptance behaviour without conflating Arn and Id.

## Why

Per the design doc + carina #3392 issue body:

- The previous shape exposed `aws.iam.Role.Arn` as a typed identifier but everything else (S3, CloudFront, ECS, ...) fell back to opaque `aws.Arn`. Consumer `.crn` files that wanted to type their `arguments {}` block as `awscc.s3.Bucket.Arn` got rejected by `validate`. Now every `arn` attribute has a typed newtype.
- The previous shape also produced `aws.*` identity strings regardless of which provider defined the type — so `awscc.iam.OidcProvider`'s ARN came out as `aws.iam.OidcProvider.Arn`. Carina #3256 tracked the resulting confusion. Moving the namespace axis to `PROVIDER_NAME` closes that for this repo's side and lines up with the AWSCC repo doing the same thing with `PROVIDER_NAME = "awscc"`.

## Test plan

All checks green locally:

- [x] `cargo check -p carina-aws-types -p carina-codegen-aws -p carina-provider-aws --all-targets`
- [x] `cargo nextest run --workspace` (478 tests pass — includes the new identity tests below)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-carina-pin.sh`
- [x] `bash scripts/check-examples.sh`
- [x] `bash scripts/check-string-enum-aliases.sh`
- [x] `./scripts/generate-schemas-smithy.sh && ./scripts/generate-docs.sh` produces zero drift on re-run

### New integration tests

Living under `carina-provider-aws/tests/` (so codegen regen doesn't erase them):

| File | Coverage |
| ---- | -------- |
| `iam_role_arn.rs` | identity is `aws.iam.Role.Arn`, accepts valid role ARN, rejects policy ARN |
| `iam_policy_arn.rs` | identity is `aws.iam.Policy.Arn`, rejects role ARN |
| `kms_key_arn.rs` | strict `arn()` + lenient `id()` (key ARN, alias ARN, bare alias, UUID) + identity |
| `organizations_arn.rs` | account/organization identity |
| `s3_bucket_data_source_arn.rs` | s3 data-source identity (resolves to `aws.s3.Bucket.Arn`) |
| `sts_arn.rs` | caller_identity service-prefix-emitted identity |

## Cross-repo

Closes `carina-rs/carina#3396`. Refs `carina-rs/carina#3392`, `carina-rs/carina#3256`. Coordinate with PR-B (`carina-rs/carina-provider-awscc`) before PR-C (`carina-rs/infra` type-reference flip).