### PR TITLE
Acceptance tests: switch awscc.ec2.Eip.Domain to aws.ec2.Eip.Domain (carina#3413)

### DIFF
--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -40,7 +40,7 @@ let subnet = aws.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 let nat_gw = awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -40,7 +40,7 @@ let subnet = aws.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -40,7 +40,7 @@ let subnet = aws.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 let nat_gw = awscc.ec2.NatGateway {


### PR DESCRIPTION
## Summary

Follow-up to carina-rs/carina-provider-aws#418. That PR rewrote ``awscc.Region`` only, missing ``awscc.ec2.Eip.Domain.vpc`` in three acceptance fixtures. After carina-rs/carina-provider-awscc#338 unified the underlying TypeIdentity to ``aws.*``, the ``awscc.ec2.Eip.Domain`` DSL form is invalid.

## Changes

3 files changed:
- ``acceptance-tests/ec2_route/nat_gateway.crn``
- ``acceptance-tests/in_place_update/ec2_route_step1.crn``
- ``acceptance-tests/in_place_update/ec2_route_step2.crn``

Each: ``domain = awscc.ec2.Eip.Domain.vpc`` → ``domain = aws.ec2.Eip.Domain.vpc``.

Resource type references (``awscc.ec2.Eip``, ``awscc.ec2.NatGateway``) stay intact.

## Verify

Ran ``./acceptance-tests/run-tests.sh full`` locally against 10 test accounts. Six failures remain unrelated to this PR's scope and concern a separate ``aws.AvailabilityZone.<value>`` validator regression (the validator now requires ``aws.AvailabilityZone.ZoneName.<value>`` form). Tracked separately.

Refs carina-rs/carina#3413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)