### PR TITLE
Follow carina structured enum identifier types (carina#3438 PR4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=805bc331cb33e28fcd640926bc52991e884071b5#805bc331cb33e28fcd640926bc52991e884071b5"
+source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=805bc331cb33e28fcd640926bc52991e884071b5#805bc331cb33e28fcd640926bc52991e884071b5"
+source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=805bc331cb33e28fcd640926bc52991e884071b5#805bc331cb33e28fcd640926bc52991e884071b5"
+source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "805bc331cb33e28fcd640926bc52991e884071b5" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -968,7 +968,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+                    Value::Concrete(ConcreteValue::enum_identifier("2012_10_17")),
                 ),
                 (
                     "statement".to_string(),
@@ -977,9 +977,7 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::EnumIdentifier(
-                                        "allow".to_string(),
-                                    )),
+                                    Value::Concrete(ConcreteValue::enum_identifier("allow")),
                                 ),
                                 (
                                     "action".to_string(),
@@ -1009,7 +1007,7 @@ mod tests {
         let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "version".to_string(),
-                Value::Concrete(ConcreteValue::EnumIdentifier("2020_01_01".to_string())),
+                Value::Concrete(ConcreteValue::enum_identifier("2020_01_01")),
             )]
             .into_iter()
             .collect(),
@@ -1026,7 +1024,7 @@ mod tests {
                     ConcreteValue::Map(
                         vec![(
                             "effect".to_string(),
-                            Value::Concrete(ConcreteValue::EnumIdentifier("grant".to_string())),
+                            Value::Concrete(ConcreteValue::enum_identifier("grant")),
                         )]
                         .into_iter()
                         .collect(),
@@ -1046,7 +1044,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+                    Value::Concrete(ConcreteValue::enum_identifier("2012_10_17")),
                 ),
                 (
                     "statement".to_string(),
@@ -1055,9 +1053,7 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::EnumIdentifier(
-                                        "deny".to_string(),
-                                    )),
+                                    Value::Concrete(ConcreteValue::enum_identifier("deny")),
                                 ),
                                 (
                                     "action".to_string(),
@@ -1092,7 +1088,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+                    Value::Concrete(ConcreteValue::enum_identifier("2012_10_17")),
                 ),
                 (
                     "statement".to_string(),
@@ -1101,9 +1097,7 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::EnumIdentifier(
-                                        "allow".to_string(),
-                                    )),
+                                    Value::Concrete(ConcreteValue::enum_identifier("allow")),
                                 ),
                                 (
                                     "principal".to_string(),
@@ -1151,7 +1145,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+                    Value::Concrete(ConcreteValue::enum_identifier("2012_10_17")),
                 ),
                 (
                     "statement".to_string(),
@@ -1160,9 +1154,7 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::EnumIdentifier(
-                                        "allow".to_string(),
-                                    )),
+                                    Value::Concrete(ConcreteValue::enum_identifier("allow")),
                                 ),
                                 (
                                     "principal".to_string(),
@@ -1446,15 +1438,13 @@ mod tests {
         let schema = carina_core::schema::Schema::flat(attr);
         assert!(
             schema
-                .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-                    "global".to_string()
-                )))
+                .validate(&Value::Concrete(ConcreteValue::enum_identifier("global")))
                 .is_ok()
         );
         assert!(
             schema
-                .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-                    "Z0000000000000".to_string()
+                .validate(&Value::Concrete(ConcreteValue::enum_identifier(
+                    "Z0000000000000"
                 )))
                 .is_err()
         );
