### PR TITLE
Release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "carina-codegen-aws"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "carina-smithy",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "carina-provider-aws"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "carina-smithy"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"


### PR DESCRIPTION
Bump workspace version 0.5.0 → 0.6.0 ahead of cutting the v0.6.0 tag.

Carries the per-resource ARN newtypes + DSL namespace migration that landed in #405 (carina#3392 + carina#3256). Pairs with the parallel awscc release; `carina-rs/infra` consumes both v0.6.0 tags once they are published.