### PR TITLE
Revert Stage A async-providers for carina#3400 (#407, #408)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
+source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
 dependencies = [
  "argon2",
  "futures",
@@ -838,13 +838,11 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
+source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "carina-provider-protocol",
- "futures-executor",
- "futures-util",
  "http 1.4.0",
  "serde",
  "serde_json",
@@ -893,7 +891,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
+source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
 dependencies = [
  "serde",
  "serde_json",
@@ -1119,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }
@@ -52,7 +52,7 @@ tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "time"] }
-wit-bindgen = { version = "0.54", default-features = false, features = ["macros", "async"] }
+wit-bindgen = { version = "0.54", default-features = false, features = ["macros"] }
 wasi = "0.14"
 
 # In-process AWS service emulator for integration tests. Host-only —

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -20,7 +20,6 @@ use carina_provider_aws::AwsNormalizer;
 use carina_provider_aws::AwsProvider;
 
 struct AwsProcessProvider {
-    runtime: tokio::runtime::Runtime,
     provider: Option<AwsProvider>,
     normalizer: AwsNormalizer,
 }
@@ -33,12 +32,7 @@ impl Default for AwsProcessProvider {
 
 impl AwsProcessProvider {
     fn new() -> Self {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
-            .build()
-            .expect("failed to build AWS provider tokio runtime");
         Self {
-            runtime,
             provider: None,
             normalizer: AwsNormalizer,
         }
@@ -198,17 +192,12 @@ impl CarinaProvider for AwsProcessProvider {
             let allowed = extract_string_list(core_attrs.get("allowed_account_ids"));
             let forbidden = extract_string_list(core_attrs.get("forbidden_account_ids"));
             let assume_role = extract_assume_role(core_attrs.get("assume_role"))?;
-            let provider = {
-                let _enter = self.runtime.enter();
-                let provider =
-                    AwsProvider::new_with_account_guard(&region, allowed, forbidden, assume_role)
-                        .await;
-                // Run the account guard before we accept this provider — fails
-                // fast (before any read/plan/apply) when the credentials in use
-                // point at the wrong AWS account.
-                provider.verify_account_id().await?;
-                provider
-            };
+            let provider =
+                AwsProvider::new_with_account_guard(&region, allowed, forbidden, assume_role).await;
+            // Run the account guard before we accept this provider — fails
+            // fast (before any read/plan/apply) when the credentials in use
+            // point at the wrong AWS account.
+            provider.verify_account_id().await?;
             self.provider = Some(provider);
             Ok(())
         })
@@ -266,7 +255,6 @@ impl CarinaProvider for AwsProcessProvider {
     ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
         Box::pin(async move {
-            let _enter = self.runtime.enter();
             let result = self
                 .provider()
                 .read(&core_id, identifier, CoreReadRequest)
@@ -284,7 +272,6 @@ impl CarinaProvider for AwsProcessProvider {
     ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
         let core_data_source = convert::proto_to_core_data_source(resource);
         Box::pin(async move {
-            let _enter = self.runtime.enter();
             let result = self.provider().read_data_source(&core_data_source).await;
             match result {
                 Ok(state) => Ok(convert::core_to_proto_state(&state)),
@@ -304,7 +291,6 @@ impl CarinaProvider for AwsProcessProvider {
             resource: core_resource,
         };
         Box::pin(async move {
-            let _enter = self.runtime.enter();
             let result = self.provider().create(&core_id, core_request).await;
             match result {
                 Ok(state) => Ok(convert::core_to_proto_state(&state)),
@@ -342,7 +328,6 @@ impl CarinaProvider for AwsProcessProvider {
             patch: core_patch,
         };
         Box::pin(async move {
-            let _enter = self.runtime.enter();
             let result = self
                 .provider()
                 .update(&core_id, identifier, core_request)
@@ -372,7 +357,6 @@ impl CarinaProvider for AwsProcessProvider {
             directives: core_directives,
         };
         Box::pin(async move {
-            let _enter = self.runtime.enter();
             let result = self
                 .provider()
                 .delete(&core_id, identifier, core_request)

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -1,10 +1,7 @@
 use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
 
 mod convert;
-use carina_plugin_sdk::{BoxFuture, CarinaProvider};
+use carina_plugin_sdk::CarinaProvider;
 use carina_provider_protocol::types as proto;
 
 use carina_core::provider::{
@@ -20,6 +17,7 @@ use carina_provider_aws::AwsNormalizer;
 use carina_provider_aws::AwsProvider;
 
 struct AwsProcessProvider {
+    runtime: tokio::runtime::Runtime,
     provider: Option<AwsProvider>,
     normalizer: AwsNormalizer,
 }
@@ -32,7 +30,15 @@ impl Default for AwsProcessProvider {
 
 impl AwsProcessProvider {
     fn new() -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+        #[cfg(target_arch = "wasm32")]
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("Failed to create tokio runtime");
         Self {
+            runtime,
             provider: None,
             normalizer: AwsNormalizer,
         }
@@ -67,16 +73,6 @@ impl AwsProcessProvider {
         self.provider
             .as_ref()
             .expect("Provider not initialized; call initialize() first")
-    }
-}
-
-fn run_ready_future<T>(future: impl Future<Output = T>) -> T {
-    let waker = Waker::noop();
-    let mut cx = Context::from_waker(waker);
-    let mut future = Box::pin(future);
-    match Pin::as_mut(&mut future).poll(&mut cx) {
-        Poll::Ready(value) => value,
-        Poll::Pending => panic!("normalizer future unexpectedly yielded"),
     }
 }
 
@@ -174,33 +170,32 @@ impl CarinaProvider for AwsProcessProvider {
         Ok(())
     }
 
-    fn initialize<'a>(
-        &'a mut self,
-        attrs: &'a HashMap<String, proto::Value>,
-    ) -> BoxFuture<'a, Result<(), String>> {
-        Box::pin(async move {
-            use carina_provider_aws::services::sts::account_guard::extract_string_list;
-            use carina_provider_aws::services::sts::assume_role::extract_assume_role;
-            let core_attrs = convert::proto_to_core_value_map(attrs);
-            let region = if let Some(CoreValue::Concrete(ConcreteValue::String(region))) =
-                core_attrs.get("region")
-            {
-                carina_core::utils::convert_region_value(region)
-            } else {
-                "ap-northeast-1".to_string()
-            };
-            let allowed = extract_string_list(core_attrs.get("allowed_account_ids"));
-            let forbidden = extract_string_list(core_attrs.get("forbidden_account_ids"));
-            let assume_role = extract_assume_role(core_attrs.get("assume_role"))?;
-            let provider =
-                AwsProvider::new_with_account_guard(&region, allowed, forbidden, assume_role).await;
-            // Run the account guard before we accept this provider — fails
-            // fast (before any read/plan/apply) when the credentials in use
-            // point at the wrong AWS account.
-            provider.verify_account_id().await?;
-            self.provider = Some(provider);
-            Ok(())
-        })
+    fn initialize(&mut self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
+        use carina_provider_aws::services::sts::account_guard::extract_string_list;
+        use carina_provider_aws::services::sts::assume_role::extract_assume_role;
+        let core_attrs = convert::proto_to_core_value_map(attrs);
+        let region = if let Some(CoreValue::Concrete(ConcreteValue::String(region))) =
+            core_attrs.get("region")
+        {
+            carina_core::utils::convert_region_value(region)
+        } else {
+            "ap-northeast-1".to_string()
+        };
+        let allowed = extract_string_list(core_attrs.get("allowed_account_ids"));
+        let forbidden = extract_string_list(core_attrs.get("forbidden_account_ids"));
+        let assume_role = extract_assume_role(core_attrs.get("assume_role"))?;
+        let provider = self.runtime.block_on(AwsProvider::new_with_account_guard(
+            &region,
+            allowed,
+            forbidden,
+            assume_role,
+        ));
+        // Run the account guard before we accept this provider — fails
+        // fast (before any read/plan/apply) when the credentials in use
+        // point at the wrong AWS account.
+        self.runtime.block_on(provider.verify_account_id())?;
+        self.provider = Some(provider);
+        Ok(())
     }
 
     fn config_completions(&self) -> HashMap<String, Vec<proto::CompletionValue>> {
@@ -247,64 +242,61 @@ impl CarinaProvider for AwsProcessProvider {
         }
     }
 
-    fn read<'a>(
-        &'a self,
-        id: &'a proto::ResourceId,
-        identifier: Option<&'a str>,
+    fn read(
+        &self,
+        id: &proto::ResourceId,
+        identifier: Option<&str>,
         _request: proto::ReadRequest,
-    ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
+    ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
-        Box::pin(async move {
-            let result = self
-                .provider()
-                .read(&core_id, identifier, CoreReadRequest)
-                .await;
-            match result {
-                Ok(state) => Ok(convert::core_to_proto_state(&state)),
-                Err(e) => Err(Self::convert_error(e)),
-            }
-        })
+        let result =
+            self.runtime
+                .block_on(self.provider().read(&core_id, identifier, CoreReadRequest));
+        match result {
+            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Err(e) => Err(Self::convert_error(e)),
+        }
     }
 
-    fn read_data_source<'a>(
-        &'a self,
-        resource: &'a proto::Resource,
-    ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
+    fn read_data_source(
+        &self,
+        resource: &proto::Resource,
+    ) -> Result<proto::State, proto::ProviderError> {
         let core_data_source = convert::proto_to_core_data_source(resource);
-        Box::pin(async move {
-            let result = self.provider().read_data_source(&core_data_source).await;
-            match result {
-                Ok(state) => Ok(convert::core_to_proto_state(&state)),
-                Err(e) => Err(Self::convert_error(e)),
-            }
-        })
+        let result = self
+            .runtime
+            .block_on(self.provider().read_data_source(&core_data_source));
+        match result {
+            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Err(e) => Err(Self::convert_error(e)),
+        }
     }
 
-    fn create<'a>(
-        &'a self,
-        id: &'a proto::ResourceId,
+    fn create(
+        &self,
+        id: &proto::ResourceId,
         request: proto::CreateRequest,
-    ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
+    ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_resource = convert::proto_to_core_resource(&request.resource);
         let core_request = CoreCreateRequest {
             resource: core_resource,
         };
-        Box::pin(async move {
-            let result = self.provider().create(&core_id, core_request).await;
-            match result {
-                Ok(state) => Ok(convert::core_to_proto_state(&state)),
-                Err(e) => Err(Self::convert_error(e)),
-            }
-        })
+        let result = self
+            .runtime
+            .block_on(self.provider().create(&core_id, core_request));
+        match result {
+            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Err(e) => Err(Self::convert_error(e)),
+        }
     }
 
-    fn update<'a>(
-        &'a self,
-        id: &'a proto::ResourceId,
-        identifier: &'a str,
+    fn update(
+        &self,
+        id: &proto::ResourceId,
+        identifier: &str,
         request: proto::UpdateRequest,
-    ) -> BoxFuture<'a, Result<proto::State, proto::ProviderError>> {
+    ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_from = convert::proto_to_core_state(&request.from);
         let core_patch = CoreUpdatePatch {
@@ -327,24 +319,21 @@ impl CarinaProvider for AwsProcessProvider {
             from: core_from,
             patch: core_patch,
         };
-        Box::pin(async move {
-            let result = self
-                .provider()
-                .update(&core_id, identifier, core_request)
-                .await;
-            match result {
-                Ok(state) => Ok(convert::core_to_proto_state(&state)),
-                Err(e) => Err(Self::convert_error(e)),
-            }
-        })
+        let result =
+            self.runtime
+                .block_on(self.provider().update(&core_id, identifier, core_request));
+        match result {
+            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Err(e) => Err(Self::convert_error(e)),
+        }
     }
 
-    fn delete<'a>(
-        &'a self,
-        id: &'a proto::ResourceId,
-        identifier: &'a str,
+    fn delete(
+        &self,
+        id: &proto::ResourceId,
+        identifier: &str,
         request: proto::DeleteRequest,
-    ) -> BoxFuture<'a, Result<(), proto::ProviderError>> {
+    ) -> Result<(), proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_directives = carina_core::resource::Directives {
             force_delete: request.directives.force_delete,
@@ -356,16 +345,13 @@ impl CarinaProvider for AwsProcessProvider {
         let core_request = CoreDeleteRequest {
             directives: core_directives,
         };
-        Box::pin(async move {
-            let result = self
-                .provider()
-                .delete(&core_id, identifier, core_request)
-                .await;
-            match result {
-                Ok(()) => Ok(()),
-                Err(e) => Err(Self::convert_error(e)),
-            }
-        })
+        let result =
+            self.runtime
+                .block_on(self.provider().delete(&core_id, identifier, core_request));
+        match result {
+            Ok(()) => Ok(()),
+            Err(e) => Err(Self::convert_error(e)),
+        }
     }
 
     fn normalize_desired(&self, resources: Vec<proto::Resource>) -> Vec<proto::Resource> {
@@ -373,7 +359,13 @@ impl CarinaProvider for AwsProcessProvider {
             .iter()
             .map(convert::proto_to_core_resource)
             .collect();
-        run_ready_future(self.normalizer.normalize_desired(&mut core_resources));
+        // Guest-side: drive the now-async normalizer on the guest's own
+        // outermost runtime — the same pattern the `Provider` CRUD
+        // methods use here (`self.runtime.block_on(...)`). Not a nested
+        // runtime: the host drives the WASM call, the guest drives its
+        // internal async with this runtime (carina#3112 design Non-goal).
+        self.runtime
+            .block_on(self.normalizer.normalize_desired(&mut core_resources));
         core_resources
             .iter()
             .map(convert::core_to_proto_resource)
@@ -398,7 +390,7 @@ impl CarinaProvider for AwsProcessProvider {
         for s in proto_schemas {
             registry.insert("aws", convert::proto_to_core_schema(s));
         }
-        run_ready_future(self.normalizer.merge_default_tags(
+        self.runtime.block_on(self.normalizer.merge_default_tags(
             &mut core_resources,
             &core_tags,
             &registry,


### PR DESCRIPTION
Reverts:
- #407 `provider: async-lift initialize/CRUD to BoxFuture for carina#3400`
- #408 `provider: restore minimal tokio runtime for AWS SDK sleep context`

## Why

Stage A of carina#3400 (host bindgen async-lift + WIT change + provider `BoxFuture` migration) was merged across 4 repos / 7 PRs but **does not fix the real-infra `carina plan` hang**. The wasmtime trace still shows the same `NeedWork ↔ StartImplicit` livelock as before Stage A. Root cause is not yet identified.

Reverting the entire Stage A surface across all 4 repos so main matches the last-known shape while the hang is investigated with debug instrumentation. carina-rs/carina#3400 stays open; the design notes are preserved on carina main.

Companion reverts:
- carina-rs/carina (Stage A host + SDK macro)
- carina-rs/carina-plugin-wit#20 (WIT async export)
- carina-rs/carina-provider-awscc#328 (#326, #327)