### PR TITLE
Trust host enum canonicalization; remove provider-side re-derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
+source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
+source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
+source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }

--- a/carina-aws-types/src/common/enums.rs
+++ b/carina-aws-types/src/common/enums.rs
@@ -75,11 +75,11 @@ fn dsl_aliases_for(values: &[&str]) -> Vec<(String, String)> {
 /// same `values` slice that defines the canonical AWS API values, making
 /// "closed enum with empty `dsl_aliases`" impossible by construction.
 ///
-/// `AwsNormalizer::api_canonicalize_recursive` relies on this alias
-/// table to rewrite DSL spellings (e.g. `aes256`) to the AWS canonical
-/// (`AES256`) before the wire call. A closed enum whose alias table is
-/// empty silently forwards the raw alias spelling to the AWS SDK and
-/// triggers `MalformedXML` / `Unknown(...)` errors.
+/// Core's enum resolver relies on this alias table to rewrite DSL
+/// spellings (e.g. `aes256`) to the AWS canonical (`AES256`) before the
+/// value crosses the provider boundary. A closed enum whose alias table is
+/// empty can silently forward the raw alias spelling to the AWS SDK and
+/// trigger `MalformedXML` / `Unknown(...)` errors.
 /// See `carina-rs/carina-provider-aws#390`.
 ///
 /// The raw [`AttributeType::enum_`] constructor remains in use

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -2005,10 +2005,9 @@ mod tests {
     }
 
     /// Regression: `s3_sse_algorithm` must register DSL aliases for every
-    /// value so `AwsNormalizer::api_canonicalize_recursive` rewrites the
-    /// DSL alias spelling (e.g. `aes256`) to the AWS API canonical
-    /// (`AES256`) before the apply path forwards it to S3. Without
-    /// aliases the literal alias string flows on the wire and
+    /// value so core rewrites the DSL alias spelling (e.g. `aes256`) to
+    /// the AWS API canonical (`AES256`) before the apply path forwards it
+    /// to S3. Without aliases the literal alias string flows on the wire and
     /// `PutBucketEncryption` returns `MalformedXML`. See
     /// `carina-rs/carina-provider-aws#390`.
     #[test]

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
-use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -361,18 +360,15 @@ impl AwsProvider {
     }
 }
 
