### PR TITLE
codegen: emit only canonical wire values in enum values lists

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1161,39 +1161,17 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
 
     // Generate enum constants.
     //
-    // The constant lists every spelling the validator must accept: the
-    // canonical AWS values, any explicit aliases, and the auto-derived
-    // snake_case DSL aliases (D7). Listing both forms keeps callers that
-    // walk `enum_valid_values()` (e.g. legacy reflection paths) consistent
-    // with what `to_dsl` already accepts at runtime.
+    // The constant lists only canonical AWS wire values. DSL spellings live
+    // in `dsl_aliases` / `enum_alias_entries`; mixing aliases into this list
+    // makes the host treat them as already API-canonical.
     for (prop_name, enum_info) in &all_enums {
         let const_name = format!("VALID_{}", prop_name.to_snake_case().to_uppercase());
-
-        let mut all_values: Vec<String> = enum_info
+        let values_str = enum_info
             .values
             .iter()
             .map(|v| format!("\"{}\"", v))
-            .collect();
-        let snake = prop_name.to_snake_case();
-        if let Some(aliases) = enum_alias_map.get(snake.as_str()) {
-            for (_, alias) in aliases {
-                let formatted = format!("\"{}\"", alias);
-                if !all_values.contains(&formatted) {
-                    all_values.push(formatted);
-                }
-            }
-        }
-        // Auto-derived snake_case DSL aliases per D7.
-        for value in &enum_info.values {
-            let dsl_form = dsl_enum_value(value);
-            if dsl_form != *value {
-                let formatted = format!("\"{}\"", dsl_form);
-                if !all_values.contains(&formatted) {
-                    all_values.push(formatted);
-                }
-            }
-        }
-        let values_str = all_values.join(", ");
+            .collect::<Vec<_>>()
+            .join(", ");
         code.push_str(&format!(
             "const {}: &[&str] = &[{}];\n\n",
             const_name, values_str
@@ -4248,10 +4226,7 @@ fn known_string_type_overrides() -> &'static HashMap<&'static str, &'static str>
 fn known_enum_overrides() -> &'static HashMap<&'static str, Vec<&'static str>> {
     static OVERRIDES: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
         let mut m = HashMap::new();
-        m.insert(
-            "IpProtocol",
-            vec!["tcp", "udp", "icmp", "icmpv6", "-1", "all"],
-        );
+        m.insert("IpProtocol", vec!["tcp", "udp", "icmp", "icmpv6", "-1"]);
         m.insert("HostnameType", vec!["ip-name", "resource-name"]);
         m
     });
@@ -4933,11 +4908,18 @@ mod tests {
 
         let generated = generate_resource(&resource, &model).expect("failed to generate resource");
 
-        // The validator's allow-list (VALID_TYPE) must include both API
-        // and DSL spellings so reflection paths see both forms.
+        // The validator's allow-list (VALID_TYPE) must stay API-canonical;
+        // DSL spellings are carried by dsl_aliases / enum_alias_entries.
+        let valid_type_line = generated
+            .lines()
+            .find(|line| line.starts_with("const VALID_TYPE:"))
+            .expect("VALID_TYPE constant should be generated");
         assert!(
-            generated.contains("\"A\"") && generated.contains("\"a\""),
-            "VALID_TYPE should list both API and DSL spellings: {generated}"
+            valid_type_line.contains("\"A\"")
+                && valid_type_line.contains("\"CNAME\"")
+                && !valid_type_line.contains("\"a\"")
+                && !valid_type_line.contains("\"cname\""),
+            "VALID_TYPE should list only API spellings: {generated}"
         );
         // The StringEnum's `dsl_aliases` must contain `(api, dsl)` pairs
         // as data so the mapping survives the WASM-component boundary.

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -119,7 +119,7 @@ impl AwsProvider {
         };
 
         let protocol = match resource.get_attr("ip_protocol") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => convert_protocol_value(s),
+            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => "-1".to_string(),
         };
 
@@ -360,48 +360,9 @@ impl AwsProvider {
     }
 }
 
