### PR TITLE
Migrate provider-aws schemas to refined primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
+source = "git+https://github.com/carina-rs/carina?rev=805bc331cb33e28fcd640926bc52991e884071b5#805bc331cb33e28fcd640926bc52991e884071b5"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
+source = "git+https://github.com/carina-rs/carina?rev=805bc331cb33e28fcd640926bc52991e884071b5#805bc331cb33e28fcd640926bc52991e884071b5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
+source = "git+https://github.com/carina-rs/carina?rev=805bc331cb33e28fcd640926bc52991e884071b5#805bc331cb33e28fcd640926bc52991e884071b5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1118,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "805bc331cb33e28fcd640926bc52991e884071b5" }

--- a/carina-aws-types/src/common/account.rs
+++ b/carina-aws-types/src/common/account.rs
@@ -1,5 +1,4 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
 use super::provider_bare_type;
 
@@ -21,19 +20,10 @@ pub fn validate_aws_account_id(id: &str) -> Result<(), String> {
 
 /// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
 pub fn aws_account_id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_bare_type(&[], "AccountId")),
-        AttributeType::string(),
         Some("^\\d{12}$".to_string()),
         Some((Some(12), Some(12))),
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_aws_account_id(s)
-                    .map_err(|reason| format!("Invalid AWS Account ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/common/arn.rs
+++ b/carina-aws-types/src/common/arn.rs
@@ -1,5 +1,4 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
 use super::provider_bare_type;
 
@@ -124,18 +123,10 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
 
 /// ARN type (e.g., "arn:aws:s3:::my-bucket")
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_bare_type(&[], "Arn")),
-        AttributeType::string(),
         Some("^arn:(aws|aws-cn|aws-us-gov):[^:]+:.*$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_arn(s).map_err(|reason| format!("Invalid ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/common/availability_zone.rs
+++ b/carina-aws-types/src/common/availability_zone.rs
@@ -122,19 +122,10 @@ pub fn validate_availability_zone_id(az_id: &str) -> Result<(), String> {
 
 /// Availability Zone ID type (e.g., "use1-az1", "usw2-az2", "apne1-az4")
 pub fn availability_zone_id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_bare_type(&["AvailabilityZone"], "ZoneId")),
-        AttributeType::string(),
         Some("^[a-z]+[0-9]+-az[0-9]+$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_availability_zone_id(s)
-                    .map_err(|reason| format!("Invalid availability zone ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/common/resource_id.rs
+++ b/carina-aws-types/src/common/resource_id.rs
@@ -1,5 +1,4 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
 use super::provider_bare_type;
 
@@ -51,19 +50,10 @@ pub fn validate_prefixed_resource_id(id: &str, expected_prefix: &str) -> Result<
 /// AWS resource ID type (e.g., "vpc-1a2b3c4d", "subnet-0123456789abcdef0")
 #[allow(dead_code)]
 pub fn aws_resource_id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_bare_type(&[], "ResourceId")),
-        AttributeType::string(),
         Some("^[a-z-]+-[0-9a-f]{8,}$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_aws_resource_id(s)
-                    .map_err(|reason| format!("Invalid resource ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -35,12 +35,12 @@ mod tests {
     }
 
     fn list_inner(attr: &AttributeType) -> &AttributeType {
-        let carina_core::schema::Shape::List { inner, .. } =
+        let carina_core::schema::Shape::List { element_type, .. } =
             attr.shape_ref_free().expect("test schema is Ref-free")
         else {
             panic!("expected List shape");
         };
-        inner
+        element_type
     }
 
     fn struct_name(attr: &AttributeType) -> &str {
@@ -72,13 +72,13 @@ mod tests {
         identity.to_string()
     }
 
-    fn assert_custom_identity(attr: &AttributeType, expected: &str) {
-        if let carina_core::schema::Shape::Custom { identity, .. } =
+    fn assert_refined_string_identity(attr: &AttributeType, expected: &str) {
+        if let carina_core::schema::Shape::String { identity, .. } =
             attr.shape_ref_free().expect("test schema is Ref-free")
         {
             assert_eq!(identity.map(|id| id.to_string()).as_deref(), Some(expected));
         } else {
-            panic!("expected AttributeType::Custom");
+            panic!("expected refined String");
         }
     }
 
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn aws_account_id_carries_pattern_and_length() {
         let t = aws_account_id();
-        if let carina_core::schema::Shape::Custom {
+        if let carina_core::schema::Shape::String {
             identity,
             pattern,
             length,
@@ -274,14 +274,14 @@ mod tests {
             assert_eq!(pattern, Some(r"^\d{12}$"));
             assert_eq!(length, Some((Some(12), Some(12))));
         } else {
-            panic!("aws_account_id() should be AttributeType::Custom");
+            panic!("aws_account_id() should be refined String");
         }
     }
 
     #[test]
     fn vpc_id_carries_identity_and_pattern() {
         let t = vpc_id();
-        if let carina_core::schema::Shape::Custom {
+        if let carina_core::schema::Shape::String {
             identity,
             pattern,
             to_dsl: None,
@@ -294,7 +294,7 @@ mod tests {
             );
             assert!(pattern.is_some(), "VpcId should carry a pattern");
         } else {
-            panic!("vpc_id() should be AttributeType::Custom");
+            panic!("vpc_id() should be refined String");
         }
     }
 
@@ -788,7 +788,7 @@ mod tests {
     #[test]
     fn kms_key_id_carries_identity_and_validates_values() {
         let attr = kms_key_id();
-        assert_custom_identity(&attr, "aws.kms.Key.Id");
+        assert_refined_string_identity(&attr, "aws.kms.Key.Id");
         assert_string_attr_accepts_and_rejects(
             attr,
             "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab",
@@ -916,7 +916,7 @@ mod tests {
     #[test]
     fn iam_role_arn_carries_identity_and_validates_values() {
         let attr = iam_role_arn();
-        assert_custom_identity(&attr, "aws.iam.Role.Arn");
+        assert_refined_string_identity(&attr, "aws.iam.Role.Arn");
         assert_string_attr_accepts_and_rejects(
             attr,
             "arn:aws:iam::123456789012:role/service-role/MyRole",
@@ -927,7 +927,7 @@ mod tests {
     #[test]
     fn iam_policy_arn_carries_identity_and_validates_values() {
         let attr = iam_policy_arn();
-        assert_custom_identity(&attr, "aws.iam.Policy.Arn");
+        assert_refined_string_identity(&attr, "aws.iam.Policy.Arn");
         assert_string_attr_accepts_and_rejects(
             attr,
             "arn:aws:iam::123456789012:policy/MyPolicy",
@@ -938,7 +938,7 @@ mod tests {
     #[test]
     fn iam_oidc_provider_arn_carries_identity_and_validates_values() {
         let attr = iam_oidc_provider_arn();
-        assert_custom_identity(&attr, "aws.iam.OidcProvider.Arn");
+        assert_refined_string_identity(&attr, "aws.iam.OidcProvider.Arn");
         assert_string_attr_accepts_and_rejects(
             attr,
             "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com",
@@ -1261,7 +1261,7 @@ mod tests {
     #[test]
     fn sso_principal_id_carries_identity_and_validates_values() {
         let attr = sso_principal_id();
-        assert_custom_identity(&attr, "aws.sso.Principal.Id");
+        assert_refined_string_identity(&attr, "aws.sso.Principal.Id");
         assert_string_attr_accepts_and_rejects(
             attr,
             "1234567890-12345678-1234-1234-1234-1234567890ab",
@@ -1272,7 +1272,7 @@ mod tests {
     #[test]
     fn sso_instance_arn_carries_identity_and_validates_values() {
         let attr = sso_instance_arn();
-        assert_custom_identity(&attr, "aws.sso.Instance.Arn");
+        assert_refined_string_identity(&attr, "aws.sso.Instance.Arn");
         assert_string_attr_accepts_and_rejects(
             attr,
             "arn:aws:sso:::instance/ssoins-1234567890abcdef",
@@ -1283,14 +1283,14 @@ mod tests {
     #[test]
     fn identity_store_id_carries_identity_and_validates_values() {
         let attr = identity_store_id();
-        assert_custom_identity(&attr, "aws.identitystore.Store.Id");
+        assert_refined_string_identity(&attr, "aws.identitystore.Store.Id");
         assert_string_attr_accepts_and_rejects(attr, "d-1234567890", "store-1234567890");
     }
 
     #[test]
     fn sso_permission_set_arn_carries_identity_and_validates_values() {
         let attr = sso_permission_set_arn();
-        assert_custom_identity(&attr, "aws.sso.PermissionSet.Arn");
+        assert_refined_string_identity(&attr, "aws.sso.PermissionSet.Arn");
         assert_string_attr_accepts_and_rejects(
             attr,
             "arn:aws:sso:::permissionSet/ssoins-1234567890abcdef/ps-1234567890abcdef",
@@ -1463,7 +1463,7 @@ mod tests {
     #[test]
     fn grantee_accepts_id_format() {
         let t = s3_grantee();
-        assert_custom_identity(&t, "aws.s3.Grantee");
+        assert_refined_string_identity(&t, "aws.s3.Grantee");
         assert!(
             carina_core::schema::Schema::flat(t.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
@@ -1528,7 +1528,7 @@ mod tests {
         ));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("must start with id=, emailAddress=, or uri="));
+        assert!(err.contains("does not match required pattern"));
     }
 
     #[test]

--- a/carina-aws-types/src/services/ec2.rs
+++ b/carina-aws-types/src/services/ec2.rs
@@ -1,497 +1,202 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::{AttributeType, TypeIdentity};
 
-use crate::{aws_resource_id, provider_type, validate_prefixed_resource_id};
+use crate::provider_type;
+
+fn resource_id(identity: TypeIdentity, pattern: &str) -> AttributeType {
+    AttributeType::refined_string(Some(identity), Some(pattern.to_string()), None, None)
+}
 
 /// VPC ID type (e.g., "vpc-1a2b3c4d")
 pub fn vpc_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "Vpc", "Id")),
-        aws_resource_id(),
-        Some("^vpc-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "vpc")
-                    .map_err(|reason| format!("Invalid VPC ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
+    resource_id(provider_type("ec2", "Vpc", "Id"), "^vpc-[0-9a-f]{8,}$")
 }
 
 /// Subnet ID type (e.g., "subnet-0123456789abcdef0")
 pub fn subnet_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "Subnet", "Id")),
-        aws_resource_id(),
-        Some("^subnet-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "subnet")
-                    .map_err(|reason| format!("Invalid Subnet ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "Subnet", "Id"),
+        "^subnet-[0-9a-f]{8,}$",
     )
 }
 
 /// Security Group ID type (e.g., "sg-12345678")
 pub fn security_group_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "SecurityGroup", "Id")),
-        aws_resource_id(),
-        Some("^sg-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "sg")
-                    .map_err(|reason| format!("Invalid Security Group ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "SecurityGroup", "Id"),
+        "^sg-[0-9a-f]{8,}$",
     )
 }
 
 /// Internet Gateway ID type (e.g., "igw-12345678")
 pub fn internet_gateway_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "InternetGateway", "Id")),
-        aws_resource_id(),
-        Some("^igw-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "igw")
-                    .map_err(|reason| format!("Invalid Internet Gateway ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "InternetGateway", "Id"),
+        "^igw-[0-9a-f]{8,}$",
     )
 }
 
 /// Route Table ID type (e.g., "rtb-abcdef12")
 pub fn route_table_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "RouteTable", "Id")),
-        aws_resource_id(),
-        Some("^rtb-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "rtb")
-                    .map_err(|reason| format!("Invalid Route Table ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "RouteTable", "Id"),
+        "^rtb-[0-9a-f]{8,}$",
     )
 }
 
 /// NAT Gateway ID type (e.g., "nat-12345678")
 pub fn nat_gateway_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "NatGateway", "Id")),
-        aws_resource_id(),
-        Some("^nat-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "nat")
-                    .map_err(|reason| format!("Invalid NAT Gateway ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "NatGateway", "Id"),
+        "^nat-[0-9a-f]{8,}$",
     )
 }
 
 /// VPC Peering Connection ID type (e.g., "pcx-12345678")
 pub fn vpc_peering_connection_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "VpcPeeringConnection", "Id")),
-        aws_resource_id(),
-        Some("^pcx-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "pcx").map_err(|reason| {
-                    format!("Invalid VPC Peering Connection ID '{}': {}", s, reason)
-                })
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "VpcPeeringConnection", "Id"),
+        "^pcx-[0-9a-f]{8,}$",
     )
 }
 
 /// Transit Gateway ID type (e.g., "tgw-12345678")
 pub fn transit_gateway_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "TransitGateway", "Id")),
-        aws_resource_id(),
-        Some("^tgw-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "tgw")
-                    .map_err(|reason| format!("Invalid Transit Gateway ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "TransitGateway", "Id"),
+        "^tgw-[0-9a-f]{8,}$",
     )
 }
 
 /// VPC CIDR Block Association ID type (e.g., "vpc-cidr-assoc-12345678")
 pub fn vpc_cidr_block_association_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "VpcCidrBlockAssociation", "Id")),
-        aws_resource_id(),
-        Some("^vpc-cidr-assoc-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "vpc-cidr-assoc").map_err(|reason| {
-                    format!("Invalid VPC CIDR Block Association ID '{}': {}", s, reason)
-                })
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "VpcCidrBlockAssociation", "Id"),
+        "^vpc-cidr-assoc-[0-9a-f]{8,}$",
     )
 }
 
 /// Transit Gateway Route Table ID type (e.g., "tgw-rtb-12345678")
 pub fn tgw_route_table_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "TransitGatewayRouteTable", "Id")),
-        aws_resource_id(),
-        Some("^tgw-rtb-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "tgw-rtb")
-                    .map_err(|reason| format!("Invalid TGW Route Table ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "TransitGatewayRouteTable", "Id"),
+        "^tgw-rtb-[0-9a-f]{8,}$",
     )
 }
 
 /// VPN Gateway ID type (e.g., "vgw-12345678")
 pub fn vpn_gateway_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "VpnGateway", "Id")),
-        aws_resource_id(),
-        Some("^vgw-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "vgw")
-                    .map_err(|reason| format!("Invalid VPN Gateway ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "VpnGateway", "Id"),
+        "^vgw-[0-9a-f]{8,}$",
     )
 }
 
-/// Gateway ID type — union of InternetGatewayId and VpnGatewayId.
+/// Gateway ID type - union of InternetGatewayId and VpnGatewayId.
 pub fn gateway_id() -> AttributeType {
     AttributeType::union(vec![internet_gateway_id(), vpn_gateway_id()])
 }
 
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
 pub fn egress_only_internet_gateway_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "EgressOnlyInternetGateway", "Id")),
-        aws_resource_id(),
-        Some("^eigw-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "eigw").map_err(|reason| {
-                    format!(
-                        "Invalid Egress Only Internet Gateway ID '{}': {}",
-                        s, reason
-                    )
-                })
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "EgressOnlyInternetGateway", "Id"),
+        "^eigw-[0-9a-f]{8,}$",
     )
 }
 
 /// VPC Endpoint ID type (e.g., "vpce-12345678")
 pub fn vpc_endpoint_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "VpcEndpoint", "Id")),
-        aws_resource_id(),
-        Some("^vpce-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "vpce")
-                    .map_err(|reason| format!("Invalid VPC Endpoint ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "VpcEndpoint", "Id"),
+        "^vpce-[0-9a-f]{8,}$",
     )
 }
 
 /// Instance ID type (e.g., "i-0123456789abcdef0")
 pub fn instance_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "Instance", "Id")),
-        aws_resource_id(),
-        Some("^i-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "i")
-                    .map_err(|reason| format!("Invalid Instance ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
+    resource_id(provider_type("ec2", "Instance", "Id"), "^i-[0-9a-f]{8,}$")
 }
 
 /// Network Interface ID type (e.g., "eni-0123456789abcdef0")
 pub fn network_interface_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "NetworkInterface", "Id")),
-        aws_resource_id(),
-        Some("^eni-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "eni")
-                    .map_err(|reason| format!("Invalid Network Interface ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "NetworkInterface", "Id"),
+        "^eni-[0-9a-f]{8,}$",
     )
 }
 
 /// EIP Allocation ID type (e.g., "eipalloc-0123456789abcdef0")
 #[allow(dead_code)]
 pub fn allocation_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "Eip", "AllocationId")),
-        aws_resource_id(),
-        Some("^eipalloc-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "eipalloc")
-                    .map_err(|reason| format!("Invalid Allocation ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "Eip", "AllocationId"),
+        "^eipalloc-[0-9a-f]{8,}$",
     )
 }
 
 /// Prefix List ID type (e.g., "pl-0123456789abcdef0")
 pub fn prefix_list_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "PrefixList", "Id")),
-        aws_resource_id(),
-        Some("^pl-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "pl")
-                    .map_err(|reason| format!("Invalid Prefix List ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "PrefixList", "Id"),
+        "^pl-[0-9a-f]{8,}$",
     )
 }
 
 /// Carrier Gateway ID type (e.g., "cagw-0123456789abcdef0")
 pub fn carrier_gateway_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "CarrierGateway", "Id")),
-        aws_resource_id(),
-        Some("^cagw-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "cagw")
-                    .map_err(|reason| format!("Invalid Carrier Gateway ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "CarrierGateway", "Id"),
+        "^cagw-[0-9a-f]{8,}$",
     )
 }
 
 /// Local Gateway ID type (e.g., "lgw-0123456789abcdef0")
 pub fn local_gateway_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "LocalGateway", "Id")),
