### PR TITLE
Remove read-state enum re-derivation; migrate off extract_enum_value

### DIFF
--- a/carina-aws-types/src/common/availability_zone.rs
+++ b/carina-aws-types/src/common/availability_zone.rs
@@ -1,6 +1,6 @@
 use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeType, DslTransform, legacy_validator};
-use carina_core::utils::{extract_enum_value, validate_enum_namespace};
+use carina_core::utils::validate_enum_namespace;
 
 use super::provider_bare_type;
 
@@ -56,6 +56,13 @@ pub fn validate_availability_zone(az: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn strip_availability_zone_prefix(value: &str) -> &str {
+    value
+        .strip_prefix("aws.AvailabilityZone.ZoneName.")
+        .or_else(|| value.strip_prefix("ZoneName."))
+        .unwrap_or(value)
+}
+
 /// Availability zone type with validation (e.g., "us-east-1a")
 /// Accepts:
 /// - DSL format: aws.AvailabilityZone.ZoneName.us_east_1a
@@ -71,7 +78,7 @@ pub fn availability_zone() -> AttributeType {
                 let id = provider_bare_type(&["AvailabilityZone"], "ZoneName");
                 validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
-                let extracted = extract_enum_value(s);
+                let extracted = strip_availability_zone_prefix(s);
                 let normalized = extracted.replace('_', "-");
                 validate_availability_zone(&normalized)
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))

--- a/carina-aws-types/src/common/region.rs
+++ b/carina-aws-types/src/common/region.rs
@@ -1,6 +1,6 @@
 use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeType, CompletionValue, DslTransform, legacy_validator};
-use carina_core::utils::{extract_enum_value, validate_enum_namespace};
+use carina_core::utils::validate_enum_namespace;
 
 use super::provider_bare_type;
 
@@ -72,6 +72,13 @@ pub fn valid_regions_display() -> String {
         .join(", ")
 }
 
+fn strip_region_prefix(value: &str) -> &str {
+    value
+        .strip_prefix("aws.Region.")
+        .or_else(|| value.strip_prefix("Region."))
+        .unwrap_or(value)
+}
+
 /// Region API spelling -> DSL spelling pairs for the carina-core /
 /// carina-provider-protocol `StringEnum.dsl_aliases` field.
 ///
@@ -121,7 +128,7 @@ pub fn aws_region() -> AttributeType {
                 validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
                 // Normalize the input to AWS format (hyphens)
-                let normalized = extract_enum_value(s).replace('_', "-");
+                let normalized = strip_region_prefix(s).replace('_', "-");
                 if is_valid_region(&normalized) {
                     Ok(())
                 } else {

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -573,6 +573,18 @@ mod tests {
     }
 
     #[test]
+    fn az_accepts_kind_shorthand_format() {
+        let az_type = availability_zone();
+        assert!(
+            carina_core::schema::Schema::flat(az_type.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "ZoneName.us_east_1a".to_string()
+                )))
+                .is_ok()
+        );
+    }
+
+    #[test]
     fn az_rejects_invalid_az() {
         let az_type = availability_zone();
         assert!(
@@ -1324,6 +1336,18 @@ mod tests {
             carina_core::schema::Schema::flat(region_type.clone())
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "Region.ap_northeast_1".to_string()
+                )))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn region_accepts_bare_dsl_value() {
+        let region_type = aws_region();
+        assert!(
+            carina_core::schema::Schema::flat(region_type.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "ap_northeast_1".to_string()
                 )))
                 .is_ok()
         );

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -2199,8 +2199,6 @@ fn generate_provider_code(
          use carina_core::resource::{\n\
          \x20   ConcreteValue, DataSource, Resource, ResourceId, State, Value,\n\
          };\n\
-         #[allow(unused_imports)]\n\
-         use carina_core::utils::extract_enum_value;\n\n\
          use crate::AwsProvider;\n\
          use crate::error_helpers::api_error_with_meta;\n\n",
     );
