### PR TITLE
Acceptance tests: switch aws.AvailabilityZone.<value> to aws.AvailabilityZone.ZoneName.<value> (carina#3424)

### DIFF
--- a/acceptance-tests/ec2_nat_gateway/basic.crn
+++ b/acceptance-tests/ec2_nat_gateway/basic.crn
@@ -25,7 +25,7 @@ aws.ec2.InternetGateway {
 let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/ec2_subnet/basic.crn
+++ b/acceptance-tests/ec2_subnet/basic.crn
@@ -17,7 +17,7 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/ec2_subnet/ipv6.crn
+++ b/acceptance-tests/ec2_subnet/ipv6.crn
@@ -17,7 +17,7 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id                          = vpc.vpc_id
   cidr_block                      = '10.0.1.0/24'
-  availability_zone               = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone               = aws.AvailabilityZone.ZoneName.ap_northeast_1a
   assign_ipv6_address_on_creation = false
 
   tags = {

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -19,7 +19,7 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 
   private_dns_name_options_on_launch = {
     enable_resource_name_dns_a_record = true

--- a/acceptance-tests/ec2_subnet_route_table_association/basic.crn
+++ b/acceptance-tests/ec2_subnet_route_table_association/basic.crn
@@ -17,7 +17,7 @@ let vpc = aws.ec2.Vpc {
 let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -13,7 +13,7 @@ let vpc = aws.ec2.Vpc {
 let subnet = aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 }
 
 let tgw = aws.ec2.TransitGateway {

--- a/acceptance-tests/in_place_update/ec2_subnet_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step1.crn
@@ -17,7 +17,7 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.101.1.0/24'
-  availability_zone       = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone       = aws.AvailabilityZone.ZoneName.ap_northeast_1a
   map_public_ip_on_launch = false
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_subnet_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step2.crn
@@ -17,7 +17,7 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.101.1.0/24'
-  availability_zone       = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone       = aws.AvailabilityZone.ZoneName.ap_northeast_1a
   map_public_ip_on_launch = true
 
   tags = {

--- a/acceptance-tests/tag_deletion/ec2_subnet_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step1.crn
@@ -18,7 +18,7 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.105.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/tag_deletion/ec2_subnet_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step2.crn
@@ -19,7 +19,7 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.105.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/tag_deletion/ec2_subnet_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_subnet_step3.crn
@@ -20,5 +20,5 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.105.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 }


### PR DESCRIPTION
## Summary

Fixes carina-rs/carina#3424. The `aws.AvailabilityZone` TypeIdentity is `provider_bare_type(&["AvailabilityZone"], "ZoneName")`, which renders as `aws.AvailabilityZone.ZoneName`. The validator's allowed full form is therefore `aws.AvailabilityZone.ZoneName.<value>`, not the 3-part `aws.AvailabilityZone.<value>` that these 11 acceptance fixtures were using.

The validator rejects the 3-part form with:

```
aws.ec2.Subnet.: Validation failed: Invalid ZoneName 'aws.AvailabilityZone.ap_northeast_1a':
expected format: value, ZoneName.value, or aws.AvailabilityZone.ZoneName.value
```

## Resolution

Per the issue's two options, the user picked option B (fixture rewrite, no validator loosening). This PR updates the 11 affected fixtures from `aws.AvailabilityZone.<value>` to `aws.AvailabilityZone.ZoneName.<value>`. No backward compatibility shim per `feedback_no_backward_compat`.

## Verify

Ran the full acceptance suite locally against 10 test accounts:

- Before this PR: 6 AvailabilityZone failures
- After this PR: 0 AvailabilityZone failures (46 passed of 47)

The one remaining failure (`ec2_subnet/with_dns_options.crn`) is a separate `HostnameType` enum issue unrelated to this PR's scope (the validator expects `aws.ec2.Subnet.PrivateDnsNameOptionsOnLaunch.HostnameType.<value>` but the fixture uses `aws.ec2.Subnet.HostnameType.<value>`). Will be tracked separately.

Closes carina-rs/carina#3424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