@@ -1910,7 +1900,7 @@ mod tests {
             vec![
                 (
                     "effect".to_string(),
-                    Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
+                    Value::Concrete(ConcreteValue::enum_identifier("allow")),
                 ),
                 (
                     "action".to_string(),
@@ -1940,7 +1930,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+                    Value::Concrete(ConcreteValue::enum_identifier("2012_10_17")),
                 ),
                 (
                     "statement".to_string(),

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -2565,17 +2565,32 @@ fn generate_provider_code(
             code.push_str("\x20       let mut has_changes = false;\n");
 
             for field in &fields {
-                code.push_str(&format!(
-                    "\x20       if let Some(Value::Concrete(ConcreteValue::String(val))) = attributes.get(\"{}\") {{\n",
-                    field.attr_snake
-                ));
                 if let Some(ref enum_type) = field.enum_type_name {
-                    code.push_str("\x20           let normalized = extract_enum_value(val);\n");
+                    code.push_str(&format!(
+                        "\x20       if let Some(value) = attributes.get(\"{}\") {{\n",
+                        field.attr_snake
+                    ));
+                    code.push_str("\x20           let normalized = match value {\n");
+                    code.push_str(
+                        "\x20               Value::Concrete(ConcreteValue::String(val)) => extract_enum_value(val),\n",
+                    );
+                    code.push_str(
+                        "\x20               Value::Concrete(ConcreteValue::EnumIdentifier(val)) => extract_enum_value(val.as_str()),\n",
+                    );
+                    code.push_str(
+                        "\x20               Value::Concrete(ConcreteValue::CanonicalEnum(val)) => val.api_value().to_string(),\n",
+                    );
+                    code.push_str("\x20               _ => continue,\n");
+                    code.push_str("\x20           };\n");
                     code.push_str(&format!(
                         "\x20           builder = builder.{}({}::from(normalized));\n",
                         field.builder_setter, enum_type
                     ));
                 } else {
+                    code.push_str(&format!(
+                        "\x20       if let Some(Value::Concrete(ConcreteValue::String(val))) = attributes.get(\"{}\") {{\n",
+                        field.attr_snake
+                    ));
                     code.push_str(&format!(
                         "\x20           builder = builder.{}(val.as_str());\n",
                         field.builder_setter

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "805bc331cb33e28fcd640926bc52991e884071b5" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "805bc331cb33e28fcd640926bc52991e884071b5" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "805bc331cb33e28fcd640926bc52991e884071b5" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -51,8 +51,13 @@ pub fn core_to_proto_value(v: &CoreValue) -> ProtoValue {
         // emit it as `ProtoValue::String` — identical to the `String`
         // arm. The shape distinction is consumed at the validator entry
         // before reaching this conversion.
-        CoreValue::Concrete(ConcreteValue::String(s))
-        | CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => ProtoValue::String(s.clone()),
+        CoreValue::Concrete(ConcreteValue::String(s)) => ProtoValue::String(s.clone()),
+        CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            ProtoValue::String(s.as_str().to_string())
+        }
+        CoreValue::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            ProtoValue::String(c.api_value().to_string())
+        }
         CoreValue::Concrete(ConcreteValue::Int(i)) => ProtoValue::Int(*i),
         CoreValue::Concrete(ConcreteValue::Float(f)) => ProtoValue::Float(*f),
         CoreValue::Concrete(ConcreteValue::Bool(b)) => ProtoValue::Bool(*b),
@@ -286,33 +291,19 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
         } => {
             let inner_t = proto_to_core_attribute_type(element_type);
             if *ordered {
-                let list = CoreAttributeType::list(inner_t);
-                if length.is_some() {
-                    CoreAttributeType::custom(
-                        None,
-                        list,
-                        None,
-                        *length,
-                        legacy_validator(|_| Ok(())),
-                        None,
-                    )
-                } else {
-                    list
-                }
+                CoreAttributeType::refined_list(
+                    inner_t,
+                    true,
+                    *length,
+                    legacy_validator(|_| Ok(())),
+                )
             } else {
-                let list = CoreAttributeType::unordered_list(inner_t);
-                if length.is_some() {
-                    CoreAttributeType::custom(
-                        None,
-                        list,
-                        None,
-                        *length,
-                        legacy_validator(|_| Ok(())),
-                        None,
-                    )
-                } else {
-                    list
-                }
+                CoreAttributeType::refined_list(
+                    inner_t,
+                    false,
+                    *length,
+                    legacy_validator(|_| Ok(())),
+                )
             }
         }
         ProtoAttributeType::Map { inner, key } => CoreAttributeType::map_with_key(
@@ -352,14 +343,19 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
                     length.map(|(min, max)| (min.map(|v| v as i64), max.map(|v| v as i64))),
                 ),
                 CoreRawShape::Float { .. } => CoreAttributeType::refined_float(identity, None),
-                CoreRawShape::List { .. } => CoreAttributeType::custom(
-                    identity,
-                    base,
-                    pattern.clone(),
-                    *length,
-                    legacy_validator(|_| Ok(())),
-                    None,
-                ),
+                CoreRawShape::List {
+                    element_type,
+                    ordered,
+                    ..
+                } => {
+                    let _ = (identity, pattern);
+                    CoreAttributeType::refined_list(
+                        element_type.clone(),
+                        ordered,
+                        *length,
+                        legacy_validator(|_| Ok(())),
+                    )
+                }
                 other => panic!("unsupported Custom base in provider protocol: {other:?}"),
             }
         }

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -154,10 +154,15 @@ fn api_canonicalize_recursive(
     // them, so the DSL spelling reached AWS and was rejected with
     // `MalformedPolicy`.
     if let Some((_, Some(values), _, _, dsl_map)) = attr_type.enum_parts() {
-        let (Value::Concrete(ConcreteValue::String(s))
-        | Value::Concrete(ConcreteValue::EnumIdentifier(s))) = value
-        else {
-            return None;
+        if let Value::Concrete(ConcreteValue::CanonicalEnum(c)) = value {
+            return Some(Value::Concrete(ConcreteValue::String(
+                c.api_value().to_string(),
+            )));
+        }
+        let s = match value {
+            Value::Concrete(ConcreteValue::String(s)) => s.as_str(),
+            Value::Concrete(ConcreteValue::EnumIdentifier(s)) => s.as_str(),
+            _ => return None,
         };
         let valid: Vec<&str> = values.iter().map(String::as_str).collect();
         let dsl_trailing = carina_core::utils::extract_enum_value_with_values(s, &valid);
@@ -166,7 +171,7 @@ fn api_canonicalize_recursive(
         // arrived as a plain `String` (no namespace, no shape rewrite).
         // An `EnumIdentifier` must still be lowered to `String` so the
         // schema-blind downstream serializers see a plain string.
-        if matches!(value, Value::Concrete(ConcreteValue::String(_))) && s == &api {
+        if matches!(value, Value::Concrete(ConcreteValue::String(_))) && s == api {
             return None;
         }
         return Some(Value::Concrete(ConcreteValue::String(api)));
@@ -636,7 +641,7 @@ mod tests {
         let mut stmt = IndexMap::new();
         stmt.insert(
             "effect".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
+            Value::Concrete(ConcreteValue::enum_identifier("allow")),
         );
         stmt.insert(
             "action".to_string(),
@@ -645,8 +650,8 @@ mod tests {
         let mut policy = IndexMap::new();
         policy.insert(
             "version".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier(
-                "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
+            Value::Concrete(ConcreteValue::enum_identifier(
+                "aws.iam.PolicyDocument.Version.2012_10_17",
             )),
         );
         policy.insert(
@@ -1033,7 +1038,7 @@ mod tests {
         let mut stmt = IndexMap::new();
         stmt.insert(
             "effect".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
+            Value::Concrete(ConcreteValue::enum_identifier("allow")),
         );
         stmt.insert(
             "condition".to_string(),
@@ -1115,7 +1120,7 @@ mod tests {
             let mut stmt = IndexMap::new();
             stmt.insert(
                 "effect".to_string(),
-                Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
+                Value::Concrete(ConcreteValue::enum_identifier("allow")),
             );
             stmt.insert(
                 "condition".to_string(),

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_LOG_DESTINATION_TYPE: &[&str] = &[
     "cloud-watch-logs",
@@ -103,6 +103,24 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
                 .create_only()
                 .with_description("The type of resource to monitor.")
                 .with_provider_name("ResourceType"),
+        )
+        .attribute(
+            AttributeSchema::new("tag_field_specifications", AttributeType::list(AttributeType::struct_(
+                    "TagFieldSpecificationRequest".to_string(),
+                    vec![
+                    StructField::new("resource_type", AttributeType::enum_(
+    carina_core::schema::enum_identity("ResourceType", Some("aws.ec2.FlowLog.TagFieldSpecificationRequest")),
+    Some(vec!["auto-scaling-group".to_string(), "instance".to_string(), "network-interface".to_string()]),
+    vec![("auto-scaling-group".to_string(), "auto_scaling_group".to_string()), ("instance".to_string(), "instance".to_string()), ("network-interface".to_string(), "network_interface".to_string())],
+    None,
+    None,
+)).with_description("The resource type for the tag keys associated with the Flow Logs Amazon EC2 Tags feature fields in your custom log format.").with_provider_name("ResourceType"),
+                    StructField::new("tag_keys", AttributeType::list(AttributeType::string())).with_description("The tag keys on your tagged resources to be displayed by the Flow Logs Amazon EC2 Tags feature fields in your custom log format.").with_provider_name("TagKeys")
+                    ],
+                )))
+                .create_only()
+                .with_description("The tag configuration associated with the Flow Logs Amazon EC2 Tags feature fields in your custom log format.")
+                .with_provider_name("TagFieldSpecifications"),
         )
         .attribute(
             AttributeSchema::new("traffic_type", AttributeType::enum_(

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -461,11 +461,20 @@ fn dsl_value_to_iam_json(
     // the WIT boundary collapses `EnumIdentifier` to `String` anyway).
     if let Some((_, Some(values), _, _, dsl_map)) = attr_type.enum_parts() {
         match value {
-            Value::Concrete(ConcreteValue::String(s))
-            | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            Value::Concrete(ConcreteValue::String(s)) => {
                 let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-                let trailing = carina_core::utils::extract_enum_value_with_values(s, &valid);
+                let trailing =
+                    carina_core::utils::extract_enum_value_with_values(s.as_str(), &valid);
                 return serde_json::Value::String(dsl_map.api_for(trailing));
+            }
+            Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+                let valid: Vec<&str> = values.iter().map(String::as_str).collect();
+                let trailing =
+                    carina_core::utils::extract_enum_value_with_values(s.as_str(), &valid);
+                return serde_json::Value::String(dsl_map.api_for(trailing));
+            }
+            Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+                return serde_json::Value::String(c.api_value().to_string());
             }
             _ => return scalar_to_json(value),
         }
@@ -611,6 +620,9 @@ fn scalar_to_json(value: &Value) -> serde_json::Value {
         Value::Concrete(ConcreteValue::Bool(b)) => serde_json::Value::Bool(*b),
         Value::Concrete(ConcreteValue::EnumIdentifier(id)) => {
             serde_json::Value::String(id.rsplit('.').next().unwrap_or(id.as_str()).to_string())
+        }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            serde_json::Value::String(c.api_value().to_string())
         }
         Value::Concrete(ConcreteValue::List(items)) => {
             serde_json::Value::Array(items.iter().map(scalar_to_json).collect())
@@ -841,7 +853,7 @@ mod tests {
         let mut policy = IndexMap::new();
         policy.insert(
             "version".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+            Value::Concrete(ConcreteValue::enum_identifier("2012_10_17")),
         );
         let mut stmt = IndexMap::new();
         // `effect` is a StringEnum. The read path now emits raw
@@ -876,6 +888,52 @@ mod tests {
         assert!(!resolved.contains("\"version\""));
     }
 
+    #[test]
+    fn resolve_iam_policy_attr_serializes_canonical_enum_api_value() {
+        let mut stmt = IndexMap::new();
+        stmt.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::enum_identifier("allow")),
+        );
+        stmt.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
+        );
+        let mut policy = IndexMap::new();
+        policy.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::enum_identifier("2012_10_17")),
+        );
+        policy.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt),
+            )])),
+        );
+        let schema = carina_core::schema::Schema::flat(carina_aws_types::iam_policy_document());
+        let canonical = schema.canonicalize(Value::Concrete(ConcreteValue::Map(policy)));
+        assert!(
+            matches!(canonical, Value::Concrete(ConcreteValue::Map(_))),
+            "policy should canonicalize to a map"
+        );
+
+        let r = make_resource(Some(canonical));
+        let resolved = resolve_iam_policy_attr(&r, "policy").expect("map -> JSON");
+
+        assert!(
+            resolved.contains(r#""Version":"2012-10-17""#),
+            "version must use CanonicalEnum api_value, got: {resolved}"
+        );
+        assert!(
+            resolved.contains(r#""Effect":"Allow""#),
+            "effect must use CanonicalEnum api_value, got: {resolved}"
+        );
+        assert!(
+            !resolved.contains("2012_10_17") && !resolved.contains(r#""allow""#),
+            "DSL spelling must not reach AWS, got: {resolved}"
+        );
+    }
+
     /// aws#315 defensive fallback: the schema-typed AWS normalizer
     /// (`api_canonicalize_recursive`) is what actually canonicalizes
     /// `version` / `effect` before this serializer runs — see the
@@ -890,14 +948,14 @@ mod tests {
         let mut policy = IndexMap::new();
         policy.insert(
             "version".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier(
-                "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
+            Value::Concrete(ConcreteValue::enum_identifier(
+                "aws.iam.PolicyDocument.Version.2012_10_17",
             )),
         );
         let mut stmt = IndexMap::new();
         stmt.insert(
             "effect".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
+            Value::Concrete(ConcreteValue::enum_identifier("allow")),
         );
         stmt.insert(
             "action".to_string(),

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -310,6 +310,7 @@ fn redrive_allow_policy_to_json_string(value: &Value) -> Option<String> {
             // -> allowAll); the enum surface is the trailing segment.
             s.rsplit('.').next().unwrap_or(s.as_str()).to_string()
         }
+        Some(Value::Concrete(ConcreteValue::CanonicalEnum(c))) => c.api_value().to_string(),
         _ => return None,
     };
     let mut obj = serde_json::Map::new();

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -1652,30 +1652,26 @@ fn test_organization_feature_set_validates_snake_case_alias() {
     // parser would emit `EnumIdentifier` for both. Mirror that here.
     let schema = carina_core::schema::Schema::flat(feature_set.attr_type.clone());
     schema
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-            "ALL".to_string(),
-        )))
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier("ALL")))
         .expect("API spelling ALL should be accepted");
     schema
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-            "all".to_string(),
-        )))
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier("all")))
         .expect("DSL spelling all should be accepted");
     schema
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-            "CONSOLIDATED_BILLING".to_string(),
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
+            "CONSOLIDATED_BILLING",
         )))
         .expect("API spelling CONSOLIDATED_BILLING should be accepted");
     schema
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-            "consolidated_billing".to_string(),
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
+            "consolidated_billing",
         )))
         .expect("DSL spelling consolidated_billing should be accepted");
     // Bogus values still rejected.
     assert!(
         schema
-            .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-                "not_a_value".to_string()
+            .validate(&Value::Concrete(ConcreteValue::enum_identifier(
+                "not_a_value"
             )))
             .is_err(),
         "unknown values must still be rejected"
@@ -1701,23 +1697,15 @@ fn test_route53_record_type_validates_snake_case_alias() {
     // to `StringLiteralExpectedEnum`.
     let schema = carina_core::schema::Schema::flat(type_attr.attr_type.clone());
     schema
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-            "A".to_string(),
-        )))
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier("A")))
         .expect("API spelling A should be accepted");
     schema
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-            "a".to_string(),
-        )))
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier("a")))
         .expect("DSL spelling a should be accepted");
     schema
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-            "CNAME".to_string(),
-        )))
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier("CNAME")))
         .expect("API spelling CNAME should be accepted");
     schema
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
-            "cname".to_string(),
-        )))
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier("cname")))
         .expect("DSL spelling cname should be accepted");
 }


