### PR TITLE
Adopt data-driven DslTransform enum from carina#3414

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 generated-docs/
 carina-provider-aws/tests/fixtures/smithy/
+.cargo/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,9 +819,10 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fe9d3f220c3f3011fa5607e9dd321d63f049064#6fe9d3f220c3f3011fa5607e9dd321d63f049064"
+source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
 dependencies = [
  "argon2",
+ "carina-provider-protocol",
  "futures",
  "indexmap",
  "pest",
@@ -838,7 +839,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fe9d3f220c3f3011fa5607e9dd321d63f049064#6fe9d3f220c3f3011fa5607e9dd321d63f049064"
+source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -891,7 +892,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fe9d3f220c3f3011fa5607e9dd321d63f049064#6fe9d3f220c3f3011fa5607e9dd321d63f049064"
+source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fe9d3f220c3f3011fa5607e9dd321d63f049064" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fe9d3f220c3f3011fa5607e9dd321d63f049064" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "6fe9d3f220c3f3011fa5607e9dd321d63f049064" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "6fe9d3f220c3f3011fa5607e9dd321d63f049064" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -307,9 +307,7 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             None,
             vec![],
             None,
-            dsl_transform
-                .as_deref()
-                .and_then(carina_core::schema::dsl_transform_for),
+            dsl_transform.clone(),
         ),
         // Cyclic CFN struct reference (carina#3340). The host's
         // structural counterpart is `AttributeType::ref_`; the matching
@@ -474,12 +472,13 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             identity,
             base,
             values: None,
+            to_dsl,
             ..
         } => ProtoAttributeType::CustomEnum {
             name: identity.kind.clone(),
             base: Box::new(core_to_proto_attribute_type(base)),
             namespace: identity.dotted_prefix().unwrap_or_default(),
-            dsl_transform: None,
+            dsl_transform: to_dsl.cloned(),
         },
         CoreRawShape::Union(members) => ProtoAttributeType::Union {
             members: members.iter().map(core_to_proto_attribute_type).collect(),
@@ -651,6 +650,40 @@ mod tests {
                 assert_eq!(rt_length, Some(length));
             }
             other => panic!("Expected Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_enum_dsl_transform_crosses_proto_boundary_both_ways() {
+        let core_type = CoreAttributeType::enum_with_base(
+            carina_core::schema::enum_identity("Region", Some("aws")),
+            CoreAttributeType::string(),
+            None,
+            vec![],
+            None,
+            Some(carina_core::schema::DslTransform::HyphenToUnderscore),
+        );
+
+        let proto_type = core_to_proto_attribute_type(&core_type);
+        match &proto_type {
+            ProtoAttributeType::CustomEnum { dsl_transform, .. } => {
+                assert_eq!(
+                    dsl_transform.as_ref(),
+                    Some(&carina_core::schema::DslTransform::HyphenToUnderscore)
+                );
+            }
+            other => panic!("Expected CustomEnum, got {other:?}"),
+        }
+
+        let roundtripped = proto_to_core_attribute_type(&proto_type);
+        match roundtripped.raw_shape() {
+            CoreRawShape::Enum { to_dsl, .. } => {
+                assert_eq!(
+                    to_dsl,
+                    Some(&carina_core::schema::DslTransform::HyphenToUnderscore)
+                );
+            }
+            other => panic!("Expected Enum, got {other:?}"),
         }
     }
 

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -8,7 +8,7 @@ pub use carina_aws_types::*;
 use std::collections::HashMap;
 
 use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, ResourceSchema, legacy_validator};
+use carina_core::schema::{AttributeType, DslTransform, ResourceSchema, legacy_validator};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 
 /// AWS schema configuration
@@ -82,7 +82,7 @@ pub fn aws_region() -> AttributeType {
                 Err("Expected string".to_string())
             }
         })),
-        Some(|s: &str| s.replace('-', "_")),
+        Some(DslTransform::HyphenToUnderscore),
     )
 }
 
@@ -109,7 +109,7 @@ pub fn availability_zone() -> AttributeType {
                 Err("Expected string".to_string())
             }
         })),
-        Some(|s: &str| s.replace('-', "_")),
+        Some(DslTransform::HyphenToUnderscore),
     )
 }
 
@@ -417,9 +417,11 @@ mod tests {
         if let carina_core::schema::Shape::Enum { to_dsl, .. } =
             az_type.shape_ref_free().expect("test schema is Ref-free")
         {
-            assert!(to_dsl.is_some());
-            let convert = to_dsl.unwrap();
-            assert_eq!(convert("us-east-1a"), "us_east_1a");
+            assert_eq!(to_dsl, Some(&DslTransform::HyphenToUnderscore));
+            assert_eq!(
+                DslTransform::HyphenToUnderscore.apply("us-east-1a"),
+                "us_east_1a"
+            );
         } else {
             panic!("Expected enum type");
         }


### PR DESCRIPTION
## Summary

Adopts the data-driven `DslTransform` enum from `carina-rs/carina#3414` (PR `carina-rs/carina#3416` merged 2026-06-07).

## Changes

- Dep bump `carina-core` git rev to `31f62d0140e754fcf6867b67d7c1e1aab008acf7`.
- Replace Region / AvailabilityZone `to_dsl` closures with `DslTransform::HyphenToUnderscore` (the data variant the host now evaluates directly without a fn-pointer registry lookup).
- `convert.rs` proto↔core conversion now passes the `Option<DslTransform>` field through verbatim instead of looking up a fn pointer by name.

## Why

In carina#3412 the transform crossed the WASM boundary as a string name resolved through a host-side `LazyLock<RwLock<HashMap>>` registry. The data-driven enum from carina#3414 makes the transform IS the data crossing the wire — host evaluates `transform.apply(s)` directly with no name lookup. Closes the same class of bug at the type level for this provider too.

## Verification

- `cargo check --workspace --all-targets` clean
- `cargo nextest run --workspace --all-features` → 479 passed
- `cargo test --workspace --doc` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `bash scripts/check-*.sh` (carina-pin / examples / string-enum-aliases) all OK
- Dead-name sweep `rg 'register_dsl_transform|dsl_transform_for|DslTransformFn|hyphen_to_underscore'` → no matches in production code

## Tests

- Updated `availability_zone` round-trip test to assert both the structural variant (`Some(&DslTransform::HyphenToUnderscore)`) AND the behavioral semantics (`apply("us-east-1a") == "us_east_1a"`) as defense-in-depth.

## Cross-repo

Parent: `carina-rs/carina#3414` (PR carina-rs/carina#3416, merged).
Sibling: carina-rs/carina-provider-awscc#332 (merged).

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
