### PR TITLE
Fix examples/ec2_subnet AvailabilityZone spelling to ZoneName-qualified form

### DIFF
--- a/carina-aws-types/src/common/availability_zone.rs
+++ b/carina-aws-types/src/common/availability_zone.rs
@@ -58,7 +58,7 @@ pub fn validate_availability_zone(az: &str) -> Result<(), String> {
 
 /// Availability zone type with validation (e.g., "us-east-1a")
 /// Accepts:
-/// - DSL format: aws.AvailabilityZone.us_east_1a
+/// - DSL format: aws.AvailabilityZone.ZoneName.us_east_1a
 /// - AWS string format: "us-east-1a"
 /// - Shorthand: us_east_1a
 pub fn availability_zone() -> AttributeType {

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -590,7 +590,7 @@ mod tests {
         assert!(
             carina_core::schema::Schema::flat(az_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
-                    "gcp.AvailabilityZone.us_east_1a".to_string()
+                    "gcp.AvailabilityZone.ZoneName.us_east_1a".to_string()
                 )))
                 .is_err()
         );

--- a/carina-provider-aws/src/schemas/config.rs
+++ b/carina-provider-aws/src/schemas/config.rs
@@ -94,7 +94,7 @@ pub fn aws_validators() -> HashMap<String, CustomValidatorFn> {
             iam_policy_arn => |s: &str| validate_iam_arn(s, "policy/"),
             kms_key_arn => |s: &str| validate_kms_key_id(s),
             // The availability_zone validator must accept both the DSL
-            // namespaced form (`aws.AvailabilityZone.ap_northeast_1a`) and the
+            // namespaced form (`aws.AvailabilityZone.ZoneName.ap_northeast_1a`) and the
             // raw AWS string format (`"ap-northeast-1a"`). The single-arg
             // `validate_availability_zone` from carina-aws-types only knows
             // the raw form, so we wrap it: strip the namespace prefix if

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -10,7 +10,7 @@ use aws_sdk_ec2::types::{AttributeBooleanValue, HostnameType};
 
 // `read_ec2_subnet` must store `availability_zone` as the AWS canonical
 // form (`"ap-northeast-1a"`). Rewriting it to a DSL-prefixed identifier
-// (`"aws.AvailabilityZone.ap_northeast_1a"`) yields a phantom
+// (`"aws.AvailabilityZone.ZoneName.ap_northeast_1a"`) yields a phantom
 // `forces replacement` diff on every post-apply plan: the schema's
 // `CustomEnum.to_dsl` folds both sides to the same identifier when
 // rendered, so the printed values match while the underlying strings

--- a/examples/ec2_subnet/main.crn
+++ b/examples/ec2_subnet/main.crn
@@ -17,7 +17,7 @@ let vpc = aws.ec2.Vpc {
 aws.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 
   tags = {
     Environment = 'example'


### PR DESCRIPTION
Fixes the 3-part AvailabilityZone spelling in the ec2_subnet example to the ZoneName-qualified form that core enum validation accepts, plus doc-comment/test-fixture alignment. Verified: carina-aws-types tests 124/124, check-examples.sh, fmt.

The check-examples.sh real-validation gate suggested in the issue is a separate CI enhancement (needs the carina binary in this repo's CI) and is intentionally not bundled here.

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)