### PR DESCRIPTION
Refs carina-rs/carina#3438

## Summary

Follow-up for the structured enum identifier types introduced in carina (carina-rs/carina#3443, #3444; design doc `notes/specs/2026-06-10-structured-enum-identifier-design.md` in the carina repo).

- Bump all carina git pins (carina-core / carina-plugin-sdk / carina-provider-protocol) to `ad91ed00f2c5b3f0345570a48835977dacfc145b`.
- Adapt `ConcreteValue::EnumIdentifier` match sites to the new `RawEnumIdentifier` payload (text-transparent via `as_str()`).
- Add explicit `CanonicalEnum` arms wherever enum-typed values can reach a serializer or normalizer, emitting `api_value()`: `core_to_proto_value`, `api_canonicalize_recursive` (the single upstream seam for nested leaves), IAM `dsl_value_to_iam_json` / `scalar_to_json`, and the SQS redrive-allow serializer. No catch-all silently swallows the new variant.
- Codegen template updated in lockstep (update-builder enum branch handles String / EnumIdentifier / CanonicalEnum); regen against Smithy fixtures produces a zero diff, so generated sources and template stay in parity.
- New unit test pins that a `CanonicalEnum` flows through the IAM policy serializer as its `api_value`.

## Verification

- `cargo test` — all green
- `cargo clippy -- -D warnings`, `cargo fmt --check`
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`
- `scripts/check-carina-pin.sh`, `scripts/check-string-enum-aliases.sh` — pass
- Review sweep confirmed every `ConcreteValue` match site either handles `CanonicalEnum` explicitly or provably cannot receive enum-typed values (proto boundary only produces String/Int/Float/Bool/List/Map).