@@ -2550,10 +2548,10 @@ fn generate_provider_code(
                     ));
                     code.push_str("\x20           let normalized = match value {\n");
                     code.push_str(
-                        "\x20               Value::Concrete(ConcreteValue::String(val)) => extract_enum_value(val),\n",
+                        "\x20               Value::Concrete(ConcreteValue::String(val)) => val.clone(),\n",
                     );
                     code.push_str(
-                        "\x20               Value::Concrete(ConcreteValue::EnumIdentifier(val)) => extract_enum_value(val.as_str()),\n",
+                        "\x20               Value::Concrete(ConcreteValue::EnumIdentifier(val)) => val.as_str().to_string(),\n",
                     );
                     code.push_str(
                         "\x20               Value::Concrete(ConcreteValue::CanonicalEnum(val)) => val.api_value().to_string(),\n",

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use indexmap::IndexMap;
 
 use carina_core::provider::{self, BoxFuture, ProviderNormalizer, SavedAttrs, ready_noop};
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 
 /// Schema extension for the AWS provider.
@@ -49,77 +49,10 @@ impl ProviderNormalizer for AwsNormalizer {
     }
 }
 
-/// Normalize enum values in read-returned state attributes to namespaced DSL format.
-///
-/// Read methods return plain values like `"Enabled"` from AWS APIs.
-/// This converts them to namespaced format like `aws.s3.Bucket.VersioningStatus.Enabled`
-/// to match the resolved DSL values.
-pub(crate) fn normalize_state_enums(resource_type: &str, attributes: &mut HashMap<String, Value>) {
-    let configs = crate::schemas::generated::configs();
-    let config = configs
-        .iter()
-        .find(|c| c.schema.resource_type == resource_type);
-    let config = match config {
-        Some(c) => c,
-        None => return,
-    };
-
-    let mut resolved = HashMap::new();
-    for (key, value) in attributes.iter() {
-        if let Some(attr_schema) = config.schema.attributes.get(key.as_str()) {
-            if let Some(parts @ (_, enum_vals, _, _, _)) = attr_schema.attr_type.enum_parts() {
-                let check = |s: &str| {
-                    enum_vals.is_some_and(|vals| vals.iter().any(|v| v.eq_ignore_ascii_case(s)))
-                };
-                if let Some(normalized) =
-                    carina_core::utils::normalize_state_enum_value(value, &parts, Some(&check))
-                {
-                    resolved.insert(key.clone(), normalized);
-                }
-            }
-            // Normalize enum fields within struct (Map) values.
-            if let carina_core::schema::Shape::Struct { .. } =
-                config.schema.shape_of(&attr_schema.attr_type)
-                && let Value::Concrete(ConcreteValue::Map(map_fields)) = value
-            {
-                let mut budget = carina_core::schema::ShapeWalkBudget::new(64);
-                let Some(fields) = config
-                    .schema
-                    .struct_fields_with_budget(&attr_schema.attr_type, &mut budget)
-                else {
-                    continue;
-                };
-                let mut normalized_map = map_fields.clone();
-                for field in fields {
-                    if let Some(parts) = field.field_type.enum_parts()
-                        && let Some(field_value) = map_fields.get(&field.name)
-                    {
-                        // Struct field state normalization: bare values only.
-                        if let Some(normalized) =
-                            carina_core::utils::resolve_enum_value(field_value, &parts)
-                        {
-                            normalized_map.insert(field.name.clone(), normalized);
-                        }
-                    }
-                }
-                if normalized_map != *map_fields {
-                    resolved.insert(
-                        key.clone(),
-                        Value::Concrete(ConcreteValue::Map(normalized_map)),
-                    );
-                }
-            }
-        }
-    }
-
-    for (key, value) in resolved {
-        attributes.insert(key, value);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use carina_core::resource::ConcreteValue;
 
     #[tokio::test]
     async fn normalize_desired_does_not_mutate_enum_typed_attributes() {
@@ -177,118 +110,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_normalize_state_enums_with_to_dsl() {
-        let mut attributes = HashMap::from([(
-            "ip_protocol".to_string(),
-            Value::Concrete(ConcreteValue::String("-1".to_string())),
-        )]);
-        normalize_state_enums("ec2.SecurityGroupIngress", &mut attributes);
-        assert_eq!(
-            attributes.get("ip_protocol"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.ec2.SecurityGroupIngress.IpProtocol.all".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_normalize_state_enums() {
-        let mut attributes = HashMap::from([
-            (
-                "bucket".to_string(),
-                Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
-            ),
-            (
-                "object_ownership".to_string(),
-                Value::Concrete(ConcreteValue::String("BucketOwnerEnforced".to_string())),
-            ),
-        ]);
-        normalize_state_enums("s3.BucketOwnershipControls", &mut attributes);
-        assert_eq!(
-            attributes.get("object_ownership"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced".to_string()
-            )))
-        );
-        assert_eq!(
-            attributes.get("bucket"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "my-bucket".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_normalize_state_enums_bucket_versioning() {
-        let mut attributes = HashMap::from([
-            (
-                "bucket".to_string(),
-                Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
-            ),
-            (
-                "status".to_string(),
-                Value::Concrete(ConcreteValue::String("Enabled".to_string())),
-            ),
-        ]);
-        normalize_state_enums("s3.BucketVersioning", &mut attributes);
-        assert_eq!(
-            attributes.get("status"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.s3.BucketVersioning.VersioningStatus.enabled".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_normalize_state_enums_already_namespaced() {
-        let mut attributes = HashMap::from([(
-            "status".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string(),
-            )),
-        )]);
-        normalize_state_enums("s3.BucketVersioning", &mut attributes);
-        assert_eq!(
-            attributes.get("status"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.s3.BucketVersioning.VersioningStatus.Enabled".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_normalize_state_enums_ec2_vpc_tenancy() {
-        let mut attributes = HashMap::from([(
-            "instance_tenancy".to_string(),
-            Value::Concrete(ConcreteValue::String("default".to_string())),
-        )]);
-        normalize_state_enums("ec2.Vpc", &mut attributes);
-        assert_eq!(
-            attributes.get("instance_tenancy"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.ec2.Vpc.InstanceTenancy.default".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_normalize_state_enums_ec2_security_group_egress() {
-        let mut attributes = HashMap::from([(
-            "ip_protocol".to_string(),
-            Value::Concrete(ConcreteValue::String("-1".to_string())),
-        )]);
-        normalize_state_enums("ec2.SecurityGroupEgress", &mut attributes);
-        assert_eq!(
-            attributes.get("ip_protocol"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.ec2.SecurityGroupEgress.IpProtocol.all".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_normalize_state_enums_struct_field_enum() {
+    #[tokio::test]
+    async fn normalize_state_keeps_raw_api_enum_spellings() {
         let mut inner = IndexMap::new();
         inner.insert(
             "hostname_type".to_string(),
@@ -298,18 +121,27 @@ mod tests {
             "enable_resource_name_dns_a_record".to_string(),
             Value::Concrete(ConcreteValue::Bool(true)),
         );
-        let mut attributes = HashMap::from([(
+        let attributes = HashMap::from([(
             "private_dns_name_options_on_launch".to_string(),
             Value::Concrete(ConcreteValue::Map(inner)),
         )]);
-        normalize_state_enums("ec2.Subnet", &mut attributes);
+        let id = Resource::with_provider("aws", "ec2.Subnet", "test-subnet", None).id;
+        let mut states = HashMap::from([(id.clone(), State::existing(id, attributes))]);
+
+        AwsNormalizer.normalize_state(&mut states).await;
+        let state = states
+            .values_mut()
+            .next()
+            .expect("state should survive normalize_state");
+        let attributes = &mut state.attributes;
+
         if let Some(Value::Concrete(ConcreteValue::Map(fields))) =
             attributes.get("private_dns_name_options_on_launch")
         {
             assert_eq!(
                 fields.get("hostname_type"),
                 Some(&Value::Concrete(ConcreteValue::String(
-                    "aws.ec2.Subnet.PrivateDnsNameOptionsOnLaunch.HostnameType.ip_name".to_string()
+                    "ip-name".to_string()
                 )))
             );
             assert_eq!(
@@ -319,52 +151,5 @@ mod tests {
         } else {
             panic!("Expected Value::Map for private_dns_name_options_on_launch");
         }
-    }
-
-    #[test]
-    fn test_normalize_state_enums_ec2_security_group_egress_tcp() {
-        let mut attributes = HashMap::from([(
-            "ip_protocol".to_string(),
-            Value::Concrete(ConcreteValue::String("tcp".to_string())),
-        )]);
-        normalize_state_enums("ec2.SecurityGroupEgress", &mut attributes);
-        assert_eq!(
-            attributes.get("ip_protocol"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.ec2.SecurityGroupEgress.IpProtocol.tcp".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_normalize_state_enums_vpn_gateway_type_with_dot() {
-        let mut attributes = HashMap::from([(
-            "type".to_string(),
-            Value::Concrete(ConcreteValue::String("ipsec.1".to_string())),
-        )]);
-        normalize_state_enums("ec2.VpnGateway", &mut attributes);
-        assert_eq!(
-            attributes.get("type"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.ec2.VpnGateway.Type.ipsec_1".to_string()
-            )))
-        );
-    }
-
-    #[test]
-    fn test_normalize_state_enums_vpn_gateway_type_already_namespaced() {
-        let mut attributes = HashMap::from([(
-            "type".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "aws.ec2.VpnGateway.Type.ipsec.1".to_string(),
-            )),
-        )]);
-        normalize_state_enums("ec2.VpnGateway", &mut attributes);
-        assert_eq!(
-            attributes.get("type"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "aws.ec2.VpnGateway.Type.ipsec.1".to_string()
-            )))
-        );
     }
 }

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -8,7 +8,6 @@ use carina_core::resource::{DataSource, ResourceId, State};
 
 use crate::AwsProvider;
 use crate::helpers::apply_patch_to_state;
-use crate::normalizer::normalize_state_enums;
 
 impl Provider for AwsProvider {
     fn name(&self) -> &str {
@@ -24,7 +23,7 @@ impl Provider for AwsProvider {
         let id = id.clone();
         let identifier = identifier.map(|s| s.to_string());
         Box::pin(async move {
-            let mut state = match id.resource_type.as_str() {
+            let state = match id.resource_type.as_str() {
                 "s3.Bucket" => self.read_s3_bucket(&id, identifier.as_deref()).await,
                 "s3.BucketPolicy" => self.read_s3_bucket_policy(&id, identifier.as_deref()).await,
                 "s3.BucketPublicAccessBlock" => {
@@ -143,11 +142,6 @@ impl Provider for AwsProvider {
                 .for_resource(id.clone())),
             }?;
 
-            // Normalize enum values in read state to namespaced DSL format
-            if state.exists {
-                normalize_state_enums(&id.resource_type, &mut state.attributes);
-            }
-
             Ok(state)
         })
     }
@@ -155,12 +149,7 @@ impl Provider for AwsProvider {
     fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
         let resource = resource.clone();
         Box::pin(async move {
-            let mut state =
-                crate::provider_generated::dispatch_read_data_source(self, &resource).await?;
-            if state.exists {
-                normalize_state_enums(&resource.id.resource_type, &mut state.attributes);
-            }
-            Ok(state)
+            crate::provider_generated::dispatch_read_data_source(self, &resource).await
         })
     }
 

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -6,13 +6,10 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, DataSource, Resource, ResourceId, State, Value};
-#[allow(unused_imports)]
-use carina_core::utils::extract_enum_value;
-
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
+use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
+use carina_core::resource::{ConcreteValue, DataSource, Resource, ResourceId, State, Value};
 
 // ===== Generated Methods on AwsProvider =====
 

--- a/carina-provider-aws/src/schemas/config.rs
+++ b/carina-provider-aws/src/schemas/config.rs
@@ -26,6 +26,13 @@ pub struct AwsSchemaConfig {
 /// Type alias for custom type validator functions.
 pub type CustomValidatorFn = Box<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
 
+fn strip_availability_zone_prefix(value: &str) -> &str {
+    value
+        .strip_prefix("aws.AvailabilityZone.ZoneName.")
+        .or_else(|| value.strip_prefix("ZoneName."))
+        .unwrap_or(value)
+}
+
 /// Return all AWS type validators for use in `validate_custom_type`.
 ///
 /// These validators are keyed by type name (matching the names used in schema
@@ -105,7 +112,7 @@ pub fn aws_validators() -> HashMap<String, CustomValidatorFn> {
                     carina_core::utils::validate_enum_namespace(s, &id)
                         .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 }
-                let extracted = carina_core::utils::extract_enum_value(s);
+                let extracted = strip_availability_zone_prefix(s);
                 let normalized = extracted.replace('_', "-");
                 validate_availability_zone(&normalized)
             },

--- a/docs/specs/2026-05-03-s3-bucket-dual-registered-plan.md
+++ b/docs/specs/2026-05-03-s3-bucket-dual-registered-plan.md
@@ -910,11 +910,7 @@ fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<
     let resource = resource.clone();
     let me = self;
     Box::pin(async move {
-        let mut state = crate::provider_generated::dispatch_read_data_source(me, &resource).await?;
-        if state.exists {
-            normalize_state_enums(&resource.id.resource_type, &mut state.attributes);
-        }
-        Ok(state)
+        crate::provider_generated::dispatch_read_data_source(me, &resource).await
     })
 }
 ```


### PR DESCRIPTION
## Summary

Fixes #428 — the read/state-side sibling of the desired-side defect removed in #425 — and migrates this repo's last `extract_enum_value` consumers (enabler for carina-rs/carina#3452).

## Changes

- **Delete `normalize_state_enums`** and its read/read_data_source call sites. This pass converted fresh AWS read results into namespaced DSL display strings (it was the producer of the 6-segment `…PrivateDnsNameOptionsOnLaunch.HostnameType.ip_name` string behind the original #423 failure). Post-carina#3438 the host lifts state enum leaves to `CanonicalEnumValue` and accepts raw API spellings directly, per the carina#3409 contract (Carina-side bidirectional normalization). Read states now return raw API spellings; regression test asserts pass-through.
- **AZ/Region validators** (aws-types + provider config) replace positional `extract_enum_value` with exact identity-prefix strips; `validate_enum_namespace` still rejects malformed namespaced forms first (the 3-part legacy form was already rejected before this PR — behavior unchanged).
- **Codegen** stops emitting the unused `extract_enum_value` import; the dead enum-normalize template arm uses pass-through / `api_value`. Regenerated with the real codegen run.
- `rg extract_enum_value` in this repo: zero hits.

## Verify

- `cargo check` / `nextest` 471/471 / clippy `-D warnings` / fmt ✓
- `check-carina-pin.sh` / `check-examples.sh` / `check-string-enum-aliases.sh` ✓
- **Real AWS acceptance: full suite 47/47**, including every plan-verify step — no phantom diffs from raw-API-spelling read states.

Sibling: carina-rs/carina-provider-awscc#343 (same class, next PR). Refs carina-rs/carina#3452, carina-rs/carina#3409.

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)