-        aws_resource_id(),
-        Some("^lgw-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "lgw")
-                    .map_err(|reason| format!("Invalid Local Gateway ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "LocalGateway", "Id"),
+        "^lgw-[0-9a-f]{8,}$",
     )
 }
 
 /// Network ACL ID type (e.g., "acl-0123456789abcdef0")
 #[allow(dead_code)]
 pub fn network_acl_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "NetworkAcl", "Id")),
-        aws_resource_id(),
-        Some("^acl-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "acl")
-                    .map_err(|reason| format!("Invalid Network ACL ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "NetworkAcl", "Id"),
+        "^acl-[0-9a-f]{8,}$",
     )
 }
 
 /// Transit Gateway Attachment ID type (e.g., "tgw-attach-0123456789abcdef0")
 pub fn transit_gateway_attachment_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "TransitGatewayAttachment", "Id")),
-        aws_resource_id(),
-        Some("^tgw-attach-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "tgw-attach").map_err(|reason| {
-                    format!("Invalid Transit Gateway Attachment ID '{}': {}", s, reason)
-                })
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "TransitGatewayAttachment", "Id"),
+        "^tgw-attach-[0-9a-f]{8,}$",
     )
 }
 
 /// Flow Log ID type (e.g., "fl-0123456789abcdef0")
 pub fn flow_log_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "FlowLog", "Id")),
-        aws_resource_id(),
-        Some("^fl-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "fl")
-                    .map_err(|reason| format!("Invalid Flow Log ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
+    resource_id(provider_type("ec2", "FlowLog", "Id"), "^fl-[0-9a-f]{8,}$")
 }
 
 /// IPAM ID type (e.g., "ipam-0123456789abcdef0")
 pub fn ipam_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "Ipam", "Id")),
-        aws_resource_id(),
-        Some("^ipam-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "ipam")
-                    .map_err(|reason| format!("Invalid IPAM ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
+    resource_id(provider_type("ec2", "Ipam", "Id"), "^ipam-[0-9a-f]{8,}$")
 }
 
 /// Subnet Route Table Association ID type (e.g., "rtbassoc-0123456789abcdef0")
 pub fn subnet_route_table_association_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "SubnetRouteTableAssociation", "Id")),