-/// Convert protocol value from DSL format to AWS format
-/// - aws.Protocol.tcp / Protocol.tcp / tcp -> tcp
-/// - aws.Protocol.all / Protocol.all / all / -1 -> -1
+/// Convert protocol value to AWS format.
+///
+/// Enum-typed protocol values arrive as AWS-canonical strings from core.
+/// Keep the legacy bare `all` alias mapping here because AWS expects `-1`.
 pub(crate) fn convert_protocol_value(value: &str) -> String {
-    // First convert DSL enum format to raw value
-    let raw = convert_enum_value(value);
-
-    // Handle special case: "all" means "-1" (all protocols)
-    if raw == "all" {
+    if value == "all" {
         "-1".to_string()
     } else {
-        raw.to_string()
+        value.to_string()
     }
 }
 
@@ -403,18 +399,8 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_protocol_value_dsl_format_tcp() {
-        assert_eq!(convert_protocol_value("aws.Protocol.tcp"), "tcp");
-    }
-
-    #[test]
-    fn test_convert_protocol_value_dsl_format_all() {
-        assert_eq!(convert_protocol_value("aws.Protocol.all"), "-1");
-    }
-
-    #[test]
-    fn test_convert_protocol_value_short_dsl_format() {
-        assert_eq!(convert_protocol_value("Protocol.tcp"), "tcp");
+    fn test_convert_protocol_value_canonical_tcp() {
+        assert_eq!(convert_protocol_value("tcp"), "tcp");
     }
 
     // --- Route composite identifier parsing tests ---

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -40,10 +40,10 @@ pub fn require_string_attr(resource: &Resource, attr_name: &str) -> ProviderResu
 
 /// Extract a required enum attribute from a resource.
 ///
-/// `AwsNormalizer::normalize_desired` rewrites every enum value to its
-/// AWS API-canonical bare spelling (`Enabled`, `VPC`, `STANDARD_IA`) at
-/// plan time, so the caller can feed the result straight to an SDK
-/// builder like `BucketVersioningStatus::from(...)`.
+/// Core rewrites every schema-known enum value to its AWS API-canonical
+/// spelling (`Enabled`, `VPC`, `STANDARD_IA`) before the provider sees it,
+/// so the caller can feed the result straight to an SDK builder like
+/// `BucketVersioningStatus::from(...)`.
 ///
 /// Equivalent to `require_string_attr` today — the alias historically
 /// stripped a DSL namespace prefix, but normalization now happens
@@ -425,9 +425,8 @@ mod tests {
 
     #[test]
     fn test_require_enum_attr_returns_canonical_value() {
-        // After AwsNormalizer::normalize_desired runs, enum attributes
-        // carry the bare AWS API-canonical spelling. require_enum_attr
-        // just passes it through.
+        // Core sends enum attributes in AWS API-canonical spelling.
+        // require_enum_attr just passes it through.
         let resource = make_test_resource(vec![("type", "A")]);
         assert_eq!(require_enum_attr(&resource, "type").unwrap(), "A");
     }

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -1,4 +1,4 @@
-//! AWS Provider normalizer and enum resolution
+//! AWS Provider normalizer
 
 use std::collections::HashMap;
 
@@ -6,21 +6,18 @@ use indexmap::IndexMap;
 
 use carina_core::provider::{self, BoxFuture, ProviderNormalizer, SavedAttrs, ready_noop};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
-use carina_core::schema::{AttributeType, ResourceSchema, SchemaRegistry};
+use carina_core::schema::SchemaRegistry;
 
 /// Schema extension for the AWS provider.
 ///
-/// Handles plan-time normalization of enum identifiers.
+/// Handles provider-local desired-state normalization.
 pub struct AwsNormalizer;
 
 impl ProviderNormalizer for AwsNormalizer {
     fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
-        // Bodies are pure (enum resolution, dns-name strip — no I/O);
-        // the trait is async only so the WASM host impl can `.await`
-        // the guest directly (carina#3112). Wrapping the existing sync
-        // logic in a ready future is sufficient here.
+        // Bodies are pure (dns-name strip — no I/O); the trait is async only
+        // so the WASM host impl can `.await` the guest directly (carina#3112).
         Box::pin(async move {
-            resolve_enum_identifiers(resources);
             crate::services::route53::record_set::normalize_record_set_dns_names(resources);
         })
     }
@@ -52,238 +49,6 @@ impl ProviderNormalizer for AwsNormalizer {
     }
 }
 
-/// Normalize enum identifiers in resources to the AWS API-canonical
-/// spelling — including nested positions (Struct fields, List items,
-/// Map values).
-///
-/// Runs as two passes per attribute:
-///
-/// 1. [`carina_core::utils::resolve_enum_value_recursive`] converts every
-///    DSL identifier in the value tree to the fully-qualified DSL form
-///    (`enabled` → `aws.s3.Bucket.VersioningStatus.enabled`). This step
-///    is provider-neutral.
-/// 2. [`api_canonicalize_recursive`] then walks the same shape and
-///    rewrites each enum value to its API-canonical spelling
-///    (`aws.s3.Bucket.VersioningStatus.enabled` → `Enabled`) via
-///    [`DslMap::api_for`]. Provider hand-written code reads
-///    `Value::Concrete(ConcreteValue::String(api_canonical))` and
-///    passes it straight to the AWS SDK builder — `extract_enum_value`
-///    is no longer needed anywhere in `services/`.
-///
-/// The recursion is the contract: every enum value reaching the
-/// provider is API-canonical no matter how deeply it is nested.
-pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
-    let configs = crate::schemas::generated::configs();
-
-    for resource in resources.iter_mut() {
-        // Only handle aws resources
-        if resource.id.provider != "aws" {
-            continue;
-        }
-
-        // Find the matching schema config
-        let config = configs
-            .iter()
-            .find(|c| c.schema.resource_type == resource.id.resource_type);
-        let config = match config {
-            Some(c) => c,
-            None => continue,
-        };
-
-        let mut resolved_attrs = HashMap::new();
-        for (key, value) in &resource.attributes {
-            let Some(attr_schema) = config.schema.attributes.get(key.as_str()) else {
-                continue;
-            };
-            // Pass 1: bare/short DSL identifiers → fully-qualified DSL form.
-            let after_dsl =
-                carina_core::utils::resolve_enum_value_recursive(value, &attr_schema.attr_type);
-            // Pass 2: DSL spelling → API canonical at every nested enum position.
-            let base = after_dsl.as_ref().unwrap_or(value);
-            let after_api =
-                api_canonicalize_recursive(base, &attr_schema.attr_type, &config.schema);
-
-            match (after_dsl, after_api) {
-                (_, Some(v)) => {
-                    resolved_attrs.insert(key.clone(), v);
-                }
-                (Some(v), None) => {
-                    resolved_attrs.insert(key.clone(), v);
-                }
-                (None, None) => {}
-            }
-        }
-
-        for (key, value) in resolved_attrs {
-            resource.set_attr(key, value);
-        }
-    }
-}
-
-/// Walk `value` against `attr_type` and rewrite every enum spelling to
-/// the AWS API-canonical form via `DslMap::api_for`.
-///
-/// Input shapes: enum leaves arrive either as fully-qualified DSL
-/// `String` (the output of `resolve_enum_value_recursive`) or as
-/// `EnumIdentifier` (DSL-source values that Pass-1 leaves untouched,
-/// e.g. nested IAM policy `version` / `effect` after the carina#3055
-/// state-lift). Both carry the same text payload; extraction is
-/// `extract_enum_value_with_values(s, values)` — strip the namespace
-/// prefix, recovering dotted enum values like the legacy `ipsec.1` —
-/// followed by `dsl_map.api_for(trailing)` to translate DSL → API.
-///
-/// Returns `None` when nothing was rewritten, mirroring the
-/// `resolve_enum_value_recursive` contract so callers can compose the
-/// two passes without redundant clones.
-fn api_canonicalize_recursive(
-    value: &Value,
-    attr_type: &AttributeType,
-    schema: &ResourceSchema,
-) -> Option<Value> {
-    // Leaf: StringEnum (with or without namespace). We canonicalize via
-    // the alias table regardless of whether the input was namespaced —
-    // `extract_enum_value_with_values` handles both shapes (including
-    // dotted enum values like the legacy `ipsec.1`).
-    //
-    // Both `String` and `EnumIdentifier` carry the same text payload; the
-    // shape distinction (carina#2986) is irrelevant once we are
-    // rewriting to the AWS wire form. Accepting `EnumIdentifier` here is
-    // the fix for aws#315: after the carina#3055 state-lift, nested
-    // StringEnum struct fields (IAM policy `version` / `effect`) arrive
-    // as `EnumIdentifier`, and a `String`-only guard silently skipped
-    // them, so the DSL spelling reached AWS and was rejected with
-    // `MalformedPolicy`.
-    if let Some((_, Some(values), _, _, dsl_map)) = attr_type.enum_parts() {
-        if let Value::Concrete(ConcreteValue::CanonicalEnum(c)) = value {
-            return Some(Value::Concrete(ConcreteValue::String(
-                c.api_value().to_string(),
-            )));
-        }
-        let s = match value {
-            Value::Concrete(ConcreteValue::String(s)) => s.as_str(),
-            Value::Concrete(ConcreteValue::EnumIdentifier(s)) => s.as_str(),
-            _ => return None,
-        };
-        let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-        let dsl_trailing = carina_core::utils::extract_enum_value_with_values(s, &valid);
-        let api = dsl_map.api_for(dsl_trailing);
-        // No-op only when the value is already the bare API spelling AND
-        // arrived as a plain `String` (no namespace, no shape rewrite).
-        // An `EnumIdentifier` must still be lowered to `String` so the
-        // schema-blind downstream serializers see a plain string.
-        if matches!(value, Value::Concrete(ConcreteValue::String(_))) && s == api {
-            return None;
-        }
-        return Some(Value::Concrete(ConcreteValue::String(api)));
-    }
-
-    use carina_core::schema::Shape;
-    match schema.shape_of(attr_type) {
-        Shape::Struct { .. } => {
-            let Value::Concrete(ConcreteValue::Map(map)) = value else {
-                return None;
-            };
-            let mut budget = carina_core::schema::ShapeWalkBudget::new(64);
-            let fields = schema.struct_fields_with_budget(attr_type, &mut budget)?;
-            let mut rewritten = map.clone();
-            let mut changed = false;
-            for field in fields {
-                if let Some(field_value) = map.get(&field.name)
-                    && let Some(new_field) =
-                        api_canonicalize_recursive(field_value, &field.field_type, schema)
-                {
-                    rewritten.insert(field.name.clone(), new_field);
-                    changed = true;
-                }
-            }
-            changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
-        }
-        Shape::List { element_type, .. } => {
-            let Value::Concrete(ConcreteValue::List(items)) = value else {
-                return None;
-            };
-            let mut rewritten = items.clone();
-            let mut changed = false;
-            for (i, item) in items.iter().enumerate() {
-                if let Some(new_item) = api_canonicalize_recursive(item, element_type, schema) {
-                    rewritten[i] = new_item;
-                    changed = true;
-                }
-            }
-            changed.then_some(Value::Concrete(ConcreteValue::List(rewritten)))
-        }
-        Shape::Map { key, value: inner } => {
-            let Value::Concrete(ConcreteValue::Map(map)) = value else {
-                return None;
-            };
-            // aws#325: when the Map's *key* type is a `StringEnum`
-            // (e.g. the IAM policy `condition`'s `ConditionOperator`),
-            // canonicalize each key to the StringEnum spelling —
-            // symmetric to the value recursion below. Without this a
-            // non-canonical operator key (namespaced / aliased) on the
-            // desired side was never reconciled, while the state side
-            // already lands on the snake spelling via the IAM read
-            // path (`json_to_condition` → `condition_operator_to_snake`,
-            // role.rs) — leaving the two sides out of sync. This key
-            // canon brings the desired side to the same spelling.
-            let canon_of = |k: &str| -> String {
-                match &key.enum_parts() {
-                    Some((_, Some(values), _, _, dsl_map)) => {
-                        let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-                        dsl_map.api_for(carina_core::utils::extract_enum_value_with_values(
-                            k, &valid,
-                        ))
-                    }
-                    Some((_, None, _, _, _)) => k.to_string(),
-                    None => k.to_string(),
-                }
-            };
-            // Detect whether canonicalizing keys would collapse two
-            // distinct source keys onto one canonical spelling (e.g.
-            // the same condition operator written twice — bare AND
-            // namespaced). That is malformed input; pre-PR the keys
-            // were never canonicalized so both survived as distinct
-            // keys and the downstream serializer rejected it loudly
-            // with `MalformedPolicy`. To preserve that (never silently
-            // drop a clause) we disable key canonicalization wholesale
-            // for this map when a collision exists — order-independent
-            // because it inspects the whole key set up front, not the
-            // per-iteration insertion order. Value recursion still
-            // applies in both cases.
-            let mut seen_canon = std::collections::HashSet::new();
-            let key_collision = map.keys().any(|k| !seen_canon.insert(canon_of(k)));
-            // Rebuild preserving insertion order (IndexMap order is
-            // load-bearing for plan display, #2222).
-            let mut rewritten = indexmap::IndexMap::with_capacity(map.len());
-            let mut changed = false;
-            for (k, v) in map {
-                let new_key = if key_collision {
-                    k.clone()
-                } else {
-                    let ck = canon_of(k);
-                    if ck != *k {
-                        changed = true;
-                    }
-                    ck
-                };
-                let new_v = match api_canonicalize_recursive(v, inner, schema) {
-                    Some(nv) => {
-                        changed = true;
-                        nv
-                    }
-                    None => v.clone(),
-                };
-                rewritten.insert(new_key, new_v);
-            }
-            changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
-        }
-        // Scalars and Union: nothing to descend into. Union arms with
-        // enum values are not supported (mirroring the upstream
-        // `resolve_enum_value_recursive` contract).
-        _ => None,
-    }
-}
-
 /// Normalize enum values in read-returned state attributes to namespaced DSL format.
 ///
 /// Read methods return plain values like `"Enabled"` from AWS APIs.
@@ -312,7 +77,7 @@ pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMa
                     resolved.insert(key.clone(), normalized);
                 }
             }