-/// Convert protocol value to AWS format.
-///
-/// Enum-typed protocol values arrive as AWS-canonical strings from core.
-/// Keep the legacy bare `all` alias mapping here because AWS expects `-1`.
-pub(crate) fn convert_protocol_value(value: &str) -> String {
-    if value == "all" {
-        "-1".to_string()
-    } else {
-        value.to_string()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // --- convert_protocol_value tests ---
-
-    #[test]
-    fn test_convert_protocol_value_tcp() {
-        assert_eq!(convert_protocol_value("tcp"), "tcp");
-    }
-
-    #[test]
-    fn test_convert_protocol_value_udp() {
-        assert_eq!(convert_protocol_value("udp"), "udp");
-    }
-
-    #[test]
-    fn test_convert_protocol_value_all_keyword() {
-        assert_eq!(convert_protocol_value("all"), "-1");
-    }
-
-    #[test]
-    fn test_convert_protocol_value_minus_one() {
-        assert_eq!(convert_protocol_value("-1"), "-1");
-    }
-
-    #[test]
-    fn test_convert_protocol_value_canonical_tcp() {
-        assert_eq!(convert_protocol_value("tcp"), "tcp");
-    }
 
     // --- Route composite identifier parsing tests ---
 

--- a/carina-provider-aws/src/schemas/generated/acm/certificate.rs
+++ b/carina-provider-aws/src/schemas/generated/acm/certificate.rs
@@ -9,10 +9,9 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
-const VALID_CERTIFICATE_TRANSPARENCY_LOGGING_PREFERENCE: &[&str] =
-    &["DISABLED", "ENABLED", "disabled", "enabled"];
+const VALID_CERTIFICATE_TRANSPARENCY_LOGGING_PREFERENCE: &[&str] = &["DISABLED", "ENABLED"];
 
-const VALID_EXPORT: &[&str] = &["DISABLED", "ENABLED", "disabled", "enabled"];
+const VALID_EXPORT: &[&str] = &["DISABLED", "ENABLED"];
 
 const VALID_KEY_ALGORITHM: &[&str] = &[
     "EC_prime256v1",
@@ -22,26 +21,15 @@ const VALID_KEY_ALGORITHM: &[&str] = &[
     "RSA_2048",
     "RSA_3072",
     "RSA_4096",
-    "ec_prime256v1",
-    "ec_secp384r1",
-    "ec_secp521r1",
-    "rsa_1024",
-    "rsa_2048",
-    "rsa_3072",
-    "rsa_4096",
 ];
 
-const VALID_RENEWAL_ELIGIBILITY: &[&str] = &["ELIGIBLE", "INELIGIBLE", "eligible", "ineligible"];
+const VALID_RENEWAL_ELIGIBILITY: &[&str] = &["ELIGIBLE", "INELIGIBLE"];
 
 const VALID_RENEWAL_STATUS: &[&str] = &[
     "FAILED",
     "PENDING_AUTO_RENEWAL",
     "PENDING_VALIDATION",
     "SUCCESS",
-    "failed",
-    "pending_auto_renewal",
-    "pending_validation",
-    "success",
 ];
 
 const VALID_RENEWAL_STATUS_REASON: &[&str] = &[
@@ -62,23 +50,6 @@ const VALID_RENEWAL_STATUS_REASON: &[&str] = &[
     "PCA_REQUEST_FAILED",
     "PCA_RESOURCE_NOT_FOUND",
     "SLR_NOT_FOUND",
-    "additional_verification_required",
-    "caa_error",
-    "domain_not_allowed",
-    "domain_validation_denied",
-    "invalid_public_domain",
-    "no_available_contacts",
-    "other",
-    "pca_access_denied",
-    "pca_invalid_args",
-    "pca_invalid_arn",
-    "pca_invalid_duration",
-    "pca_invalid_state",
-    "pca_limit_exceeded",
-    "pca_name_constraints_validation",
-    "pca_request_failed",
-    "pca_resource_not_found",
-    "slr_not_found",
 ];
 
 const VALID_STATUS: &[&str] = &[
@@ -89,27 +60,13 @@ const VALID_STATUS: &[&str] = &[
     "PENDING_VALIDATION",
     "REVOKED",
     "VALIDATION_TIMED_OUT",
-    "expired",
-    "failed",
-    "inactive",
-    "issued",
-    "pending_validation",
-    "revoked",
-    "validation_timed_out",
 ];
 
-const VALID_TYPE: &[&str] = &["CNAME", "cname"];
+const VALID_TYPE: &[&str] = &["CNAME"];
 
-const VALID_VALIDATION_METHOD: &[&str] = &["DNS", "EMAIL", "HTTP", "dns", "email", "http"];
+const VALID_VALIDATION_METHOD: &[&str] = &["DNS", "EMAIL", "HTTP"];
 
-const VALID_VALIDATION_STATUS: &[&str] = &[
-    "FAILED",
-    "PENDING_VALIDATION",
-    "SUCCESS",
-    "failed",
-    "pending_validation",
-    "success",
-];
+const VALID_VALIDATION_STATUS: &[&str] = &["FAILED", "PENDING_VALIDATION", "SUCCESS"];
 
 /// Returns the schema config for acm.Certificate (Smithy: com.amazonaws.acm)
 pub fn acm_certificate_config() -> AwsSchemaConfig {

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -9,13 +9,7 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
-const VALID_LOG_DESTINATION_TYPE: &[&str] = &[
-    "cloud-watch-logs",
-    "kinesis-data-firehose",
-    "s3",
-    "cloud_watch_logs",
-    "kinesis_data_firehose",
-];
+const VALID_LOG_DESTINATION_TYPE: &[&str] = &["cloud-watch-logs", "kinesis-data-firehose", "s3"];
 
 const VALID_RESOURCE_TYPE: &[&str] = &[
     "NetworkInterface",
@@ -24,15 +18,9 @@ const VALID_RESOURCE_TYPE: &[&str] = &[
     "TransitGateway",
     "TransitGatewayAttachment",
     "VPC",
-    "network_interface",
-    "regional_nat_gateway",
-    "subnet",
-    "transit_gateway",
-    "transit_gateway_attachment",
-    "vpc",
 ];
 
-const VALID_TRAFFIC_TYPE: &[&str] = &["ACCEPT", "ALL", "REJECT", "accept", "all", "reject"];
+const VALID_TRAFFIC_TYPE: &[&str] = &["ACCEPT", "ALL", "REJECT"];
 
 /// Returns the schema config for ec2.FlowLog (Smithy: com.amazonaws.ec2)
 pub fn ec2_flow_log_config() -> AwsSchemaConfig {

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
-const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all", "_1"];
+const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1"];
 
 /// Returns the schema config for ec2.SecurityGroupEgress (Smithy: com.amazonaws.ec2)
 pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
@@ -71,7 +71,6 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                             "icmp".to_string(),
                             "icmpv6".to_string(),
                             "-1".to_string(),
-                            "all".to_string(),
                         ]),
                         vec![
                             ("-1".to_string(), "all".to_string()),
@@ -79,7 +78,6 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                             ("udp".to_string(), "udp".to_string()),
                             ("icmp".to_string(), "icmp".to_string()),
                             ("icmpv6".to_string(), "icmpv6".to_string()),
-                            ("all".to_string(), "all".to_string()),
                         ],
                         None,
                         None,

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
-const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all", "_1"];
+const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1"];
 
 /// Returns the schema config for ec2.SecurityGroupIngress (Smithy: com.amazonaws.ec2)
 pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
@@ -59,8 +59,8 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         .attribute(
             AttributeSchema::new("ip_protocol", AttributeType::enum_(
     carina_core::schema::enum_identity("IpProtocol", Some("aws.ec2.SecurityGroupIngress")),
-    Some(vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string(), "all".to_string()]),
-    vec![("-1".to_string(), "all".to_string()), ("tcp".to_string(), "tcp".to_string()), ("udp".to_string(), "udp".to_string()), ("icmp".to_string(), "icmp".to_string()), ("icmpv6".to_string(), "icmpv6".to_string()), ("all".to_string(), "all".to_string())],
+    Some(vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string()]),
+    vec![("-1".to_string(), "all".to_string()), ("tcp".to_string(), "tcp".to_string()), ("udp".to_string(), "udp".to_string()), ("icmp".to_string(), "icmp".to_string()), ("icmpv6".to_string(), "icmpv6".to_string())],
     None,
     None,
 ))

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -9,7 +9,7 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
-const VALID_HOSTNAME_TYPE: &[&str] = &["ip-name", "resource-name", "ip_name", "resource_name"];
+const VALID_HOSTNAME_TYPE: &[&str] = &["ip-name", "resource-name"];
 
 /// Returns the schema config for ec2.Subnet (Smithy: com.amazonaws.ec2)
 pub fn ec2_subnet_config() -> AwsSchemaConfig {

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -15,11 +15,6 @@ const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
     "Interface",
     "Resource",
     "ServiceNetwork",
-    "gateway",
-    "gateway_load_balancer",
-    "interface",
-    "resource",
-    "service_network",
 ];
 
 /// Returns the schema config for ec2.VpcEndpoint (Smithy: com.amazonaws.ec2)

--- a/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpn_gateway.rs
@@ -9,7 +9,7 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-const VALID_TYPE: &[&str] = &["ipsec.1", "ipsec_1"];
+const VALID_TYPE: &[&str] = &["ipsec.1"];
 
 /// Returns the schema config for ec2.VpnGateway (Smithy: com.amazonaws.ec2)
 pub fn ec2_vpn_gateway_config() -> AwsSchemaConfig {

--- a/carina-provider-aws/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-aws/src/schemas/generated/logs/log_group.rs
@@ -9,14 +9,7 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-const VALID_LOG_GROUP_CLASS: &[&str] = &[
-    "DELIVERY",
-    "INFREQUENT_ACCESS",
-    "STANDARD",
-    "delivery",
-    "infrequent_access",
-    "standard",
-];
+const VALID_LOG_GROUP_CLASS: &[&str] = &["DELIVERY", "INFREQUENT_ACCESS", "STANDARD"];
 
 /// Returns the schema config for logs.LogGroup (Smithy: com.amazonaws.cloudwatchlogs)
 pub fn logs_log_group_config() -> AwsSchemaConfig {

--- a/carina-provider-aws/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/account.rs
@@ -9,18 +9,11 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
-const VALID_IAM_USER_ACCESS_TO_BILLING: &[&str] = &["ALLOW", "DENY", "allow", "deny"];
+const VALID_IAM_USER_ACCESS_TO_BILLING: &[&str] = &["ALLOW", "DENY"];
 
-const VALID_JOINED_METHOD: &[&str] = &["CREATED", "INVITED", "created", "invited"];
+const VALID_JOINED_METHOD: &[&str] = &["CREATED", "INVITED"];
 
-const VALID_STATUS: &[&str] = &[
-    "ACTIVE",
-    "PENDING_CLOSURE",
-    "SUSPENDED",
-    "active",
-    "pending_closure",
-    "suspended",
-];
+const VALID_STATUS: &[&str] = &["ACTIVE", "PENDING_CLOSURE", "SUSPENDED"];
 
 pub fn arn() -> AttributeType {
     AttributeType::refined_string(

--- a/carina-provider-aws/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-aws/src/schemas/generated/organizations/organization.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
-const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING", "all", "consolidated_billing"];
+const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING"];
 
 pub fn arn() -> AttributeType {
     AttributeType::refined_string(

--- a/carina-provider-aws/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-aws/src/schemas/generated/route53/record_set.rs
@@ -9,8 +9,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, Struct
 
 const VALID_TYPE: &[&str] = &[
     "A", "AAAA", "CAA", "CNAME", "DS", "HTTPS", "MX", "NAPTR", "NS", "PTR", "SOA", "SPF", "SRV",
-    "SSHFP", "SVCB", "TLSA", "TXT", "a", "aaaa", "caa", "cname", "ds", "https", "mx", "naptr",
-    "ns", "ptr", "soa", "spf", "srv", "sshfp", "svcb", "tlsa", "txt",
+    "SSHFP", "SVCB", "TLSA", "TXT",
 ];
 
 /// Returns the schema config for route53.RecordSet (Smithy: com.amazonaws.route53)

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -9,7 +9,7 @@ use super::tags_type;
 use super::validate_tags_map;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-const VALID_BUCKET_NAMESPACE: &[&str] = &["account-regional", "global", "account_regional"];
+const VALID_BUCKET_NAMESPACE: &[&str] = &["account-regional", "global"];
 
 /// Returns the schema config for s3.Bucket (Smithy: com.amazonaws.s3)
 pub fn s3_bucket_config() -> AwsSchemaConfig {

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_acl.rs
@@ -12,9 +12,6 @@ const VALID_ACL: &[&str] = &[
     "private",
     "public-read",
     "public-read-write",
-    "authenticated_read",
-    "public_read",
-    "public_read_write",
 ];
 
 /// Returns the schema config for s3.BucketAcl (Smithy: com.amazonaws.s3)

--- a/carina-provider-aws/src/schemas/mod.rs
+++ b/carina-provider-aws/src/schemas/mod.rs
@@ -216,4 +216,48 @@ mod tests {
             Some("^vpc-[0-9a-f]{8,}$"),
         );
     }
+
+    #[test]
+    fn security_group_ip_protocol_values_are_canonical_and_aliases_reverse() {
+        for resource_type in ["ec2.SecurityGroupIngress", "ec2.SecurityGroupEgress"] {
+            let values = super::generated::get_enum_valid_values(resource_type, "ip_protocol")
+                .unwrap_or_else(|| panic!("{resource_type}.ip_protocol values should exist"));
+
+            assert!(
+                values.contains(&"tcp")
+                    && values.contains(&"udp")
+                    && values.contains(&"icmp")
+                    && values.contains(&"icmpv6")
+                    && values.contains(&"-1"),
+                "{resource_type}.ip_protocol should include canonical wire values: {values:?}"
+            );
+            assert!(
+                !values.contains(&"all") && !values.contains(&"_1"),
+                "{resource_type}.ip_protocol values must not include DSL aliases: {values:?}"
+            );
+
+            assert_eq!(
+                super::generated::get_enum_alias_reverse(resource_type, "ip_protocol", "all"),
+                Some("-1")
+            );
+            assert_eq!(
+                super::generated::get_enum_alias_reverse(resource_type, "ip_protocol", "_1"),
+                Some("-1")
+            );
+
+            let aliases = super::generated::build_enum_aliases_map();
+            let ip_protocol_aliases = aliases
+                .get(resource_type)
+                .and_then(|attrs| attrs.get("ip_protocol"))
+                .unwrap_or_else(|| panic!("{resource_type}.ip_protocol aliases should exist"));
+            assert_eq!(
+                ip_protocol_aliases.get("all").map(String::as_str),
+                Some("-1")
+            );
+            assert_eq!(
+                ip_protocol_aliases.get("_1").map(String::as_str),
+                Some("-1")
+            );
+        }
+    }
 }

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -1572,12 +1572,10 @@ fn test_organizations_account_schema_attributes() {
     assert!(config.has_tags);
 }
 
-// --- ip_protocol enum "all" variant tests (issue #1428) ---
+// --- ip_protocol enum canonical values and aliases ---
 
 #[test]
-fn test_security_group_egress_schema_includes_all_variant() {
-    // The "all" value (alias for "-1") must be included in the enum values
-    // so it is accepted even when to_dsl is lost during protocol serialization.
+fn test_security_group_egress_schema_keeps_all_as_alias_only() {
     let config =
         crate::schemas::generated::ec2::security_group_egress::ec2_security_group_egress_config();
     let ip_protocol = config
@@ -1591,9 +1589,17 @@ fn test_security_group_egress_schema_includes_all_variant() {
     } = config.schema.shape_of(&ip_protocol.attr_type)
     {
         assert!(
-            values.contains(&"all".to_string()),
-            "enum values must include 'all': {:?}",
+            values.contains(&"-1".to_string()) && !values.contains(&"all".to_string()),
+            "enum values must include '-1' and exclude alias 'all': {:?}",
             values
+        );
+        assert_eq!(
+            crate::schemas::generated::get_enum_alias_reverse(
+                "ec2.SecurityGroupEgress",
+                "ip_protocol",
+                "all"
+            ),
+            Some("-1")
         );
     } else {
         panic!("ip_protocol should be enum");
@@ -1601,7 +1607,7 @@ fn test_security_group_egress_schema_includes_all_variant() {
 }
 
 #[test]
-fn test_security_group_ingress_schema_includes_all_variant() {
+fn test_security_group_ingress_schema_keeps_all_as_alias_only() {
     let config =
         crate::schemas::generated::ec2::security_group_ingress::ec2_security_group_ingress_config();
     let ip_protocol = config
@@ -1615,9 +1621,17 @@ fn test_security_group_ingress_schema_includes_all_variant() {
     } = config.schema.shape_of(&ip_protocol.attr_type)
     {
         assert!(
-            values.contains(&"all".to_string()),
-            "enum values must include 'all': {:?}",
+            values.contains(&"-1".to_string()) && !values.contains(&"all".to_string()),
+            "enum values must include '-1' and exclude alias 'all': {:?}",
             values
+        );
+        assert_eq!(
+            crate::schemas::generated::get_enum_alias_reverse(
+                "ec2.SecurityGroupIngress",
+                "ip_protocol",
+                "all"
+            ),
+            Some("-1")
         );
     } else {
         panic!("ip_protocol should be enum");


### PR DESCRIPTION
## Summary

Fixes #427. The codegen mixed DSL alias spellings into enum `values` lists; because `all` was a member of `values`, core treated a quoted `'all'` as already API-canonical and shipped it to the provider, which compensated with a hand-written `all`→`-1` carve-out.

## Changes

- `known_enum_overrides` IpProtocol → wire spellings only; `dsl_aliases` still map `all`/`_1` → `-1`.
- `VALID_*` emission drops alias/snake spellings repo-wide. The constants feed `get_enum_valid_values`, a reflection table with **zero production consumers** (verified by grep), so this is shape-only. Same-class contamination removed in ACM, EC2, Logs, Organizations, Route53, S3 generated schemas.
- `convert_protocol_value` deleted — the host now canonicalizes `all` → `-1` because the values list no longer claims `all` is canonical.
- Schemas regenerated with the real codegen run (`generate-schemas-smithy.sh`, reproducible — regen after the hand-verified edits produced an identical tree); docs regenerated (no diff).

## Verify

- `cargo check` / `nextest` 478/478 / clippy `-D warnings` / fmt ✓
- `check-carina-pin.sh`, `check-examples.sh`, `check-string-enum-aliases.sh` ✓
- **Real AWS acceptance: all 9 `ec2_security_group*` tests pass, including the `ip_protocol = all` fixtures** (apply → plan-verify → destroy).

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)