-        aws_resource_id(),
-        Some("^rtbassoc-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "rtbassoc").map_err(|reason| {
-                    format!(
-                        "Invalid Subnet Route Table Association ID '{}': {}",
-                        s, reason
-                    )
-                })
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "SubnetRouteTableAssociation", "Id"),
+        "^rtbassoc-[0-9a-f]{8,}$",
     )
 }
 
 /// Security Group Rule ID type (e.g., "sgr-0123456789abcdef0")
 pub fn security_group_rule_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_type("ec2", "SecurityGroupRule", "Id")),
-        aws_resource_id(),
-        Some("^sgr-[0-9a-f]{8,}$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_prefixed_resource_id(s, "sgr")
-                    .map_err(|reason| format!("Invalid Security Group Rule ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
+    resource_id(
+        provider_type("ec2", "SecurityGroupRule", "Id"),
+        "^sgr-[0-9a-f]{8,}$",
     )
 }

--- a/carina-aws-types/src/services/iam/arn.rs
+++ b/carina-aws-types/src/services/iam/arn.rs
@@ -1,61 +1,33 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
-use crate::{arn, provider_type, validate_iam_arn};
+use crate::provider_type;
 
 /// IAM Role ARN type (e.g., "arn:aws:iam::123456789012:role/MyRole").
 pub fn iam_role_arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("iam", "Role", "Arn")),
-        arn(),
         Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_iam_arn(s, "role/")
-                    .map_err(|reason| format!("Invalid IAM Role ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }
 
 /// IAM Policy ARN type (e.g., "arn:aws:iam::123456789012:policy/MyPolicy").
 pub fn iam_policy_arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("iam", "Policy", "Arn")),
-        arn(),
         Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_iam_arn(s, "policy/")
-                    .map_err(|reason| format!("Invalid IAM Policy ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }
 
 /// IAM OIDC Provider ARN type (e.g., "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com").
 pub fn iam_oidc_provider_arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("iam", "OidcProvider", "Arn")),
-        arn(),
         Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:oidc-provider/.+$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_iam_arn(s, "oidc-provider/")
-                    .map_err(|reason| format!("Invalid IAM OIDC Provider ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/services/iam/identity.rs
+++ b/carina-aws-types/src/services/iam/identity.rs
@@ -1,7 +1,6 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
-use crate::{aws_resource_id, provider_type};
+use crate::provider_type;
 
 /// Validate IAM Role ID format: starts with "AROA" followed by alphanumeric characters.
 pub fn validate_iam_role_id(id: &str) -> Result<(), String> {
@@ -19,19 +18,10 @@ pub fn validate_iam_role_id(id: &str) -> Result<(), String> {
 
 /// IAM Role ID type (e.g., "AROAEXAMPLEID")
 pub fn iam_role_id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("iam", "Role", "Id")),
-        aws_resource_id(),
         Some("^AROA[A-Z0-9]+$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_iam_role_id(s)
-                    .map_err(|reason| format!("Invalid IAM Role ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/services/identity_store.rs
+++ b/carina-aws-types/src/services/identity_store.rs
@@ -1,5 +1,4 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
 use crate::provider_type;
 
@@ -22,19 +21,10 @@ pub fn validate_identity_store_id(id: &str) -> Result<(), String> {
 
 /// IdentityStore identity store id (`d-...` or UUID).
 pub fn identity_store_id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("identitystore", "Store", "Id")),
-        AttributeType::string(),
+        Some("^(d-[0-9a-fA-F]{10}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$".to_string()),
         None,
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_identity_store_id(s)
-                    .map_err(|reason| format!("Invalid IdentityStore id '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/services/ipam.rs
+++ b/carina-aws-types/src/services/ipam.rs
@@ -1,7 +1,6 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
-use crate::{aws_resource_id, provider_type};
+use crate::provider_type;
 
 // ========== IPAM types ==========
 
@@ -21,19 +20,10 @@ pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
 
 /// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
 pub fn ipam_pool_id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("ec2", "IpamPool", "Id")),
-        aws_resource_id(),
         Some("^ipam-pool-[0-9a-f]{8,}$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_ipam_pool_id(s)
-                    .map_err(|reason| format!("Invalid IPAM Pool ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/services/kms.rs
+++ b/carina-aws-types/src/services/kms.rs
@@ -1,7 +1,6 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
-use crate::{aws_resource_id, provider_type, validate_service_arn};
+use crate::{provider_type, validate_service_arn};
 
 // ========== KMS Key ID ==========
 
@@ -54,19 +53,13 @@ pub fn validate_kms_key_id(value: &str) -> Result<(), String> {
 /// - Key alias: "alias/my-key"
 /// - Key ID: "1234abcd-12ab-34cd-56ef-1234567890ab"
 pub fn kms_key_id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("kms", "Key", "Id")),
-        aws_resource_id(),
+        Some(
+            "^((arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:(key|alias)/.+)|(alias/.+)|([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))$"
+                .to_string(),
+        ),
         None,
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_kms_key_id(s)
-                    .map_err(|reason| format!("Invalid KMS key identifier '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/services/s3/grantee.rs
+++ b/carina-aws-types/src/services/s3/grantee.rs
@@ -1,5 +1,4 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
 use crate::provider_bare_type;
 
@@ -14,35 +13,10 @@ use crate::provider_bare_type;
 ///
 /// Multiple grantees can be comma-separated.
 pub fn s3_grantee() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_bare_type(&["s3"], "Grantee")),
-        AttributeType::string(),
+        Some(r"^(id|emailAddress|uri)=.+(\s*,\s*(id|emailAddress|uri)=.+)*$".to_string()),
         None,
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                if s.is_empty() {
-                    return Err("Grantee specification must not be empty".to_string());
-                }
-                // Split by comma and validate each grantee spec
-                for part in s.split(',') {
-                    let trimmed = part.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    let valid_prefixes = ["id=", "emailAddress=", "uri="];
-                    if !valid_prefixes.iter().any(|p| trimmed.starts_with(p)) {
-                        return Err(format!(
-                            "Invalid grantee spec '{}': must start with id=, emailAddress=, or uri=",
-                            trimmed
-                        ));
-                    }
-                }
-                Ok(())
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-aws-types/src/services/sso.rs
+++ b/carina-aws-types/src/services/sso.rs
@@ -1,7 +1,6 @@
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
-use crate::{arn, provider_type, validate_arn};
+use crate::{provider_type, validate_arn};
 
 // ========== SSO / Identity Center helpers ==========
 
@@ -20,19 +19,10 @@ pub fn validate_sso_principal_id(id: &str) -> Result<(), String> {
 
 /// SSO PrincipalId type (user or group id from IdentityStore).
 pub fn sso_principal_id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("sso", "Principal", "Id")),
-        AttributeType::string(),
+        Some("^.{1,64}$".to_string()),
         None,
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_sso_principal_id(s)
-                    .map_err(|reason| format!("Invalid SSO principal ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }
@@ -55,19 +45,10 @@ pub fn validate_sso_instance_arn(arn: &str) -> Result<(), String> {
 
 /// SSO Instance ARN type (e.g., "arn:aws:sso:::instance/ssoins-xxxxxxxx").
 pub fn sso_instance_arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("sso", "Instance", "Arn")),
-        arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):sso:::instance/.+$".to_string()),
         None,
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_sso_instance_arn(s)
-                    .map_err(|reason| format!("Invalid SSO instance ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }
@@ -87,19 +68,10 @@ pub fn validate_sso_permission_set_arn(arn: &str) -> Result<(), String> {
 
 /// SSO PermissionSet ARN type.
 pub fn sso_permission_set_arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(provider_type("sso", "PermissionSet", "Arn")),
-        arn(),
+        Some("^arn:(aws|aws-cn|aws-us-gov):sso:::permissionSet/.+$".to_string()),
         None,
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_sso_permission_set_arn(s)
-                    .map_err(|reason| format!("Invalid SSO permission set ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -213,6 +213,7 @@ fn resource_identity_parts(name: &str) -> Option<(&str, &str)> {
     name.split_once('.')
 }
 
+#[allow(dead_code)]
 fn arn_validator_for(validator: ArnValidator) -> String {
     match validator {
         ArnValidator::Iam { prefix, label } => format!(
@@ -248,6 +249,7 @@ fn arn_validator_for(validator: ArnValidator) -> String {
     }
 }
 
+#[allow(dead_code)]
 fn arn_validator_expression(choice: ArnEmitChoice) -> String {
     match choice {
         ArnEmitChoice::PerKind(entry) => arn_validator_for(entry.validator),
@@ -279,7 +281,8 @@ fn arn_helper_needs_validation_imports(
     resource: &str,
     choice: ArnEmitChoice,
 ) -> bool {
-    !matches!(choice, ArnEmitChoice::Generic) && shared_arn_constructor(service, resource).is_none()
+    let _ = (service, resource, choice);
+    false
 }
 
 fn emit_arn_helper(service: &str, resource: &str, choice: ArnEmitChoice) -> String {
@@ -301,15 +304,12 @@ fn emit_arn_helper(service: &str, resource: &str, choice: ArnEmitChoice) -> Stri
         }
         ArnEmitChoice::Generic => unreachable!("handled above"),
     };
-    let validator_expr = arn_validator_expression(choice);
     format!(
         r#"pub fn arn() -> AttributeType {{
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(super::provider_type("{service}", "{resource}", "Arn")),
-        super::arn(),
         {regex_expr},
         None,
-        legacy_validator({validator_expr}),
         None,
     )
 }}
@@ -1086,7 +1086,6 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     }
 
     // Determine needed imports
-    let has_ranged_ints = !all_ranged_ints.is_empty();
     let code_str = attrs
         .iter()
         .map(|a| a.type_code.as_str())
@@ -1134,9 +1133,6 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     if has_arn_helper && !schema_imports.contains(&"AttributeType") {
         schema_imports.insert(1, "AttributeType");
     }
-    if has_ranged_ints {
-        schema_imports.push("legacy_validator");
-    }
     if arn_helper_needs_validation_imports && !schema_imports.contains(&"legacy_validator") {
         schema_imports.push("legacy_validator");
     }
@@ -1155,7 +1151,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         code.push_str("use super::tags_type;\n");
         code.push_str("use super::validate_tags_map;\n");
     }
-    if has_ranged_ints || arn_helper_needs_validation_imports {
+    if arn_helper_needs_validation_imports {
         code.push_str("use carina_core::resource::{ConcreteValue, Value};\n");
     }
     code.push_str(&format!(
@@ -1204,25 +1200,6 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         ));
     }
 
-    // Generate range validation functions
-    for (prop_name, range) in &all_ranged_ints {
-        let fn_name = format!("validate_{}_range", prop_name.to_snake_case());
-        let (condition, display) = int_range_condition_and_display(range.min, range.max);
-        code.push_str(&format!(
-            "fn {}(value: &Value) -> Result<(), String> {{\n\
-             \x20   if let Value::Concrete(ConcreteValue::Int(n)) = value {{\n\
-             \x20       if {} {{\n\
-             \x20           Err(format!(\"Value {{}} is out of range {}\", n))\n\
-             \x20       }} else {{\n\
-             \x20           Ok(())\n\
-             \x20       }}\n\
-             \x20   }} else {{\n\
-             \x20       Err(\"Expected integer\".to_string())\n\
-             \x20   }}\n\
-             }}\n\n",
-            fn_name, condition, display
-        ));
-    }
     if let Some(helper) = &arn_helper {
         code.push_str(helper);
     }
@@ -1563,26 +1540,21 @@ fn resolve_type(
                 ctx.all_ranged_ints
                     .entry(field_name.to_string())
                     .or_insert(r);
-                let validate_fn = format!("validate_{}_range", field_name.to_snake_case());
-                let length_expr = match (r.min, r.max) {
-                    (Some(min), Some(max)) if min >= 0 && max >= 0 => {
+                let range_expr = match (r.min, r.max) {
+                    (Some(min), Some(max)) => {
                         format!("Some((Some({}), Some({})))", min, max)
                     }
-                    (Some(min), None) if min >= 0 => format!("Some((Some({}), None))", min),
-                    (None, Some(max)) if max >= 0 => format!("Some((None, Some({})))", max),
-                    _ => "None".to_string(),
+                    (Some(min), None) => format!("Some((Some({}), None))", min),
+                    (None, Some(max)) => format!("Some((None, Some({})))", max),
+                    (None, None) => "None".to_string(),
                 };
                 (
                     format!(
-                        "AttributeType::custom(\n\
-                         \x20               None,\n\
-                         \x20               AttributeType::int(),\n\
+                        "AttributeType::refined_int(\n\
                          \x20               None,\n\
                          \x20               {},\n\
-                         \x20               legacy_validator({}),\n\
-                         \x20               None,\n\
                          \x20           )",
-                        length_expr, validate_fn
+                        range_expr
                     ),
                     None,
                 )
@@ -1833,22 +1805,12 @@ fn generate_virtual_helper_modules(
          //!\n\
          //! DO NOT EDIT MANUALLY - regenerate with:\n\
          //!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh\n\n\
-         use carina_core::resource::{{ConcreteValue, Value}};\n\
-         use carina_core::schema::{{AttributeType, legacy_validator}};\n\n{}\
+         use carina_core::schema::AttributeType;\n\n{}\
          pub fn id() -> AttributeType {{\n\
-         \x20   AttributeType::custom(\n\
+         \x20   AttributeType::refined_string(\n\
          \x20       Some(super::provider_type(\"kms\", \"Key\", \"Id\")),\n\
-         \x20       super::aws_resource_id(),\n\
          \x20       None,\n\
          \x20       None,\n\
-         \x20       legacy_validator(|value| {{\n\
-         \x20           if let Value::Concrete(ConcreteValue::String(s)) = value {{\n\
-         \x20               super::validate_kms_key_id(s)\n\
-         \x20                   .map_err(|reason| format!(\"Invalid KMS key identifier '{{}}': {{}}\", s, reason))\n\
-         \x20           }} else {{\n\
-         \x20               Err(\"Expected string\".to_string())\n\
-         \x20           }}\n\
-         \x20       }}),\n\
          \x20       None,\n\
          \x20   )\n\
          }}\n",
@@ -4282,6 +4244,7 @@ fn known_enum_overrides() -> &'static HashMap<&'static str, Vec<&'static str>> {
 }
 
 /// Generate condition string and display string for integer range validation.
+#[allow(dead_code)]
 fn int_range_condition_and_display(min: Option<i64>, max: Option<i64>) -> (String, String) {
     match (min, max) {
         (Some(min), Some(max)) => (

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "805bc331cb33e28fcd640926bc52991e884071b5" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "805bc331cb33e28fcd640926bc52991e884071b5" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "805bc331cb33e28fcd640926bc52991e884071b5" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -224,9 +224,35 @@ pub fn proto_to_core_data_source(r: &ProtoResource) -> CoreDataSource {
 
 fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
     match t {
-        ProtoAttributeType::String => CoreAttributeType::string(),
-        ProtoAttributeType::Int => CoreAttributeType::int(),
-        ProtoAttributeType::Float => CoreAttributeType::float(),
+        ProtoAttributeType::String {
+            pattern,
+            length,
+            to_dsl,
+            identity,
+            ..
+        } => CoreAttributeType::refined_string(
+            identity
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(carina_core::schema::TypeIdentity::from_dotted),
+            pattern.clone(),
+            *length,
+            to_dsl.clone(),
+        ),
+        ProtoAttributeType::Int { range, identity } => CoreAttributeType::refined_int(
+            identity
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(carina_core::schema::TypeIdentity::from_dotted),
+            *range,
+        ),
+        ProtoAttributeType::Float { range, identity } => CoreAttributeType::refined_float(
+            identity
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(carina_core::schema::TypeIdentity::from_dotted),
+            *range,
+        ),
         ProtoAttributeType::Bool => CoreAttributeType::bool(),
         ProtoAttributeType::Duration => CoreAttributeType::duration(),
         ProtoAttributeType::StringEnum {
@@ -252,12 +278,41 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             None,
             None,
         ),
-        ProtoAttributeType::List { inner, ordered } => {
-            let inner_t = proto_to_core_attribute_type(inner);
+        ProtoAttributeType::List {
+            element_type,
+            ordered,
+            length,
+            ..
+        } => {
+            let inner_t = proto_to_core_attribute_type(element_type);
             if *ordered {
-                CoreAttributeType::list(inner_t)
+                let list = CoreAttributeType::list(inner_t);
+                if length.is_some() {
+                    CoreAttributeType::custom(
+                        None,
+                        list,
+                        None,
+                        *length,
+                        legacy_validator(|_| Ok(())),
+                        None,
+                    )
+                } else {
+                    list
+                }
             } else {
-                CoreAttributeType::unordered_list(inner_t)
+                let list = CoreAttributeType::unordered_list(inner_t);
+                if length.is_some() {
+                    CoreAttributeType::custom(
+                        None,
+                        list,
+                        None,
+                        *length,
+                        legacy_validator(|_| Ok(())),
+                        None,
+                    )
+                } else {
+                    list
+                }
             }
         }
         ProtoAttributeType::Map { inner, key } => CoreAttributeType::map_with_key(
@@ -276,21 +331,38 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             base,
             pattern,
             length,
-        } => CoreAttributeType::custom(
-            if name.is_empty() {
+            to_dsl,
+            ..
+        } => {
+            let identity = if name.is_empty() {
                 None
             } else {
                 Some(carina_core::schema::TypeIdentity::from_dotted(name))
-            },
-            proto_to_core_attribute_type(base),
-            // carina#3364: carry the schema `pattern`/`length` so the
-            // host's `validate_custom` can enforce them; dropping them
-            // here is why a violating value only failed at `apply`.
-            pattern.clone(),
-            *length,
-            legacy_validator(|_| Ok(())),
-            None,
-        ),
+            };
+            let base = proto_to_core_attribute_type(base);
+            match base.raw_shape() {
+                CoreRawShape::String { .. } => CoreAttributeType::refined_string(
+                    identity,
+                    pattern.clone(),
+                    *length,
+                    to_dsl.clone(),
+                ),
+                CoreRawShape::Int { .. } => CoreAttributeType::refined_int(
+                    identity,
+                    length.map(|(min, max)| (min.map(|v| v as i64), max.map(|v| v as i64))),
+                ),
+                CoreRawShape::Float { .. } => CoreAttributeType::refined_float(identity, None),
+                CoreRawShape::List { .. } => CoreAttributeType::custom(
+                    identity,
+                    base,
+                    pattern.clone(),
+                    *length,
+                    legacy_validator(|_| Ok(())),
+                    None,
+                ),
+                other => panic!("unsupported Custom base in provider protocol: {other:?}"),
+            }
+        }
         // CustomEnum: carries a mandatory identity, lifted from the
         // wire-form flat `(name, namespace)` pair via the
         // `enum_identity` helper. Matches the post-#3222 core
@@ -408,9 +480,31 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
     // so the receiver can rebuild from its own copy of `defs`. Aligns
     // this provider with awscc#284.
     match t.raw_shape() {
-        CoreRawShape::String => ProtoAttributeType::String,
-        CoreRawShape::Int => ProtoAttributeType::Int,
-        CoreRawShape::Float => ProtoAttributeType::Float,
+        CoreRawShape::String {
+            identity,
+            pattern,
+            length,
+            to_dsl,
+            ..
+        } => ProtoAttributeType::String {
+            pattern: pattern.map(|s| s.to_string()),
+            length,
+            validate: None,
+            to_dsl: to_dsl.cloned(),
+            identity: identity.map(|id| id.to_string()),
+        },
+        CoreRawShape::Int {
+            identity, range, ..
+        } => ProtoAttributeType::Int {
+            range,
+            identity: identity.map(|id| id.to_string()),
+        },
+        CoreRawShape::Float {
+            identity, range, ..
+        } => ProtoAttributeType::Float {
+            range,
+            identity: identity.map(|id| id.to_string()),
+        },
         CoreRawShape::Bool => ProtoAttributeType::Bool,
         // `Duration` is now a first-class proto variant (carina#3166) so
         // providers can declare Duration-typed schema attributes and the
@@ -434,9 +528,16 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             namespace: identity.dotted_prefix(),
             dsl_aliases: dsl_aliases.to_vec(),
         },
-        CoreRawShape::List { inner, ordered } => ProtoAttributeType::List {
-            inner: Box::new(core_to_proto_attribute_type(inner)),
+        CoreRawShape::List {
+            element_type,
             ordered,
+            length,
+            ..
+        } => ProtoAttributeType::List {
+            element_type: Box::new(core_to_proto_attribute_type(element_type)),
+            ordered,
+            length,
+            validate: None,
         },
         CoreRawShape::Map { key, value: inner } => ProtoAttributeType::Map {
             inner: Box::new(core_to_proto_attribute_type(inner)),
@@ -445,24 +546,6 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreRawShape::Struct { name, fields } => ProtoAttributeType::Struct {
             name: name.to_string(),
             fields: fields.iter().map(core_to_proto_struct_field).collect(),
-        },
-        CoreRawShape::Custom {
-            identity,
-            base,
-            pattern,
-            length,
-            ..
-        } => ProtoAttributeType::Custom {
-            // Serialize the structured identity to its dotted display
-            // form for the wire. The host's `TypeIdentity::from_dotted`
-            // parses it back on the other side, so the provider axis
-            // survives the JSON round-trip.
-            name: identity.map(|id| id.to_string()).unwrap_or_default(),
-            base: Box::new(core_to_proto_attribute_type(base)),
-            // carina#3364: carry the schema `pattern`/`length` across the
-            // wire so the host can enforce them at validate/plan time.
-            pattern: pattern.map(|s| s.to_string()),
-            length,
         },
         // Enum without a closed value list carries the enum-shorthand marker as a type-level
         // fact (carina#3222); on the wire form it still travels as a
@@ -603,53 +686,61 @@ mod tests {
         }
     }
 
-    /// Regression for aws#395 / carina#3364: a `Custom` attribute's schema
+    /// Regression for aws#395 / carina#3364: a refined string attribute's schema
     /// `pattern` and `length` constraints MUST cross the WASM boundary in
     /// BOTH directions. If they are dropped, `carina validate` cannot
     /// enforce them and a violating value only fails at `apply`. Asserts
     /// the constraints reach the proto wire form and survive the
     /// proto -> core round-trip.
     #[test]
-    fn custom_pattern_and_length_cross_proto_boundary_both_ways() {
+    fn refined_string_pattern_and_length_cross_proto_boundary_both_ways() {
         let pattern = "^[a-z]+$";
         let length = (Some(1u64), Some(256u64));
-        let core_type = CoreAttributeType::custom(
+        let core_type = CoreAttributeType::refined_string(
             Some(carina_core::schema::TypeIdentity::from_dotted(
                 "aws.example.Resource.SomeConstrained",
             )),
-            CoreAttributeType::string(),
             Some(pattern.to_string()),
             Some(length),
-            legacy_validator(|_| Ok(())),
             None,
         );
 
         // core -> proto: the constraint must reach the wire form.
         let proto_type = core_to_proto_attribute_type(&core_type);
         match &proto_type {
-            ProtoAttributeType::Custom {
+            ProtoAttributeType::String {
+                identity,
                 pattern: proto_pattern,
                 length: proto_length,
                 ..
             } => {
+                assert_eq!(
+                    identity.as_deref(),
+                    Some("aws.example.Resource.SomeConstrained")
+                );
                 assert_eq!(proto_pattern.as_deref(), Some(pattern));
                 assert_eq!(*proto_length, Some(length));
             }
-            other => panic!("Expected Custom, got {other:?}"),
+            other => panic!("Expected String, got {other:?}"),
         }
 
         // proto -> core round-trip: the constraint must survive.
         let roundtripped = proto_to_core_attribute_type(&proto_type);
         match roundtripped.raw_shape() {
-            CoreRawShape::Custom {
+            CoreRawShape::String {
+                identity,
                 pattern: rt_pattern,
                 length: rt_length,
                 ..
             } => {
+                assert_eq!(
+                    identity.map(|id| id.to_string()).as_deref(),
+                    Some("aws.example.Resource.SomeConstrained")
+                );
                 assert_eq!(rt_pattern, Some(pattern));
                 assert_eq!(rt_length, Some(length));
             }
-            other => panic!("Expected Custom, got {other:?}"),
+            other => panic!("Expected String, got {other:?}"),
         }
     }
 
@@ -687,27 +778,21 @@ mod tests {
         }
     }
 
-    /// An anonymous pattern-only `Custom` (`identity: None`, no `length`)
+    /// An anonymous pattern-only refined string (`identity: None`, no `length`)
     /// is the common generated shape for a string attribute carrying just
     /// a CloudFormation `pattern`. The `identity: None` path crosses the
     /// boundary via the `name.is_empty()` branch, so it gets its own
     /// coverage.
     #[test]
-    fn anonymous_custom_pattern_only_crosses_proto_boundary() {
+    fn anonymous_refined_string_pattern_only_crosses_proto_boundary() {
         let pattern = "^[\\w\\-]+$";
-        let core_type = CoreAttributeType::custom(
-            None,
-            CoreAttributeType::string(),
-            Some(pattern.to_string()),
-            None,
-            legacy_validator(|_| Ok(())),
-            None,
-        );
+        let core_type =
+            CoreAttributeType::refined_string(None, Some(pattern.to_string()), None, None);
 
         let proto_type = core_to_proto_attribute_type(&core_type);
         let roundtripped = proto_to_core_attribute_type(&proto_type);
         match roundtripped.raw_shape() {
-            CoreRawShape::Custom {
+            CoreRawShape::String {
                 identity,
                 pattern: rt_pattern,
                 length: rt_length,
@@ -717,7 +802,43 @@ mod tests {
                 assert_eq!(rt_pattern, Some(pattern));
                 assert_eq!(rt_length, None);
             }
-            other => panic!("Expected Custom, got {other:?}"),
+            other => panic!("Expected String, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_custom_string_wire_payload_converts_to_refined_string() {
+        let proto_type = ProtoAttributeType::Custom {
+            name: "aws.example.Resource.Legacy".to_string(),
+            base: Box::new(ProtoAttributeType::String {
+                pattern: None,
+                length: None,
+                validate: None,
+                to_dsl: None,
+                identity: None,
+            }),
+            pattern: Some("^[a-z]+$".to_string()),
+            length: Some((Some(1), Some(9))),
+            validate: None,
+            to_dsl: None,
+        };
+
+        let core_type = proto_to_core_attribute_type(&proto_type);
+        match core_type.raw_shape() {
+            CoreRawShape::String {
+                identity,
+                pattern,
+                length,
+                ..
+            } => {
+                assert_eq!(
+                    identity.map(|id| id.to_string()).as_deref(),
+                    Some("aws.example.Resource.Legacy")
+                );
+                assert_eq!(pattern, Some("^[a-z]+$"));
+                assert_eq!(length, Some((Some(1), Some(9))));
+            }
+            other => panic!("Expected String, got {other:?}"),
         }
     }
 }

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -136,15 +136,19 @@ impl CarinaProvider for AwsProcessProvider {
         types.insert(
             "allowed_account_ids".to_string(),
             proto::AttributeType::List {
-                inner: Box::new(proto::AttributeType::String),
+                element_type: Box::new(proto_string_type()),
                 ordered: false,
+                length: None,
+                validate: None,
             },
         );
         types.insert(
             "forbidden_account_ids".to_string(),
             proto::AttributeType::List {
-                inner: Box::new(proto::AttributeType::String),
+                element_type: Box::new(proto_string_type()),
                 ordered: false,
+                length: None,
+                validate: None,
             },
         );
         types.insert("assume_role".to_string(), assume_role_attribute_type());
@@ -413,7 +417,7 @@ fn assume_role_attribute_type() -> proto::AttributeType {
         fields: vec![
             proto::StructField {
                 name: "role_arn".to_string(),
-                field_type: proto::AttributeType::String,
+                field_type: proto_string_type(),
                 required: true,
                 description: Some("IAM role ARN to assume.".to_string()),
                 block_name: None,
@@ -421,7 +425,7 @@ fn assume_role_attribute_type() -> proto::AttributeType {
             },
             proto::StructField {
                 name: "session_name".to_string(),
-                field_type: proto::AttributeType::String,
+                field_type: proto_string_type(),
                 required: false,
                 description: Some(
                     "STS session name to associate with the assumed-role session.".to_string(),
@@ -431,7 +435,7 @@ fn assume_role_attribute_type() -> proto::AttributeType {
             },
             proto::StructField {
                 name: "external_id".to_string(),
-                field_type: proto::AttributeType::String,
+                field_type: proto_string_type(),
                 required: false,
                 description: Some(
                     "External ID required by the trust policy of the assumed role.".to_string(),
@@ -450,6 +454,16 @@ fn assume_role_attribute_type() -> proto::AttributeType {
                 provider_name: None,
             },
         ],
+    }
+}
+
+fn proto_string_type() -> proto::AttributeType {
+    proto::AttributeType::String {
+        pattern: None,
+        length: None,
+        validate: None,
+        to_dsl: None,
+        identity: None,
     }
 }
 
@@ -597,8 +611,8 @@ mod tests {
                 panic!("{attr} must be declared as a provider config attribute")
             });
             match ty {
-                proto::AttributeType::List { inner, .. } => match inner.as_ref() {
-                    proto::AttributeType::String => {}
+                proto::AttributeType::List { element_type, .. } => match element_type.as_ref() {
+                    proto::AttributeType::String { .. } => {}
                     other => {
                         panic!("{attr} must be List<String>, inner was {other:?}")
                     }
@@ -655,14 +669,17 @@ mod tests {
                     .find(|f| f.name == "role_arn")
                     .expect("assume_role.role_arn must be declared");
                 assert!(role_arn.required, "role_arn must be required");
-                assert!(matches!(role_arn.field_type, proto::AttributeType::String));
+                assert!(matches!(
+                    role_arn.field_type,
+                    proto::AttributeType::String { .. }
+                ));
                 for opt in ["session_name", "external_id"] {
                     let f = fields
                         .iter()
                         .find(|f| f.name == opt)
                         .unwrap_or_else(|| panic!("assume_role.{opt} must be declared"));
                     assert!(!f.required, "assume_role.{opt} must be optional");
-                    assert!(matches!(f.field_type, proto::AttributeType::String));
+                    assert!(matches!(f.field_type, proto::AttributeType::String { .. }));
                 }
                 let duration = fields
                     .iter()

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -193,14 +193,14 @@ fn api_canonicalize_recursive(
             }
             changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
         }
-        Shape::List { inner, .. } => {
+        Shape::List { element_type, .. } => {
             let Value::Concrete(ConcreteValue::List(items)) = value else {
                 return None;
             };
             let mut rewritten = items.clone();
             let mut changed = false;
             for (i, item) in items.iter().enumerate() {
-                if let Some(new_item) = api_canonicalize_recursive(item, inner, schema) {
+                if let Some(new_item) = api_canonicalize_recursive(item, element_type, schema) {
                     rewritten[i] = new_item;
                     changed = true;
                 }

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -5,36 +5,9 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
-};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all", "_1"];
-
-fn validate_from_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < -1 || *n > 65535 {
-            Err(format!("Value {} is out of range -1..=65535", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
-
-fn validate_to_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < -1 || *n > 65535 {
-            Err(format!("Value {} is out of range -1..=65535", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
 
 /// Returns the schema config for ec2.SecurityGroupEgress (Smithy: com.amazonaws.ec2)
 pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
@@ -71,14 +44,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
             .attribute(
                 AttributeSchema::new(
                     "from_port",
-                    AttributeType::custom(
-                        None,
-                        AttributeType::int(),
-                        None,
-                        None,
-                        legacy_validator(validate_from_port_range),
-                        None,
-                    ),
+                    AttributeType::refined_int(None, Some((Some(-1), Some(65535)))),
                 )
                 .create_only()
                 .with_description("Not supported. Use IP permissions instead.")
@@ -139,14 +105,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
             .attribute(
                 AttributeSchema::new(
                     "to_port",
-                    AttributeType::custom(
-                        None,
-                        AttributeType::int(),
-                        None,
-                        None,
-                        legacy_validator(validate_to_port_range),
-                        None,
-                    ),
+                    AttributeType::refined_int(None, Some((Some(-1), Some(65535)))),
                 )
                 .create_only()
                 .with_description("Not supported. Use IP permissions instead.")

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -5,36 +5,9 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
-};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all", "_1"];
-
-fn validate_from_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < -1 || *n > 65535 {
-            Err(format!("Value {} is out of range -1..=65535", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
-
-fn validate_to_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < -1 || *n > 65535 {
-            Err(format!("Value {} is out of range -1..=65535", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
 
 /// Returns the schema config for ec2.SecurityGroupIngress (Smithy: com.amazonaws.ec2)
 pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
@@ -63,13 +36,9 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 .with_provider_name("Description"),
         )
         .attribute(
-            AttributeSchema::new("from_port", AttributeType::custom(
+            AttributeSchema::new("from_port", AttributeType::refined_int(
                 None,
-                AttributeType::int(),
-                None,
-                None,
-                legacy_validator(validate_from_port_range),
-                None,
+                Some((Some(-1), Some(65535))),
             ))
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the start of the port range. If the protocol is ICMP, this is the ICMP type or -1 (all ICMP types). To specify ...")
@@ -119,13 +88,9 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 .with_provider_name("SourceSecurityGroupOwnerId"),
         )
         .attribute(
-            AttributeSchema::new("to_port", AttributeType::custom(
+            AttributeSchema::new("to_port", AttributeType::refined_int(
                 None,
-                AttributeType::int(),
-                None,
-                None,
-                legacy_validator(validate_to_port_range),
-                None,
+                Some((Some(-1), Some(65535))),
             ))
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP, this is the ICMP code or -1 (all ICMP codes). If the start ...")

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -7,36 +7,9 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator, types,
-};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
 const VALID_HOSTNAME_TYPE: &[&str] = &["ip-name", "resource-name", "ip_name", "resource_name"];
-
-fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < 0 || *n > 32 {
-            Err(format!("Value {} is out of range 0..=32", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
-
-fn validate_ipv6_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < 0 || *n > 128 {
-            Err(format!("Value {} is out of range 0..=128", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
 
 /// Returns the schema config for ec2.Subnet (Smithy: com.amazonaws.ec2)
 pub fn ec2_subnet_config() -> AwsSchemaConfig {
@@ -86,13 +59,9 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 .with_provider_name("Ipv4IpamPoolId"),
         )
         .attribute(
-            AttributeSchema::new("ipv4_netmask_length", AttributeType::custom(
-                None,
-                AttributeType::int(),
+            AttributeSchema::new("ipv4_netmask_length", AttributeType::refined_int(
                 None,
                 Some((Some(0), Some(32))),
-                legacy_validator(validate_ipv4_netmask_length_range),
-                None,
             ))
                 .create_only()
                 .with_description("An IPv4 netmask length for the subnet.")
@@ -117,13 +86,9 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 .with_provider_name("Ipv6Native"),
         )
         .attribute(
-            AttributeSchema::new("ipv6_netmask_length", AttributeType::custom(
-                None,
-                AttributeType::int(),
+            AttributeSchema::new("ipv6_netmask_length", AttributeType::refined_int(
                 None,
                 Some((Some(0), Some(128))),
-                legacy_validator(validate_ipv6_netmask_length_range),
-                None,
             ))
                 .create_only()
                 .with_description("An IPv6 netmask length for the subnet.")

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -7,24 +7,9 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
-};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_INSTANCE_TENANCY: &[&str] = &["dedicated", "default", "host"];
-
-fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < 0 || *n > 32 {
-            Err(format!("Value {} is out of range 0..=32", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
 
 /// Returns the schema config for ec2.Vpc (Smithy: com.amazonaws.ec2)
 pub fn ec2_vpc_config() -> AwsSchemaConfig {
@@ -69,13 +54,9 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
                 .with_provider_name("Ipv4IpamPoolId"),
         )
         .attribute(
-            AttributeSchema::new("ipv4_netmask_length", AttributeType::custom(
-                None,
-                AttributeType::int(),
+            AttributeSchema::new("ipv4_netmask_length", AttributeType::refined_int(
                 None,
                 Some((Some(0), Some(32))),
-                legacy_validator(validate_ipv4_netmask_length_range),
-                None,
             ))
                 .create_only()
                 .with_description("The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Amazon VPC IP Address Manager (IPAM) pool. For more information about IPA...")

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -7,20 +7,7 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
-
-fn validate_max_session_duration_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < 3600 || *n > 43200 {
-            Err(format!("Value {} is out of range 3600..=43200", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 pub fn arn() -> AttributeType {
     super::iam_role_arn()
@@ -48,13 +35,9 @@ pub fn iam_role_config() -> AwsSchemaConfig {
                 .with_provider_name("Description"),
         )
         .attribute(
-            AttributeSchema::new("max_session_duration", AttributeType::custom(
-                None,
-                AttributeType::int(),
+            AttributeSchema::new("max_session_duration", AttributeType::refined_int(
                 None,
                 Some((Some(3600), Some(43200))),
-                legacy_validator(validate_max_session_duration_range),
-                None,
             ))
                 .create_only()
                 .with_description("The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default val...")

--- a/carina-provider-aws/src/schemas/generated/kms/key.rs
+++ b/carina-provider-aws/src/schemas/generated/kms/key.rs
@@ -3,41 +3,22 @@
 //! DO NOT EDIT MANUALLY - regenerate with:
 //!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh
 
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(super::provider_type("kms", "Key", "Arn")),
-        super::arn(),
         Some("^arn:(aws|aws-cn|aws-us-gov):kms:[^:]*:[^:]*:key/.+$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_service_arn(s, "kms", Some("key/"))
-                    .map_err(|reason| format!("Invalid KMS Key ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }
 
 pub fn id() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(super::provider_type("kms", "Key", "Id")),
-        super::aws_resource_id(),
         None,
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_kms_key_id(s)
-                    .map_err(|reason| format!("Invalid KMS key identifier '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -7,10 +7,7 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
-};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_IAM_USER_ACCESS_TO_BILLING: &[&str] = &["ALLOW", "DENY", "allow", "deny"];
 
@@ -26,19 +23,10 @@ const VALID_STATUS: &[&str] = &[
 ];
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(super::provider_type("organizations", "Account", "Arn")),
-        super::arn(),
         Some("^arn:(aws|aws-cn|aws-us-gov):organizations:.*$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_service_arn(s, "organizations", None)
-                    .map_err(|reason| format!("Invalid organizations ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -5,27 +5,15 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
-};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING", "all", "consolidated_billing"];
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(super::provider_type("organizations", "Organization", "Arn")),
-        super::arn(),
         Some("^arn:(aws|aws-cn|aws-us-gov):organizations:.*$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_service_arn(s, "organizations", None)
-                    .map_err(|reason| format!("Invalid organizations ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -5,28 +5,13 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
-};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_TYPE: &[&str] = &[
     "A", "AAAA", "CAA", "CNAME", "DS", "HTTPS", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF", "SRV",
     "SSHFP", "SVCB", "TLSA", "TXT", "a", "aaaa", "caa", "cname", "ds", "https", "mx", "naptr",
     "ns", "ptr", "soa", "spf", "srv", "sshfp", "svcb", "tlsa", "txt",
 ];
-
-fn validate_ttl_range(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::Int(n)) = value {
-        if *n < 0 || *n > 2147483647 {
-            Err(format!("Value {} is out of range 0..=2147483647", n))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Expected integer".to_string())
-    }
-}
 
 /// Returns the schema config for route53.RecordSet (Smithy: com.amazonaws.route53)
 pub fn route53_record_set_config() -> AwsSchemaConfig {
@@ -61,13 +46,9 @@ pub fn route53_record_set_config() -> AwsSchemaConfig {
                 .with_provider_name("ResourceRecords"),
         )
         .attribute(
-            AttributeSchema::new("ttl", AttributeType::custom(
-                None,
-                AttributeType::int(),
+            AttributeSchema::new("ttl", AttributeType::refined_int(
                 None,
                 Some((Some(0), Some(2147483647))),
-                legacy_validator(validate_ttl_range),
-                None,
             ))
                 .with_description("The resource record cache time to live (TTL), in seconds. Note the following: If you're creating or updating an alias resource record set, omit TTL. A...")
                 .with_provider_name("TTL"),

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_data_source.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_data_source.rs
@@ -5,23 +5,13 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(super::provider_type("s3", "Bucket", "Arn")),
-        super::arn(),
         Some("^arn:(aws|aws-cn|aws-us-gov):s3:::.+$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_service_arn(s, "s3", None)
-                    .map_err(|reason| format!("Invalid s3 ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
+++ b/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
@@ -5,23 +5,13 @@
 //! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
 
 use super::AwsSchemaConfig;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string(
         Some(super::provider_type("sts", "CallerIdentity", "Arn")),
-        super::arn(),
         Some("^arn:(aws|aws-cn|aws-us-gov):sts:.*$".to_string()),
         None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_service_arn(s, "sts", None)
-                    .map_err(|reason| format!("Invalid sts ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
         None,
     )
 }

--- a/carina-provider-aws/src/schemas/mod.rs
+++ b/carina-provider-aws/src/schemas/mod.rs
@@ -14,7 +14,7 @@ pub fn all_schemas() -> Vec<ResourceSchema> {
 mod tests {
     use std::collections::HashMap;
 
-    use carina_core::schema::{AttributeType, SchemaKind, Shape};
+    use carina_core::schema::{AttributeType, RawShape, ResourceSchema, SchemaKind, Shape};
 
     #[test]
     fn configs_register_s3_bucket_under_both_kinds() {
@@ -44,8 +44,8 @@ mod tests {
             Shape::Enum { identity, .. } => {
                 identities.push((path.to_string(), identity.to_string()))
             }
-            Shape::List { inner, .. } => {
-                collect_enum_identities(inner, &format!("{path}[]"), identities)
+            Shape::List { element_type, .. } => {
+                collect_enum_identities(element_type, &format!("{path}[]"), identities)
             }
             Shape::Map { key, value } => {
                 collect_enum_identities(key, &format!("{path}.<key>"), identities);
@@ -81,6 +81,39 @@ mod tests {
             }
             _ => {}
         }
+    }
+
+    fn attr_type<'a>(schema: &'a ResourceSchema, name: &str) -> &'a AttributeType {
+        &schema
+            .attributes
+            .get(name)
+            .unwrap_or_else(|| panic!("missing attribute {name}"))
+            .attr_type
+    }
+
+    fn assert_refined_string(
+        attr: &AttributeType,
+        expected_identity: &str,
+        expected_pattern: Option<&str>,
+    ) {
+        let RawShape::String {
+            identity, pattern, ..
+        } = attr.raw_shape()
+        else {
+            panic!("expected refined String, got {:?}", attr.raw_shape());
+        };
+        assert_eq!(
+            identity.map(|id| id.to_string()).as_deref(),
+            Some(expected_identity)
+        );
+        assert_eq!(pattern, expected_pattern);
+    }
+
+    fn assert_refined_int_range(attr: &AttributeType, expected_range: (Option<i64>, Option<i64>)) {
+        let RawShape::Int { range, .. } = attr.raw_shape() else {
+            panic!("expected refined Int, got {:?}", attr.raw_shape());
+        };
+        assert_eq!(range, Some(expected_range));
     }
 
     #[test]
@@ -135,6 +168,52 @@ mod tests {
             Some(
                 &"aws.acm.Certificate.RenewalSummary.DomainValidation.ValidationMethod".to_string()
             )
+        );
+    }
+
+    #[test]
+    fn generated_acceptance_refined_primitives_are_direct_shapes() {
+        let iam_role = super::generated::iam::role::iam_role_config();
+        assert_refined_int_range(
+            attr_type(&iam_role.schema, "max_session_duration"),
+            (Some(3600), Some(43200)),
+        );
+        assert_refined_string(
+            attr_type(&iam_role.schema, "arn"),
+            "aws.iam.Role.Arn",
+            Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$"),
+        );
+
+        let route53_record_set = super::generated::route53::record_set::route53_record_set_config();
+        assert_refined_int_range(
+            attr_type(&route53_record_set.schema, "ttl"),
+            (Some(0), Some(2147483647)),
+        );
+
+        let s3_bucket = super::generated::s3::bucket_data_source::s3_bucket_data_source_config();
+        assert_refined_string(
+            attr_type(&s3_bucket.schema, "arn"),
+            "aws.s3.Bucket.Arn",
+            Some("^arn:(aws|aws-cn|aws-us-gov):s3:::.+$"),
+        );
+
+        let ec2_vpc = super::generated::ec2::vpc::ec2_vpc_config();
+        assert_refined_string(
+            attr_type(&ec2_vpc.schema, "vpc_id"),
+            "aws.ec2.Vpc.Id",
+            Some("^vpc-[0-9a-f]{8,}$"),
+        );
+
+        let ec2_nat_gateway = super::generated::ec2::nat_gateway::ec2_nat_gateway_config();
+        assert_refined_string(
+            attr_type(&ec2_nat_gateway.schema, "subnet_id"),
+            "aws.ec2.Subnet.Id",
+            Some("^subnet-[0-9a-f]{8,}$"),
+        );
+        assert_refined_string(
+            attr_type(&ec2_nat_gateway.schema, "vpc_id"),
+            "aws.ec2.Vpc.Id",
+            Some("^vpc-[0-9a-f]{8,}$"),
         );
     }
 }

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -510,16 +510,16 @@ fn dsl_value_to_iam_json(
             }
             scalar_to_json(value)
         }
-        Shape::List { inner, .. } => match value {
+        Shape::List { element_type, .. } => match value {
             Value::Concrete(ConcreteValue::List(items)) => serde_json::Value::Array(
                 items
                     .iter()
-                    .map(|it| dsl_value_to_iam_json(it, inner, attr_name))
+                    .map(|it| dsl_value_to_iam_json(it, element_type, attr_name))
                     .collect(),
             ),
             // A scalar where the schema declares a list: emit the scalar
             // (AWS accepts a bare string for single-element Action etc.).
-            _ => dsl_value_to_iam_json(value, inner, attr_name),
+            _ => dsl_value_to_iam_json(value, element_type, attr_name),
         },
         Shape::Struct { .. } => {
             // Block syntax materializes a single-element List<Map>.

--- a/carina-provider-aws/tests/iam_policy_arn.rs
+++ b/carina-provider-aws/tests/iam_policy_arn.rs
@@ -1,12 +1,11 @@
-use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::RawShape;
-use carina_provider_aws::schemas::generated::iam;
+use carina_provider_aws::schemas::{config::aws_validators, generated::iam};
 
 #[test]
 fn policy_arn_identity_is_provider_scoped() {
     let t = iam::policy::arn();
-    let RawShape::Custom { identity, .. } = t.raw_shape() else {
-        panic!("iam::policy::arn() should be Custom");
+    let RawShape::String { identity, .. } = t.raw_shape() else {
+        panic!("iam::policy::arn() should be refined String");
     };
     assert_eq!(
         identity.map(|id| id.to_string()).as_deref(),
@@ -16,12 +15,7 @@ fn policy_arn_identity_is_provider_scoped() {
 
 #[test]
 fn policy_arn_rejects_role_arn() {
-    let t = iam::policy::arn();
-    let RawShape::Custom { validate, .. } = t.raw_shape() else {
-        panic!("iam::policy::arn() should be Custom");
-    };
-    let v = Value::Concrete(ConcreteValue::String(
-        "arn:aws:iam::123456789012:role/MyRole".to_string(),
-    ));
-    assert!(validate(&v).is_err());
+    let validators = aws_validators();
+    let validate = validators.get("iam_policy_arn").unwrap();
+    assert!(validate("arn:aws:iam::123456789012:role/MyRole").is_err());
 }

--- a/carina-provider-aws/tests/iam_role_arn.rs
+++ b/carina-provider-aws/tests/iam_role_arn.rs
@@ -1,22 +1,17 @@
-use carina_core::resource::{ConcreteValue, Value};
+use carina_provider_aws::schemas::config::aws_validators;
 
 #[test]
 fn arn_rejects_non_role_iam_arn() {
-    let t = carina_provider_aws::schemas::generated::iam::role::arn();
-    let carina_core::schema::RawShape::Custom { validate, .. } = t.raw_shape() else {
-        panic!("arn() should be custom");
-    };
-    let v = Value::Concrete(ConcreteValue::String(
-        "arn:aws:iam::123456789012:policy/Foo".to_string(),
-    ));
-    assert!(validate(&v).is_err());
+    let validators = aws_validators();
+    let validate = validators.get("iam_role_arn").unwrap();
+    assert!(validate("arn:aws:iam::123456789012:policy/Foo").is_err());
 }
 
 #[test]
 fn arn_identity_is_provider_scoped() {
     let t = carina_provider_aws::schemas::generated::iam::role::arn();
-    let carina_core::schema::RawShape::Custom { identity, .. } = t.raw_shape() else {
-        panic!("arn() should be custom");
+    let carina_core::schema::RawShape::String { identity, .. } = t.raw_shape() else {
+        panic!("arn() should be refined String");
     };
     assert_eq!(
         identity.map(|id| id.to_string()).as_deref(),
@@ -26,16 +21,7 @@ fn arn_identity_is_provider_scoped() {
 
 #[test]
 fn arn_accepts_valid_role_arn() {
-    let t = carina_provider_aws::schemas::generated::iam::role::arn();
-    let carina_core::schema::RawShape::Custom { validate, .. } = t.raw_shape() else {
-        panic!("arn() should be Custom");
-    };
-    let v = Value::Concrete(ConcreteValue::String(
-        "arn:aws:iam::123456789012:role/MyRole".to_string(),
-    ));
-    assert!(
-        validate(&v).is_ok(),
-        "should accept valid role ARN: {:?}",
-        validate(&v)
-    );
+    let validators = aws_validators();
+    let validate = validators.get("iam_role_arn").unwrap();
+    assert!(validate("arn:aws:iam::123456789012:role/MyRole").is_ok());
 }

--- a/carina-provider-aws/tests/kms_key_arn.rs
+++ b/carina-provider-aws/tests/kms_key_arn.rs
@@ -1,36 +1,42 @@
-use carina_core::resource::{ConcreteValue, Value};
+use carina_provider_aws::schemas::config::aws_validators;
 
-fn assert_accepts(t: carina_core::schema::AttributeType, value: &str) {
-    let carina_core::schema::RawShape::Custom { validate, .. } = t.raw_shape() else {
-        panic!("type should be custom");
-    };
-    let value = Value::Concrete(ConcreteValue::String(value.to_string()));
-    assert!(validate(&value).is_ok());
+fn assert_validator_accepts(validator_name: &str, value: &str) {
+    let validators = aws_validators();
+    let validate = validators.get(validator_name).unwrap();
+    assert!(validate(value).is_ok());
 }
 
-fn assert_rejects(t: carina_core::schema::AttributeType, value: &str) {
-    let carina_core::schema::RawShape::Custom { validate, .. } = t.raw_shape() else {
-        panic!("type should be custom");
-    };
-    let value = Value::Concrete(ConcreteValue::String(value.to_string()));
-    assert!(validate(&value).is_err());
+fn assert_schema_accepts(t: carina_core::schema::AttributeType, value: &str) {
+    let schema = carina_core::schema::Schema::flat(t);
+    let value = carina_core::resource::Value::Concrete(
+        carina_core::resource::ConcreteValue::String(value.to_string()),
+    );
+    assert!(schema.validate(&value).is_ok());
+}
+
+fn assert_schema_rejects(t: carina_core::schema::AttributeType, value: &str) {
+    let schema = carina_core::schema::Schema::flat(t);
+    let value = carina_core::resource::Value::Concrete(
+        carina_core::resource::ConcreteValue::String(value.to_string()),
+    );
+    assert!(schema.validate(&value).is_err());
 }
 
 #[test]
 fn arn_accepts_only_kms_key_arn() {
-    assert_accepts(
+    assert_schema_accepts(
         carina_provider_aws::schemas::generated::kms::key::arn(),
         "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab",
     );
-    assert_rejects(
+    assert_schema_rejects(
         carina_provider_aws::schemas::generated::kms::key::arn(),
         "arn:aws:kms:us-east-1:123456789012:alias/my-key",
     );
-    assert_rejects(
+    assert_schema_rejects(
         carina_provider_aws::schemas::generated::kms::key::arn(),
         "alias/my-key",
     );
-    assert_rejects(
+    assert_schema_rejects(
         carina_provider_aws::schemas::generated::kms::key::arn(),
         "1234abcd-12ab-34cd-56ef-1234567890ab",
     );
@@ -38,29 +44,23 @@ fn arn_accepts_only_kms_key_arn() {
 
 #[test]
 fn id_accepts_kms_key_identifier_forms() {
-    assert_accepts(
-        carina_provider_aws::schemas::generated::kms::key::id(),
+    assert_validator_accepts(
+        "kms_key_id",
         "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab",
     );
-    assert_accepts(
-        carina_provider_aws::schemas::generated::kms::key::id(),
+    assert_validator_accepts(
+        "kms_key_id",
         "arn:aws:kms:us-east-1:123456789012:alias/my-key",
     );
-    assert_accepts(
-        carina_provider_aws::schemas::generated::kms::key::id(),
-        "alias/my-key",
-    );
-    assert_accepts(
-        carina_provider_aws::schemas::generated::kms::key::id(),
-        "1234abcd-12ab-34cd-56ef-1234567890ab",
-    );
+    assert_validator_accepts("kms_key_id", "alias/my-key");
+    assert_validator_accepts("kms_key_id", "1234abcd-12ab-34cd-56ef-1234567890ab");
 }
 
 #[test]
 fn arn_identity_is_provider_scoped() {
     let t = carina_provider_aws::schemas::generated::kms::key::arn();
-    let carina_core::schema::RawShape::Custom { identity, .. } = t.raw_shape() else {
-        panic!("kms::key::arn() should be Custom");
+    let carina_core::schema::RawShape::String { identity, .. } = t.raw_shape() else {
+        panic!("kms::key::arn() should be refined String");
     };
     assert_eq!(
         identity.map(|id| id.to_string()).as_deref(),

--- a/carina-provider-aws/tests/organizations_arn.rs
+++ b/carina-provider-aws/tests/organizations_arn.rs
@@ -4,8 +4,8 @@ use carina_provider_aws::schemas::generated::organizations;
 #[test]
 fn account_arn_identity_is_provider_scoped() {
     let t = organizations::account::arn();
-    let RawShape::Custom { identity, .. } = t.raw_shape() else {
-        panic!("organizations::account::arn() should be Custom");
+    let RawShape::String { identity, .. } = t.raw_shape() else {
+        panic!("organizations::account::arn() should be refined String");
     };
     assert_eq!(
         identity.map(|id| id.to_string()).as_deref(),
@@ -16,8 +16,8 @@ fn account_arn_identity_is_provider_scoped() {
 #[test]
 fn organization_arn_identity_is_provider_scoped() {
     let t = organizations::organization::arn();
-    let RawShape::Custom { identity, .. } = t.raw_shape() else {
-        panic!("organizations::organization::arn() should be Custom");
+    let RawShape::String { identity, .. } = t.raw_shape() else {
+        panic!("organizations::organization::arn() should be refined String");
     };
     assert_eq!(
         identity.map(|id| id.to_string()).as_deref(),

--- a/carina-provider-aws/tests/s3_bucket_data_source_arn.rs
+++ b/carina-provider-aws/tests/s3_bucket_data_source_arn.rs
@@ -4,8 +4,8 @@ use carina_provider_aws::schemas::generated::s3;
 #[test]
 fn bucket_data_source_arn_identity_is_provider_scoped() {
     let t = s3::bucket_data_source::arn();
-    let RawShape::Custom { identity, .. } = t.raw_shape() else {
-        panic!("s3::bucket_data_source::arn() should be Custom");
+    let RawShape::String { identity, .. } = t.raw_shape() else {
+        panic!("s3::bucket_data_source::arn() should be refined String");
     };
     assert_eq!(
         identity.map(|id| id.to_string()).as_deref(),

--- a/carina-provider-aws/tests/sts_arn.rs
+++ b/carina-provider-aws/tests/sts_arn.rs
@@ -4,8 +4,8 @@ use carina_provider_aws::schemas::generated::sts;
 #[test]
 fn caller_identity_arn_identity_is_provider_scoped() {
     let t = sts::caller_identity::arn();
-    let RawShape::Custom { identity, .. } = t.raw_shape() else {
-        panic!("sts::caller_identity::arn() should be Custom");
+    let RawShape::String { identity, .. } = t.raw_shape() else {
+        panic!("sts::caller_identity::arn() should be refined String");
     };
     assert_eq!(
         identity.map(|id| id.to_string()).as_deref(),


### PR DESCRIPTION
## Summary

Fourth implementation PR in the chain from carina#3429. Migrates provider-aws to the refined primitive type system from carina#3431 / #3432 / #3433.

- Bump carina pins (`carina-core`, `carina-plugin-sdk`, `carina-provider-protocol`) to `805bc331cb33e28fcd640926bc52991e884071b5`.
- Rewrite the hand-written `carina-aws-types` schemas (Arn, ResourceId, VpcId / SubnetId / SecurityGroupId family, IAM Role, IAM Policy, KMS Key, S3, STS, Identity Store, etc.) so they use the refined primitive constructors directly instead of `AttributeType::custom(...)`.
- Switch the Smithy codegen to emit refined string / int metadata for ARN, ResourceId, and numeric-range attributes; regenerate everything under `carina-provider-aws/src/schemas/generated/`.
- Update protocol conversion in `carina-provider-aws` for refined primitive / list wire payloads while leaving the legacy `Custom` deserialize compat (provided by carina-core's PR2) untouched.
- Refresh ARN / range schema-assertion tests so they read identity, pattern, range, and validators from the refined variants instead of `Shape::Custom`.

## Verification

- `./scripts/generate-schemas-smithy.sh`
- `RUSTC_WRAPPER= cargo check --workspace --all-targets`
- `RUSTC_WRAPPER= cargo nextest run` — 494 passed
- `RUSTC_WRAPPER= cargo test --doc`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets`
- `CARINA_CORE_DIR=… ./scripts/check-carina-pin.sh`
- `./scripts/check-string-enum-aliases.sh`
- `./scripts/check-examples.sh`

Refs: carina#3429
