### PR TITLE
provider: async-lift initialize/CRUD to BoxFuture for carina#3400

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
+source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
 dependencies = [
  "argon2",
  "futures",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
+source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -893,7 +893,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
+source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1119,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
+source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
 dependencies = [
  "argon2",
  "futures",
@@ -838,11 +838,13 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
+source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "carina-provider-protocol",
+ "futures-executor",
+ "futures-util",
  "http 1.4.0",
  "serde",
  "serde_json",
@@ -891,7 +893,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
+source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }
@@ -52,7 +52,7 @@ tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "time"] }
-wit-bindgen = { version = "0.54", default-features = false, features = ["macros"] }
+wit-bindgen = { version = "0.54", default-features = false, features = ["macros", "async"] }
 wasi = "0.14"
 
 # In-process AWS service emulator for integration tests. Host-only —

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
 
 mod convert;
-use carina_plugin_sdk::CarinaProvider;
+use carina_plugin_sdk::{BoxFuture, CarinaProvider};
 use carina_provider_protocol::types as proto;
 
 use carina_core::provider::{
@@ -17,7 +20,6 @@ use carina_provider_aws::AwsNormalizer;
 use carina_provider_aws::AwsProvider;
 
 struct AwsProcessProvider {
-    runtime: tokio::runtime::Runtime,
     provider: Option<AwsProvider>,
     normalizer: AwsNormalizer,
 }
@@ -30,15 +32,7 @@ impl Default for AwsProcessProvider {
 
 impl AwsProcessProvider {
     fn new() -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-        #[cfg(target_arch = "wasm32")]
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
-            .build()
-            .expect("Failed to create tokio runtime");
         Self {
-            runtime,
             provider: None,
             normalizer: AwsNormalizer,
         }
@@ -73,6 +67,16 @@ impl AwsProcessProvider {
         self.provider
             .as_ref()
             .expect("Provider not initialized; call initialize() first")
+    }
+}
+
+fn run_ready_future<T>(future: impl Future<Output = T>) -> T {
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(waker);
+    let mut future = Box::pin(future);
+    match Pin::as_mut(&mut future).poll(&mut cx) {
+        Poll::Ready(value) => value,
+        Poll::Pending => panic!("normalizer future unexpectedly yielded"),
     }
 }
 
@@ -170,32 +174,33 @@ impl CarinaProvider for AwsProcessProvider {
         Ok(())
     }
 
-    fn initialize(&mut self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
-        use carina_provider_aws::services::sts::account_guard::extract_string_list;
-        use carina_provider_aws::services::sts::assume_role::extract_assume_role;
-        let core_attrs = convert::proto_to_core_value_map(attrs);
-        let region = if let Some(CoreValue::Concrete(ConcreteValue::String(region))) =
-            core_attrs.get("region")
-        {
-            carina_core::utils::convert_region_value(region)
-        } else {
-            "ap-northeast-1".to_string()
-        };
-        let allowed = extract_string_list(core_attrs.get("allowed_account_ids"));
-        let forbidden = extract_string_list(core_attrs.get("forbidden_account_ids"));
-        let assume_role = extract_assume_role(core_attrs.get("assume_role"))?;
-        let provider = self.runtime.block_on(AwsProvider::new_with_account_guard(
-            &region,
-            allowed,
-            forbidden,
-            assume_role,
-        ));
-        // Run the account guard before we accept this provider — fails
-        // fast (before any read/plan/apply) when the credentials in use
-        // point at the wrong AWS account.
-        self.runtime.block_on(provider.verify_account_id())?;
-        self.provider = Some(provider);
-        Ok(())
+    fn initialize<'a>(
+        &'a mut self,
+        attrs: &'a HashMap<String, proto::Value>,
+    ) -> BoxFuture<'a, Result<(), String>> {
+        Box::pin(async move {
+            use carina_provider_aws::services::sts::account_guard::extract_string_list;
+            use carina_provider_aws::services::sts::assume_role::extract_assume_role;
+            let core_attrs = convert::proto_to_core_value_map(attrs);
+            let region = if let Some(CoreValue::Concrete(ConcreteValue::String(region))) =
+                core_attrs.get("region")
+            {
+                carina_core::utils::convert_region_value(region)
+            } else {
+                "ap-northeast-1".to_string()
+            };
+            let allowed = extract_string_list(core_attrs.get("allowed_account_ids"));
+            let forbidden = extract_string_list(core_attrs.get("forbidden_account_ids"));
+            let assume_role = extract_assume_role(core_attrs.get("assume_role"))?;
+            let provider =
+                AwsProvider::new_with_account_guard(&region, allowed, forbidden, assume_role).await;
+            // Run the account guard before we accept this provider — fails
+            // fast (before any read/plan/apply) when the credentials in use
+            // point at the wrong AWS account.
+            provider.verify_account_id().await?;
+            self.provider = Some(provider);
+            Ok(())
+        })
     }
 
     fn config_completions(&self) -> HashMap<String, Vec<proto::CompletionValue>> {
@@ -242,61 +247,64 @@ impl CarinaProvider for AwsProcessProvider {
         }
     }
 
-    fn read(
-        &self,
-        id: &proto::ResourceId,
-        identifier: Option<&str>,
+    fn read<'a>(
+        &'a self,
+        id: &'a proto::ResourceId,
+        identifier: Option<&'a str>,
         _request: proto::ReadRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
-        let result =
-            self.runtime
-                .block_on(self.provider().read(&core_id, identifier, CoreReadRequest));
-        match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self
+                .provider()
+                .read(&core_id, identifier, CoreReadRequest)
+                .await;
+            match result {
+                Ok(state) => Ok(convert::core_to_proto_state(&state)),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
-    fn read_data_source(
-        &self,
-        resource: &proto::Resource,
-    ) -> Result<proto::State, proto::ProviderError> {
+    fn read_data_source<'a>(
+        &'a self,
+        resource: &'a proto::Resource,
+    ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
         let core_data_source = convert::proto_to_core_data_source(resource);
-        let result = self
-            .runtime
-            .block_on(self.provider().read_data_source(&core_data_source));
-        match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self.provider().read_data_source(&core_data_source).await;
+            match result {
+                Ok(state) => Ok(convert::core_to_proto_state(&state)),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
-    fn create(
-        &self,
-        id: &proto::ResourceId,
+    fn create<'a>(
+        &'a self,
+        id: &'a proto::ResourceId,
         request: proto::CreateRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_resource = convert::proto_to_core_resource(&request.resource);
         let core_request = CoreCreateRequest {
             resource: core_resource,
         };
-        let result = self
-            .runtime
-            .block_on(self.provider().create(&core_id, core_request));
-        match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self.provider().create(&core_id, core_request).await;
+            match result {
+                Ok(state) => Ok(convert::core_to_proto_state(&state)),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
-    fn update(
-        &self,
-        id: &proto::ResourceId,
-        identifier: &str,
+    fn update<'a>(
+        &'a self,
+        id: &'a proto::ResourceId,
+        identifier: &'a str,
         request: proto::UpdateRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_from = convert::proto_to_core_state(&request.from);
         let core_patch = CoreUpdatePatch {
@@ -319,21 +327,24 @@ impl CarinaProvider for AwsProcessProvider {
             from: core_from,
             patch: core_patch,
         };
-        let result =
-            self.runtime
-                .block_on(self.provider().update(&core_id, identifier, core_request));
-        match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self
+                .provider()
+                .update(&core_id, identifier, core_request)
+                .await;
+            match result {
+                Ok(state) => Ok(convert::core_to_proto_state(&state)),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
-    fn delete(
-        &self,
-        id: &proto::ResourceId,
-        identifier: &str,
+    fn delete<'a>(
+        &'a self,
+        id: &'a proto::ResourceId,
+        identifier: &'a str,
         request: proto::DeleteRequest,
-    ) -> Result<(), proto::ProviderError> {
+    ) -> BoxFuture<'a, Result<(), proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_directives = carina_core::resource::Directives {
             force_delete: request.directives.force_delete,
@@ -345,13 +356,16 @@ impl CarinaProvider for AwsProcessProvider {
         let core_request = CoreDeleteRequest {
             directives: core_directives,
         };
-        let result =
-            self.runtime
-                .block_on(self.provider().delete(&core_id, identifier, core_request));
-        match result {
-            Ok(()) => Ok(()),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self
+                .provider()
+                .delete(&core_id, identifier, core_request)
+                .await;
+            match result {
+                Ok(()) => Ok(()),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
     fn normalize_desired(&self, resources: Vec<proto::Resource>) -> Vec<proto::Resource> {
@@ -359,13 +373,7 @@ impl CarinaProvider for AwsProcessProvider {
             .iter()
             .map(convert::proto_to_core_resource)
             .collect();
-        // Guest-side: drive the now-async normalizer on the guest's own
-        // outermost runtime — the same pattern the `Provider` CRUD
-        // methods use here (`self.runtime.block_on(...)`). Not a nested
-        // runtime: the host drives the WASM call, the guest drives its
-        // internal async with this runtime (carina#3112 design Non-goal).
-        self.runtime
-            .block_on(self.normalizer.normalize_desired(&mut core_resources));
+        run_ready_future(self.normalizer.normalize_desired(&mut core_resources));
         core_resources
             .iter()
             .map(convert::core_to_proto_resource)
@@ -390,7 +398,7 @@ impl CarinaProvider for AwsProcessProvider {
         for s in proto_schemas {
             registry.insert("aws", convert::proto_to_core_schema(s));
         }
-        self.runtime.block_on(self.normalizer.merge_default_tags(
+        run_ready_future(self.normalizer.merge_default_tags(
             &mut core_resources,
             &core_tags,
             &registry,


### PR DESCRIPTION
## Summary

Re-pins carina-plugin-sdk / carina-core / carina-provider-protocol (and carina-aws-types' carina-core pin) to carina@387d64b5 (which contains carina#3401's WIT async lift). The `AwsProcessProvider` drops its embedded `tokio::runtime::Runtime` and `block_on` layer; `initialize`, `read`, `read_data_source`, `create`, `update`, `delete` return `BoxFuture` and await the existing async core provider futures directly.

The sync normalizer hook uses a one-poll helper so the runtime field is no longer required for non-I/O normalizer futures.

## Cross-repo dependency

This PR pairs with:
- carina-rs/carina#3401 (already merged) — WIT + SDK + host + mock change.
- carina-rs/carina-provider-awscc#326 (parallel) — same conversion for the AWSCC provider.

The user-visible hang in `carina-rs/infra/envs/registry/dev/infra` is cured only after this PR + the awscc PR + an `infra` lock refresh.

## Test plan

- [x] `cargo check --workspace` PASS
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release` PASS
- [x] `cargo nextest run --workspace` 478 tests PASS
- [x] `cargo clippy --workspace --all-targets -- -D warnings` PASS
- [ ] Real-infra `carina plan` once all three PRs merge and lock refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)