-            // Normalize enum fields within struct (Map) values
+            // Normalize enum fields within struct (Map) values.
             if let carina_core::schema::Shape::Struct { .. } =
                 config.schema.shape_of(&attr_schema.attr_type)
                 && let Value::Concrete(ConcreteValue::Map(map_fields)) = value
@@ -329,7 +94,7 @@ pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMa
                     if let Some(parts) = field.field_type.enum_parts()
                         && let Some(field_value) = map_fields.get(&field.name)
                     {
-                        // Struct field state normalization: bare values only (no dot-check needed)
+                        // Struct field state normalization: bare values only.
                         if let Some(normalized) =
                             carina_core::utils::resolve_enum_value(field_value, &parts)
                         {
@@ -356,128 +121,64 @@ pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMa
 mod tests {
     use super::*;
 
-    // After aws#258, `resolve_enum_identifiers` runs a second pass that
-    // canonicalizes DSL spellings into the AWS API form (bare value). So
-    // every shape of input — namespaced, TypeName.value, bare DSL alias,
-    // bare API canonical — collapses to the AWS API spelling
-    // (e.g. `"Enabled"`) before the provider sees it. Pre-#258, the
-    // output was the fully-qualified DSL form
-    // (e.g. `"aws.s3.BucketVersioning.VersioningStatus.enabled"`).
-    #[test]
-    fn test_resolve_enum_identifiers_namespaced_value() {
-        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
+    #[tokio::test]
+    async fn normalize_desired_does_not_mutate_enum_typed_attributes() {
+        let mut resource = Resource::with_provider("aws", "ec2.Subnet", "test-subnet", None);
         resource.set_attr(
-            "status".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string(),
-            )),
+            "availability_zone".to_string(),
+            Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
+        );
+        resource.set_attr(
+            "private_dns_name_options_on_launch".to_string(),
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+                "hostname_type".to_string(),
+                Value::Concrete(ConcreteValue::String("ip-name".to_string())),
+            )]))),
         );
         let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
+
+        AwsNormalizer.normalize_desired(&mut resources).await;
+
         assert_eq!(
-            resources[0].get_attr("status"),
+            resources[0].get_attr("availability_zone"),
             Some(&Value::Concrete(ConcreteValue::String(
-                "Enabled".to_string()
+                "ap-northeast-1a".to_string()
+            )))
+        );
+        let Some(Value::Concrete(ConcreteValue::Map(fields))) =
+            resources[0].get_attr("private_dns_name_options_on_launch")
+        else {
+            panic!("expected private_dns_name_options_on_launch map");
+        };
+        assert_eq!(
+            fields.get("hostname_type"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "ip-name".to_string()
             )))
         );
     }
 
-    #[test]
-    fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
+    #[tokio::test]
+    async fn normalize_desired_still_strips_record_set_trailing_dot() {
+        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-rec", None);
         resource.set_attr(
-            "status".to_string(),
-            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("_abc.example.com.".to_string())),
         );
         let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        assert_eq!(
-            resources[0].get_attr("status"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "Enabled".to_string()
-            )))
-        );
-    }
 
-    #[test]
-    fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource =
-            Resource::with_provider("aws", "s3.BucketOwnershipControls", "test", None);
-        resource.set_attr(
-            "object_ownership".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "ObjectOwnership.BucketOwnerEnforced".to_string(),
-            )),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        assert_eq!(
-            resources[0].get_attr("object_ownership"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "BucketOwnerEnforced".to_string()
-            )))
-        );
-    }
+        AwsNormalizer.normalize_desired(&mut resources).await;
 
