### PR TITLE
Acceptance tests: switch HostnameType to fully-qualified form (carina#3426)

### DIFF
--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -23,7 +23,7 @@ aws.ec2.Subnet {
 
   private_dns_name_options_on_launch = {
     enable_resource_name_dns_a_record = true
-    hostname_type                     = aws.ec2.Subnet.HostnameType.ip_name
+    hostname_type                     = aws.ec2.Subnet.PrivateDnsNameOptionsOnLaunch.HostnameType.ip_name
   }
 
   tags = {


### PR DESCRIPTION
## Summary

Fixes carina-rs/carina#3426. The `HostnameType` enum lives inside the nested struct `PrivateDnsNameOptionsOnLaunch`, so its TypeIdentity is `aws.ec2.Subnet.PrivateDnsNameOptionsOnLaunch.HostnameType`. The validator's allowed forms are:

- bare value: `ip_name`
- kind-qualified: `HostnameType.ip_name`
- fully-qualified: `aws.ec2.Subnet.PrivateDnsNameOptionsOnLaunch.HostnameType.ip_name`

The previous fixture used `aws.ec2.Subnet.HostnameType.ip_name` (4-part), which matches none of those forms.

## Resolution

Rewrite the fixture to the fully-qualified 5-part form. Consistent with the rest of the carina#3413 fixture sweep (awscc#340 also chose fully-qualified over the shorter alternatives).

## Verify

Ran the affected fixture locally:

- `./acceptance-tests/run-tests.sh full ec2_subnet/with_dns_options`: 1 passed, 0 failed.

Closes carina-rs/carina#3426

🤖 Generated with [Claude Code](https://claude.com/claude-code)
