### PR TITLE
Acceptance tests: switch awscc.Region to aws.Region (carina#3413)

### DIFF
--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -10,7 +10,7 @@ provider aws {
 }
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = aws.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -10,7 +10,7 @@ provider aws {
 }
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = aws.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -10,7 +10,7 @@ provider aws {
 }
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = aws.ec2.Vpc {


### PR DESCRIPTION
## Summary

Follow-up to carina-rs/carina#3413. The unified TypeIdentity contract removed the ``awscc.Region`` / ``awscc.AvailabilityZone`` DSL forms; only ``aws.Region`` etc. are valid now. Three acceptance test fixtures in this repo still wrote the old form. This PR updates them mechanically.

## Changes

- ``acceptance-tests/ec2_route/nat_gateway.crn``
- ``acceptance-tests/in_place_update/ec2_route_step1.crn``
- ``acceptance-tests/in_place_update/ec2_route_step2.crn``

All three: ``region = awscc.Region.ap_northeast_1`` → ``region = aws.Region.ap_northeast_1``.

## Verify

- ``cargo nextest run -p carina-provider-aws``: 281 tests pass

Refs carina-rs/carina#3413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)