-    #[test]
-    fn test_resolve_enum_identifiers_plain_string() {
-        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
-        resource.set_attr(
-            "status".to_string(),
-            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
         assert_eq!(
-            resources[0].get_attr("status"),
+            resources[0].get_attr("name"),
             Some(&Value::Concrete(ConcreteValue::String(
-                "Enabled".to_string()
+                "_abc.example.com".to_string()
             )))
-        );
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_skips_non_aws() {
-        let mut resource = Resource::with_provider("awscc", "s3.BucketVersioning", "test", None);
-        resource.set_attr(
-            "status".to_string(),
-            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        // Should not be modified since provider is "awscc"
-        assert_eq!(
-            resources[0].get_attr("status"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "Enabled".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_with_to_dsl() {
-        // ip_protocol has `dsl_aliases` mapping API `"-1"` ↔ DSL `"all"`.
-        // The pass-2 canonicalize rewrites the DSL spelling back to
-        // the API form, so `"-1"` round-trips to itself (it's already
-        // API-canonical; pass-1 only namespaces it, pass-2 strips the
-        // namespace and canonicalizes via api_for).
-        let mut resource =
-            Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule", None);
-        resource.set_attr(
-            "ip_protocol".to_string(),
-            Value::Concrete(ConcreteValue::String("-1".to_string())),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        assert_eq!(
-            resources[0].get_attr("ip_protocol"),
-            Some(&Value::Concrete(ConcreteValue::String("-1".to_string())))
         );
     }
 
     #[test]
     fn test_normalize_state_enums_with_to_dsl() {
-        // Read returns "-1" for ip_protocol, should be normalized to "all" via to_dsl
         let mut attributes = HashMap::from([(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("-1".to_string())),
@@ -504,15 +205,12 @@ mod tests {
             ),
         ]);
         normalize_state_enums("s3.BucketOwnershipControls", &mut attributes);
-        // After carina#2832, normalize_state_enum_value applies dsl_aliases
-        // and writes back the DSL spelling for diff stability.
         assert_eq!(
             attributes.get("object_ownership"),
             Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced".to_string()
             )))
         );
-        // Non-enum attributes should not be modified
         assert_eq!(
             attributes.get("bucket"),
             Some(&Value::Concrete(ConcreteValue::String(
@@ -551,321 +249,11 @@ mod tests {
             )),
         )]);
         normalize_state_enums("s3.BucketVersioning", &mut attributes);
-        // Already namespaced values (contain dots) should not be modified
         assert_eq!(
             attributes.get("status"),
             Some(&Value::Concrete(ConcreteValue::String(
                 "aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string()
             )))
-        );
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_dsl_alias_to_api_canonical() {
-        // Regression for issue #258: DSL alias `enabled` must be
-        // canonicalized to AWS API spelling `Enabled` before reaching
-        // the provider's SDK::from() call. Without this, the SDK wraps
-        // the unknown value and S3 returns MalformedXML.
-        let mut resource = Resource::with_provider("aws", "s3.BucketVersioning", "test", None);
-        resource.set_attr(
-            "status".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "aws.s3.BucketVersioning.VersioningStatus.enabled".to_string(),
-            )),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        assert_eq!(
-            resources[0].get_attr("status"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "Enabled".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_nested_struct_field() {
-        // Struct field enums (e.g. partitioned_prefix.partition_date_source
-        // in BucketLogging) must be canonicalized through the recursion,
-        // not just the top-level attribute.
-        use indexmap::IndexMap;
-        let mut resource = Resource::with_provider("aws", "s3.BucketLogging", "test", None);
-        let mut pp = IndexMap::new();
-        pp.insert(
-            "partition_date_source".to_string(),
-            Value::Concrete(ConcreteValue::String("event_time".to_string())),
-        );
-        let mut tokf = IndexMap::new();
-        tokf.insert(
-            "partitioned_prefix".to_string(),
-            Value::Concrete(ConcreteValue::Map(pp)),
-        );
-        resource.set_attr(
-            "target_object_key_format".to_string(),
-            Value::Concrete(ConcreteValue::Map(tokf)),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        let Some(Value::Concrete(ConcreteValue::Map(outer))) =
-            resources[0].get_attr("target_object_key_format")
-        else {
-            panic!("expected map");
-        };
-        let Some(Value::Concrete(ConcreteValue::Map(inner))) = outer.get("partitioned_prefix")
-        else {
-            panic!("expected nested map");
-        };
-        assert_eq!(
-            inner.get("partition_date_source"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "EventTime".to_string()
-            )))
-        );
-    }
-
-    /// Root-cause regression for aws#315: the IAM policy document is a
-    /// fully schema-typed `Struct` (`iam_policy_document()`) whose
-    /// `version` and nested `statement[].effect` are `StringEnum` fields.
-    /// After the carina#3055 state-lift these arrive as `EnumIdentifier`,
-    /// not `String`. The Pass-2 leaf guard previously matched only
-    /// `String`, so it silently skipped them and the DSL spelling
-    /// (`aws.iam.PolicyDocument.Version.2012_10_17`, `allow`) flowed
-    /// through to the AWS API, which rejected the PUT with
-    /// `MalformedPolicy`. The fix accepts `EnumIdentifier` at the
-    /// StringEnum leaf and lowers it to the AWS-canonical `String`
-    /// (`"2012-10-17"`, `"Allow"`) — generically, for every nested
-    /// StringEnum struct field, not just IAM policy.
-    #[test]
-    fn test_resolve_enum_identifiers_iam_policy_doc_enum_identifier_nested() {
-        use indexmap::IndexMap;
-        let mut stmt = IndexMap::new();
-        stmt.insert(
-            "effect".to_string(),
-            Value::Concrete(ConcreteValue::enum_identifier("allow")),
-        );
-        stmt.insert(
-            "action".to_string(),
-            Value::Concrete(ConcreteValue::String("sts:AssumeRole".to_string())),
-        );
-        let mut policy = IndexMap::new();
-        policy.insert(
-            "version".to_string(),
-            Value::Concrete(ConcreteValue::enum_identifier(
-                "aws.iam.PolicyDocument.Version.2012_10_17",
-            )),
-        );
-        policy.insert(
-            "statement".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
-                ConcreteValue::Map(stmt),
-            )])),
-        );
-
-        let mut resource = Resource::with_provider("aws", "iam.Role", "test-role", None);
-        resource.set_attr(
-            "assume_role_policy_document".to_string(),
-            Value::Concrete(ConcreteValue::Map(policy)),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-
-        let Some(Value::Concrete(ConcreteValue::Map(pd))) =
-            resources[0].get_attr("assume_role_policy_document")
-        else {
-            panic!("expected assume_role_policy_document Map");
-        };
-        assert_eq!(
-            pd.get("version"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "2012-10-17".to_string()
-            ))),
-            "version must be lowered to AWS-canonical String"
-        );
-        let Some(Value::Concrete(ConcreteValue::List(stmts))) = pd.get("statement") else {
-            panic!("expected statement List");
-        };
-        let Some(Value::Concrete(ConcreteValue::Map(s0))) = stmts.first() else {
-            panic!("expected statement[0] Map");
-        };
-        assert_eq!(
-            s0.get("effect"),
-            Some(&Value::Concrete(ConcreteValue::String("Allow".to_string()))),
-            "effect must be lowered to AWS-canonical String"
-        );
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_cloudfront_hosted_zone_id_in_alias_target() {
-        // Regression for aws#302: `aws.cloudfront.HostedZoneId.global` written
-        // at value position of `alias_target.hosted_zone_id` (a Struct field)
-        // must resolve to the AWS-published constant `Z2FDTNDATAQYW2` before
-        // the value reaches the SDK builder. The receiving Struct field is
-        // schema-typed as a CloudFront-namespaced StringEnum, so the normalizer
-        // descends into the struct and rewrites via `DslMap::api_for`.
-        use indexmap::IndexMap;
-        let mut resource =
-            Resource::with_provider("aws", "route53.RecordSet", "test-cf-alias", None);
-        let mut alias_target = IndexMap::new();
-        alias_target.insert(
-            "dns_name".to_string(),
-            Value::Concrete(ConcreteValue::String("d1234.cloudfront.net".to_string())),
-        );
-        alias_target.insert(
-            "evaluate_target_health".to_string(),
-            Value::Concrete(ConcreteValue::Bool(false)),
-        );
-        alias_target.insert(
-            "hosted_zone_id".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "aws.cloudfront.HostedZoneId.global".to_string(),
-            )),
-        );
-        resource.set_attr(
-            "alias_target".to_string(),
-            Value::Concrete(ConcreteValue::Map(alias_target)),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        let Some(Value::Concrete(ConcreteValue::Map(at))) = resources[0].get_attr("alias_target")
-        else {
-            panic!("expected alias_target Map");
-        };
-        assert_eq!(
-            at.get("hosted_zone_id"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "Z2FDTNDATAQYW2".to_string()
-            )))
-        );
-    }
-
-    /// Variants of the aws#302 input shape — literal AWS spelling,
-    /// TypeName shorthand, and the negative case where the *top-level*
-    /// `RecordSet.hosted_zone_id` (user's own Route 53 zone) must NOT
-    /// be coerced through the CloudFront alias table.
-    #[test]
-    fn test_resolve_enum_identifiers_cloudfront_hosted_zone_id_input_shapes() {
-        use indexmap::IndexMap;
-        let make_resource = |hzid: &str| {
-            let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test", None);
-            let mut at = IndexMap::new();
-            at.insert(
-                "dns_name".to_string(),
-                Value::Concrete(ConcreteValue::String("d1.cloudfront.net".to_string())),
-            );
-            at.insert(
-                "evaluate_target_health".to_string(),
-                Value::Concrete(ConcreteValue::Bool(false)),
-            );
-            at.insert(
-                "hosted_zone_id".to_string(),
-                Value::Concrete(ConcreteValue::String(hzid.to_string())),
-            );
-            resource.set_attr(
-                "alias_target".to_string(),
-                Value::Concrete(ConcreteValue::Map(at)),
-            );
-            resource
-        };
-
-        // Literal `Z2FDTNDATAQYW2` (the AWS-published spelling) — the
-        // StringEnum's `values` list accepts it directly without alias
-        // rewriting.
-        let mut resources = vec![make_resource("Z2FDTNDATAQYW2")];
-        resolve_enum_identifiers(&mut resources);
-        let Some(Value::Concrete(ConcreteValue::Map(at))) = resources[0].get_attr("alias_target")
-        else {
-            panic!("expected alias_target Map");
-        };
-        assert_eq!(
-            at.get("hosted_zone_id"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "Z2FDTNDATAQYW2".to_string()
-            )))
-        );
-
-        // TypeName shorthand `HostedZoneId.global` — resolves through
-        // Pass 1's `TypeName.value` arm.
-        let mut resources = vec![make_resource("HostedZoneId.global")];
-        resolve_enum_identifiers(&mut resources);
-        let Some(Value::Concrete(ConcreteValue::Map(at))) = resources[0].get_attr("alias_target")
-        else {
-            panic!("expected alias_target Map");
-        };
-        assert_eq!(
-            at.get("hosted_zone_id"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "Z2FDTNDATAQYW2".to_string()
-            )))
-        );
-
-        // Bare DSL alias `global` — `resolve_enum_value_recursive`
-        // expands a bare identifier to `aws.cloudfront.HostedZoneId.global`
-        // (Pass 1), and Pass 2 then rewrites the trailing alias through
-        // `DslMap::api_for` to land on `Z2FDTNDATAQYW2`.
-        let mut resources = vec![make_resource("global")];
-        resolve_enum_identifiers(&mut resources);
-        let Some(Value::Concrete(ConcreteValue::Map(at))) = resources[0].get_attr("alias_target")
-        else {
-            panic!("expected alias_target Map");
-        };
-        assert_eq!(
-            at.get("hosted_zone_id"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "Z2FDTNDATAQYW2".to_string()
-            )))
-        );
-
-        // Negative: top-level `RecordSet.hosted_zone_id` is the user's
-        // own Route 53 zone (plain String in the schema) — a literal
-        // hosted-zone ID like `Z1XYZABC123` must NOT be rewritten.
-        let mut resource =
-            Resource::with_provider("aws", "route53.RecordSet", "test-toplevel", None);
-        resource.set_attr(
-            "hosted_zone_id".to_string(),
-            Value::Concrete(ConcreteValue::String("Z1XYZABC123".to_string())),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        assert_eq!(
-            resources[0].get_attr("hosted_zone_id"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "Z1XYZABC123".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_ec2_vpc_instance_tenancy() {
-        let mut resource = Resource::with_provider("aws", "ec2.Vpc", "test-vpc", None);
-        resource.set_attr(
-            "instance_tenancy".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "InstanceTenancy.dedicated".to_string(),
-            )),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        assert_eq!(
-            resources[0].get_attr("instance_tenancy"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "dedicated".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_ec2_security_group_ingress_protocol() {
-        let mut resource =
-            Resource::with_provider("aws", "ec2.SecurityGroupIngress", "test-rule", None);
-        resource.set_attr(
-            "ip_protocol".to_string(),
-            Value::Concrete(ConcreteValue::String("IpProtocol.tcp".to_string())),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-        assert_eq!(
-            resources[0].get_attr("ip_protocol"),
-            Some(&Value::Concrete(ConcreteValue::String("tcp".to_string())))
         );
     }
 
@@ -924,7 +312,6 @@ mod tests {
                     "aws.ec2.Subnet.PrivateDnsNameOptionsOnLaunch.HostnameType.ip_name".to_string()
                 )))
             );
-            // Non-enum fields should not be modified
             assert_eq!(
                 fields.get("enable_resource_name_dns_a_record"),
                 Some(&Value::Concrete(ConcreteValue::Bool(true)))
@@ -951,11 +338,6 @@ mod tests {
 
     #[test]
     fn test_normalize_state_enums_vpn_gateway_type_with_dot() {
-        // "ipsec.1" arrives from the AWS API as the canonical spelling.
-        // Under carina#2980 / aws#268 the dotted form is rewritten to
-        // snake_case (`ipsec.1` → `ipsec_1`) so it stays a bare DSL
-        // identifier, and the namespaced DSL form uses the underscore
-        // variant.
         let mut attributes = HashMap::from([(
             "type".to_string(),
             Value::Concrete(ConcreteValue::String("ipsec.1".to_string())),
@@ -969,31 +351,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_aws_normalizer_strips_record_set_trailing_dot() {
-        // Regression for aws#300: when `route53.RecordSet.name` is fed by
-        // another resource's read (e.g. `cert.domain_validation_options[0]
-        // .resource_record.name`), the AWS API returns the FQDN with a
-        // trailing dot. AwsNormalizer::normalize_desired must strip it so
-        // the diff against the dot-stripped state row is stable.
-        let mut resource = Resource::with_provider("aws", "route53.RecordSet", "test-rec", None);
-        resource.set_attr(
-            "name".to_string(),
-            Value::Concrete(ConcreteValue::String("_abc.example.com.".to_string())),
-        );
-        let mut resources = vec![resource];
-        AwsNormalizer.normalize_desired(&mut resources).await;
-        assert_eq!(
-            resources[0].get_attr("name"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "_abc.example.com".to_string()
-            )))
-        );
-    }
-
     #[test]
     fn test_normalize_state_enums_vpn_gateway_type_already_namespaced() {
-        // Already in DSL format — should NOT be double-normalized.
         let mut attributes = HashMap::from([(
             "type".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -1007,170 +366,5 @@ mod tests {
                 "aws.ec2.VpnGateway.Type.ipsec.1".to_string()
             )))
         );
-    }
-
-    /// aws#325: the IAM policy `condition` field is
-    /// `Map<StringEnum "ConditionOperator", Map<..>>`.
-    /// `api_canonicalize_recursive`'s `Map` arm recursed only the
-    /// value, never the **key**, so a non-canonical
-    /// `ConditionOperator` map key (here a fully-namespaced form) was
-    /// left untouched on both the desired and state passes. Symmetric
-    /// to the value recursion, the key must be canonicalized to the
-    /// StringEnum's spelling.
-    #[test]
-    fn test_resolve_enum_identifiers_condition_operator_map_key() {
-        use indexmap::IndexMap;
-
-        // Inner condition body: { "aws:SecureTransport": "true" }
-        let mut cond_body = IndexMap::new();
-        cond_body.insert(
-            "aws:SecureTransport".to_string(),
-            Value::Concrete(ConcreteValue::String("true".to_string())),
-        );
-        // Operator key arrives fully-namespaced (the shape Pass-1 can
-        // produce / a read path could emit); only the trailing
-        // `string_equals` is the StringEnum value.
-        let mut condition = IndexMap::new();
-        condition.insert(
-            "aws.iam.Statement.ConditionOperator.string_equals".to_string(),
-            Value::Concrete(ConcreteValue::Map(cond_body)),
-        );
-        let mut stmt = IndexMap::new();
-        stmt.insert(
-            "effect".to_string(),
-            Value::Concrete(ConcreteValue::enum_identifier("allow")),
-        );
-        stmt.insert(
-            "condition".to_string(),
-            Value::Concrete(ConcreteValue::Map(condition)),
-        );
-        let mut policy = IndexMap::new();
-        policy.insert(
-            "statement".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
-                ConcreteValue::Map(stmt),
-            )])),
-        );
-
-        let mut resource = Resource::with_provider("aws", "iam.Role", "test-role", None);
-        resource.set_attr(
-            "assume_role_policy_document".to_string(),
-            Value::Concrete(ConcreteValue::Map(policy)),
-        );
-        let mut resources = vec![resource];
-        resolve_enum_identifiers(&mut resources);
-
-        let Some(Value::Concrete(ConcreteValue::Map(pd))) =
-            resources[0].get_attr("assume_role_policy_document")
-        else {
-            panic!("expected assume_role_policy_document Map");
-        };
-        let Some(Value::Concrete(ConcreteValue::List(stmts))) = pd.get("statement") else {
-            panic!("expected statement List");
-        };
-        let Some(Value::Concrete(ConcreteValue::Map(s0))) = stmts.first() else {
-            panic!("expected statement[0] Map");
-        };
-        let Some(Value::Concrete(ConcreteValue::Map(cond))) = s0.get("condition") else {
-            panic!("expected condition Map");
-        };
-        assert!(
-            cond.contains_key("string_equals"),
-            "ConditionOperator map key must be canonicalized to the \
-             StringEnum spelling, got keys: {:?}",
-            cond.keys().collect::<Vec<_>>()
-        );
-        assert!(
-            !cond.contains_key("aws.iam.Statement.ConditionOperator.string_equals"),
-            "the namespaced key must not survive"
-        );
-    }
-
-    /// aws#325 collision guard: a malformed `condition` writing the
-    /// same operator twice in different spellings (bare + namespaced)
-    /// would have both keys fold to `string_equals`. Blind
-    /// canonicalization lets `IndexMap::insert` overwrite one clause —
-    /// silent policy weakening. The guard inspects the whole key set
-    /// up front and, on collision, disables key canonicalization for
-    /// the map wholesale so BOTH clauses survive with their original
-    /// spellings (pre-PR behavior) and the downstream serializer still
-    /// rejects the malformed input loudly. Asserted for **both**
-    /// insertion orders — the bug the first cut had was order-dependent
-    /// (reversed order silently dropped a clause).
-    #[test]
-    fn test_condition_operator_key_collision_keeps_both_clauses() {
-        use indexmap::IndexMap;
-
-        let body = |v: &str| {
-            let mut m = IndexMap::new();
-            m.insert(
-                "aws:SecureTransport".to_string(),
-                Value::Concrete(ConcreteValue::String(v.to_string())),
-            );
-            Value::Concrete(ConcreteValue::Map(m))
-        };
-        let bare = "string_equals";
-        let nsd = "aws.iam.Statement.ConditionOperator.string_equals";
-
-        // Run the same malformed condition in both key orderings.
-        for (first, second) in [(bare, nsd), (nsd, bare)] {
-            let mut condition = IndexMap::new();
-            condition.insert(first.to_string(), body("true"));
-            condition.insert(second.to_string(), body("false"));
-            let mut stmt = IndexMap::new();
-            stmt.insert(
-                "effect".to_string(),
-                Value::Concrete(ConcreteValue::enum_identifier("allow")),
-            );
-            stmt.insert(
-                "condition".to_string(),
-                Value::Concrete(ConcreteValue::Map(condition)),
-            );
-            let mut policy = IndexMap::new();
-            policy.insert(
-                "statement".to_string(),
-                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
-                    ConcreteValue::Map(stmt),
-                )])),
-            );
-
-            let mut resource = Resource::with_provider("aws", "iam.Role", "test-role", None);
-            resource.set_attr(
-                "assume_role_policy_document".to_string(),
-                Value::Concrete(ConcreteValue::Map(policy)),
-            );
-            let mut resources = vec![resource];
-            resolve_enum_identifiers(&mut resources);
-
-            let Some(Value::Concrete(ConcreteValue::Map(pd))) =
-                resources[0].get_attr("assume_role_policy_document")
-            else {
-                panic!("expected Map");
-            };
-            let Some(Value::Concrete(ConcreteValue::List(stmts))) = pd.get("statement") else {
-                panic!("expected statement List");
-            };
-            let Some(Value::Concrete(ConcreteValue::Map(s0))) = stmts.first() else {
-                panic!("expected statement[0] Map");
-            };
-            let Some(Value::Concrete(ConcreteValue::Map(cond))) = s0.get("condition") else {
-                panic!("expected condition Map");
-            };
-            // Both clauses survive with their ORIGINAL spellings —
-            // collision disables canon wholesale, order-independent.
-            assert_eq!(
-                cond.len(),
-                2,
-                "order ({first}, {second}): both colliding clauses must \
-                 survive, got: {:?}",
-                cond.keys().collect::<Vec<_>>()
-            );
-            assert!(
-                cond.contains_key(bare) && cond.contains_key(nsd),
-                "order ({first}, {second}): both original keys kept \
-                 (no silent drop), got: {:?}",
-                cond.keys().collect::<Vec<_>>()
-            );
-        }
     }
 }

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
-use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -82,7 +81,7 @@ impl AwsProvider {
         if let Some(Value::Concrete(ConcreteValue::String(az))) =
             resource.get_attr("availability_zone")
         {
-            req = req.availability_zone(convert_enum_value(az).replace('_', "-"));
+            req = req.availability_zone(az);
         }
 
         let result = req.send().await.map_err(|e| {
@@ -200,11 +199,10 @@ impl AwsProvider {
             attributes.get("private_dns_name_options_on_launch")
         {
             if let Some(Value::Concrete(ConcreteValue::String(ht))) = fields.get("hostname_type") {
-                let hostname_val = convert_enum_value(ht).replace('_', "-");
                 self.ec2_client
                     .modify_subnet_attribute()
                     .subnet_id(subnet_id)
-                    .private_dns_hostname_type_on_launch(HostnameType::from(hostname_val.as_str()))
+                    .private_dns_hostname_type_on_launch(HostnameType::from(ht.as_str()))
                     .send()
                     .await
                     .map_err(|e| {

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -463,15 +463,19 @@ fn dsl_value_to_iam_json(
         match value {
             Value::Concrete(ConcreteValue::String(s)) => {
                 let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-                let trailing =
-                    carina_core::utils::extract_enum_value_with_values(s.as_str(), &valid);
-                return serde_json::Value::String(dsl_map.api_for(trailing));
+                return serde_json::Value::String(carina_core::utils::canonicalize_enum_to_api(
+                    s.as_str(),
+                    &valid,
+                    &dsl_map,
+                ));
             }
             Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
                 let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-                let trailing =
-                    carina_core::utils::extract_enum_value_with_values(s.as_str(), &valid);
-                return serde_json::Value::String(dsl_map.api_for(trailing));
+                return serde_json::Value::String(carina_core::utils::canonicalize_enum_to_api(
+                    s.as_str(),
+                    &valid,
+                    &dsl_map,
+                ));
             }
             Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
                 return serde_json::Value::String(c.api_value().to_string());
@@ -610,8 +614,8 @@ fn dsl_value_to_iam_json(
 /// Terminal scalar conversion. No enum handling here — `StringEnum`
 /// leaves are canonicalized in `dsl_value_to_iam_json` before reaching
 /// this point. An `EnumIdentifier` only lands here for a non-schema
-/// position (none exist in `iam_policy_document()` today); strip its
-/// namespace so a stray value still serializes as a plain string.
+/// position or schema desync, so serialize it verbatim and let AWS reject
+/// invalid wire text visibly.
 fn scalar_to_json(value: &Value) -> serde_json::Value {
     match value {
         Value::Concrete(ConcreteValue::String(s)) => serde_json::Value::String(s.clone()),
@@ -619,7 +623,10 @@ fn scalar_to_json(value: &Value) -> serde_json::Value {
         Value::Concrete(ConcreteValue::Float(f)) => serde_json::json!(*f),
         Value::Concrete(ConcreteValue::Bool(b)) => serde_json::Value::Bool(*b),
         Value::Concrete(ConcreteValue::EnumIdentifier(id)) => {
-            serde_json::Value::String(id.rsplit('.').next().unwrap_or(id.as_str()).to_string())
+            // Raw EnumIdentifier at wire-out means the host did not
+            // canonicalize it; pass it through so AWS-side rejection is
+            // visible instead of silently mis-splitting.
+            serde_json::Value::String(id.as_str().to_string())
         }
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
             serde_json::Value::String(c.api_value().to_string())
@@ -930,21 +937,12 @@ mod tests {
         );
         assert!(
             !resolved.contains("2012_10_17") && !resolved.contains(r#""allow""#),
-            "DSL spelling must not reach AWS, got: {resolved}"
+            "non-canonical enum spelling must not reach IAM JSON, got: {resolved}"
         );
     }
 
-    /// aws#315 defensive fallback: the schema-typed AWS normalizer
-    /// (`api_canonicalize_recursive`) is what actually canonicalizes
-    /// `version` / `effect` before this serializer runs — see the
-    /// end-to-end regression in `normalizer.rs`. But if an
-    /// `EnumIdentifier` reaches the serializer un-canonicalized (a future
-    /// enum field not yet covered by the normalizer pass), the
-    /// `scalar_to_json` fallback must still emit the AWS wire form so AWS
-    /// does not reject the PUT with `MalformedPolicy`. Both the namespaced
-    /// and the bare-alias `EnumIdentifier` shapes are covered here.
     #[test]
-    fn resolve_iam_policy_attr_enum_identifier_fallback_is_aws_canonical() {
+    fn resolve_iam_policy_attr_canonicalizes_schema_typed_enum_identifier() {
         let mut policy = IndexMap::new();
         policy.insert(
             "version".to_string(),
@@ -955,7 +953,9 @@ mod tests {
         let mut stmt = IndexMap::new();
         stmt.insert(
             "effect".to_string(),
-            Value::Concrete(ConcreteValue::enum_identifier("allow")),
+            Value::Concrete(ConcreteValue::enum_identifier(
+                "aws.iam.PolicyDocument.Statement.Effect.allow",
+            )),
         );
         stmt.insert(
             "action".to_string(),
@@ -969,20 +969,24 @@ mod tests {
         );
 
         let r = make_resource(Some(Value::Concrete(ConcreteValue::Map(policy))));
-        let resolved = resolve_iam_policy_attr(&r, "policy").expect("map → JSON");
+        let resolved = resolve_iam_policy_attr(&r, "policy").expect("map -> JSON");
 
         assert!(
             resolved.contains(r#""Version":"2012-10-17""#),
-            "version must be AWS-canonical, got: {resolved}"
+            "version EnumIdentifier must canonicalize at schema-typed position, got: {resolved}"
         );
         assert!(
             resolved.contains(r#""Effect":"Allow""#),
-            "effect must be AWS-canonical, got: {resolved}"
+            "effect EnumIdentifier must canonicalize at schema-typed position, got: {resolved}"
         );
-        assert!(
-            !resolved.contains("2012_10_17") && !resolved.contains(r#""allow""#),
-            "DSL spelling must not reach AWS, got: {resolved}"
-        );
+    }
+
+    #[test]
+    fn scalar_to_json_raw_enum_identifier_passes_through_verbatim() {
+        let raw = "aws.iam.PolicyDocument.Version.2012_10_17";
+        let json = scalar_to_json(&Value::Concrete(ConcreteValue::enum_identifier(raw)));
+
+        assert_eq!(json, serde_json::Value::String(raw.to_string()));
     }
 
     /// Real aws#315 reproduction (root cause: carina#3060). At apply
@@ -1048,7 +1052,7 @@ mod tests {
         );
         assert!(
             !resolved.contains("2012_10_17") && !resolved.contains(r#""allow""#),
-            "DSL spelling must not reach AWS, got: {resolved}"
+            "non-canonical enum spelling must not reach IAM JSON, got: {resolved}"
         );
         // Constraint A regression: canonical_user Principal must not be
         // silently dropped by the schema-driven walk.

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -5,7 +5,6 @@ use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{
     ConcreteValue, DataSource, Directives, Resource, ResourceId, State, Value,
 };
-use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -77,12 +76,11 @@ impl AwsProvider {
             }
         };
 
-        // Get region (use Provider's region if not specified)
+        // Region is not part of the generated s3.Bucket schema today, so this
+        // optional hand-written override only supports plain AWS-format strings.
+        // Otherwise use the provider region.
         let region = match resource.get_attr("region") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => {
-                // Convert from aws.Region.ap_northeast_1 format to ap-northeast-1 format
-                convert_enum_value(s).to_string()
-            }
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.to_string(),
             _ => self.region.clone(),
         };
 

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use aws_sdk_s3::types::{BucketCannedAcl, Grant, Permission, Type as GranteeType};
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
-use carina_core::utils::convert_enum_value;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -166,10 +165,7 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let acl_str = match resource.get_attr("acl") {
-            // convert_enum_value normalizes namespaced/typed identifiers
-            // (`aws.s3.BucketAcl.Acl.public_read`) and snake-cased aliases
-            // (`public_read` ⇄ `public-read`) back to AWS canonical form.
-            Some(Value::Concrete(ConcreteValue::String(s))) => convert_enum_value(s).to_string(),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.to_string(),
             _ => {
                 return Err(
                     ProviderError::invalid_input("acl is required").for_resource(id.clone())

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -305,10 +305,10 @@ fn redrive_allow_policy_to_json_string(value: &Value) -> Option<String> {
     let permission = match map.get("redrive_permission") {
         Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
         Some(Value::Concrete(ConcreteValue::EnumIdentifier(s))) => {
-            // Strip any namespace prefix (e.g.
-            // aws.sqs.Queue.RedriveAllowPolicy.RedrivePermission.allowAll
-            // -> allowAll); the enum surface is the trailing segment.
-            s.rsplit('.').next().unwrap_or(s.as_str()).to_string()
+            // Raw EnumIdentifier at wire-out means the host did not
+            // canonicalize it; pass it through so AWS-side rejection is
+            // visible instead of silently mis-splitting.
+            s.as_str().to_string()
         }
         Some(Value::Concrete(ConcreteValue::CanonicalEnum(c))) => c.api_value().to_string(),
         _ => return None,
@@ -662,4 +662,45 @@ fn resource_tags_map(resource: &Resource) -> Option<HashMap<String, String>> {
         }
     }
     if out.is_empty() { None } else { Some(out) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn redrive_allow_policy_with_permission(permission: Value) -> Value {
+        let mut map = IndexMap::new();
+        map.insert("redrive_permission".to_string(), permission);
+        Value::Concrete(ConcreteValue::Map(map))
+    }
+
+    #[test]
+    fn redrive_allow_policy_serializes_canonical_enum_api_value() {
+        let mut map = IndexMap::new();
+        map.insert(
+            "redrive_permission".to_string(),
+            Value::Concrete(ConcreteValue::enum_identifier("allowAll")),
+        );
+        let schema =
+            carina_core::schema::Schema::flat(carina_aws_types::sqs_redrive_allow_policy());
+        let canonical = schema.canonicalize(Value::Concrete(ConcreteValue::Map(map)));
+
+        let json = redrive_allow_policy_to_json_string(&canonical).expect("redrive allow JSON");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["redrivePermission"].as_str(), Some("allowAll"));
+    }
+
+    #[test]
+    fn redrive_allow_policy_raw_enum_identifier_passes_through_verbatim() {
+        let raw = "aws.sqs.Queue.RedriveAllowPolicy.RedrivePermission.allowAll";
+        let value = redrive_allow_policy_with_permission(Value::Concrete(
+            ConcreteValue::enum_identifier(raw),
+        ));
+
+        let json = redrive_allow_policy_to_json_string(&value).expect("redrive allow JSON");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["redrivePermission"].as_str(), Some(raw));
+    }
 }

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 
 use indexmap::IndexMap;
 
+use carina_core::provider::ProviderNormalizer;
 use carina_core::resource::{ConcreteValue, Value};
 
-use crate::AwsProvider;
+use crate::{AwsNormalizer, AwsProvider};
 
 // --- extract_ec2_vpc_attributes tests ---
 
@@ -613,41 +614,39 @@ fn test_extract_ec2_subnet_attributes_map_public_ip_true() {
     );
 }
 
-#[test]
-fn test_subnet_availability_zone_dsl_to_aws_sdk() {
-    use carina_core::utils::convert_enum_value;
+#[tokio::test]
+async fn test_subnet_availability_zone_survives_normalize_desired() {
+    let mut resource =
+        carina_core::resource::Resource::with_provider("aws", "ec2.Subnet", "test-subnet", None);
+    resource.set_attr(
+        "availability_zone".to_string(),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
+    );
+    let mut resources = vec![resource];
 
-    // DSL namespaced form -> AWS hyphenated form that EC2 CreateSubnet expects.
-    let dsl_value = "aws.AvailabilityZone.ap_northeast_1a";
-    let aws_value = convert_enum_value(dsl_value).replace('_', "-");
-    assert_eq!(aws_value, "ap-northeast-1a");
+    AwsNormalizer.normalize_desired(&mut resources).await;
 
-    let dsl_value2 = "aws.AvailabilityZone.us_east_1b";
-    let aws_value2 = convert_enum_value(dsl_value2).replace('_', "-");
-    assert_eq!(aws_value2, "us-east-1b");
+    assert_eq!(
+        resources[0].get_attr("availability_zone"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1a".to_string()
+        )))
+    );
 }
 
 // --- Subnet DNS hostname_type enum conversion ---
 
 #[test]
-fn test_subnet_hostname_type_dsl_to_aws_sdk() {
+fn test_subnet_hostname_type_canonical_value_to_aws_sdk() {
     use aws_sdk_ec2::types::HostnameType;
-    use carina_core::utils::convert_enum_value;
 
-    // DSL uses underscores: aws.ec2.Subnet.HostnameType.ip_name
-    // convert_enum_value extracts the value, then underscore→hyphen for AWS SDK
-    let dsl_value = "aws.ec2.Subnet.HostnameType.ip_name";
-    let extracted = convert_enum_value(dsl_value);
-    assert_eq!(extracted, "ip_name");
-    let aws_value = extracted.replace('_', "-");
-    let hostname_type = HostnameType::from(aws_value.as_str());
+    // Core sends the provider the canonical API spelling.
+    let aws_value = "ip-name";
+    let hostname_type = HostnameType::from(aws_value);
     assert_eq!(hostname_type, HostnameType::IpName);
 
-    let dsl_value2 = "aws.ec2.Subnet.HostnameType.resource_name";
-    let extracted2 = convert_enum_value(dsl_value2);
-    assert_eq!(extracted2, "resource_name");
-    let aws_value2 = extracted2.replace('_', "-");
-    let hostname_type2 = HostnameType::from(aws_value2.as_str());
+    let aws_value2 = "resource-name";
+    let hostname_type2 = HostnameType::from(aws_value2);
     assert_eq!(hostname_type2, HostnameType::ResourceName);
 }
 
@@ -660,15 +659,11 @@ fn test_subnet_hostname_type_dsl_to_aws_sdk() {
 
 #[test]
 fn test_subnet_dns_options_fields_parsed_separately() {
-    use carina_core::utils::convert_enum_value;
-
     // Simulate the attributes map that would be passed to modify_subnet_attributes
     let mut fields = HashMap::new();
     fields.insert(
         "hostname_type".to_string(),
-        Value::Concrete(ConcreteValue::String(
-            "aws.ec2.Subnet.HostnameType.ip_name".to_string(),
-        )),
+        Value::Concrete(ConcreteValue::String("ip-name".to_string())),
     );
     fields.insert(
         "enable_resource_name_dns_a_record".to_string(),
@@ -681,8 +676,10 @@ fn test_subnet_dns_options_fields_parsed_separately() {
 
     // Each field should be independently extractable for separate API calls
     if let Some(Value::Concrete(ConcreteValue::String(ht))) = fields.get("hostname_type") {
-        let hostname_val = convert_enum_value(ht);
-        assert_eq!(hostname_val, "ip_name");
+        assert_eq!(
+            aws_sdk_ec2::types::HostnameType::from(ht.as_str()),
+            aws_sdk_ec2::types::HostnameType::IpName
+        );
     } else {
         panic!("hostname_type should be present and a String");
     }


### PR DESCRIPTION
## Summary

Provider-aws sweep PR of the carina-provider-aws#423 chain (design: carina-rs/carina#3436 → core: carina-rs/carina#3451). Bumps the carina pin to `1b95cdf2` and removes every dependence on the deleted schema-free extraction API — including the provider's own desired-side enum re-derivation, which turned out to be the deeper defect the wire-site bandaids were hiding.

## The deeper bug this surfaced

Post-carina#3438 the host sends canonical API spellings for every schema-known enum position. But `AwsNormalizer::normalize_desired` ran a two-pass enum re-derivation: Pass-1 re-namespaced host-canonical bare values into the DSL form, and Pass-2 (gated on `values: Some`) never rewrote **open enums** (`values: None`, e.g. AvailabilityZone ZoneName) back. Real-AWS repro on this branch before the fix:

```
Failed to create subnet: Value (aws.AvailabilityZone.ZoneName.ap_northeast_1a)
for parameter availabilityZone is invalid.
```

The deleted `convert_enum_value(az).replace('_', "-")` wire-site calls were bandaids compensating for exactly this round-trip defect. The root fix removes the desired-side re-derivation entirely — the host owns canonicalization. (Read/state-side `normalize_state_enums` is untouched.)

## Changes

- Pin bump `ad91ed00` → `1b95cdf2` in all 4 locations (`check-carina-pin.sh` green, ancestry verified).
- `normalizer.rs`: delete `resolve_enum_identifiers` / `api_canonicalize_recursive`; `normalize_desired` now only does Route53 DNS-name stripping.
- Wire-out sites use incoming canonical strings directly (subnet AZ + hostname_type, s3 bucket region, bucket_acl).
- `convert_protocol_value` keeps only the bare `all` → `-1` mapping (AWS-specific, sanctioned by the design doc).
- Read-normalize paths (`normalizer.rs` state pass, `iam/role.rs` policy serializer) migrate `extract_enum_value_with_values` (now `pub(crate)` in core) → still-pub schema-aware `canonicalize_enum_to_api`.
- Raw `EnumIdentifier` reaching wire-out JSON (iam `scalar_to_json`, sqs `redrive_permission`) serializes **verbatim**: an un-canonicalized identifier there is a schema desync, and AWS-side rejection is the visible failure surface — the local `rsplit('.')` mis-split fallbacks (broken by the #3438 shim removal anyway) are gone.

## Verify

- `cargo check --workspace --all-targets` / `cargo nextest run` (482) / clippy `-D warnings` / `cargo fmt --check` ✓
- `scripts/check-carina-pin.sh`, `check-examples.sh`, `check-string-enum-aliases.sh` ✓
- **Real AWS acceptance**: full suite 47/47 (one failure was a stale sibling awscc WASM predating the current WIT world — rebuilt, re-run green), `tag_deletion` multi-step 40/40 **including Test 9, the #423 reproduction**.

Review: 2-angle adversarial finder fan-out (which caught the normalizer regression before the suite did), 3 Codex implementation rounds.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
