### PR TITLE
Bump carina pin to 0a70d5bf and drop force_replace mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
+source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
+source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
+source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
 dependencies = [
  "serde",
  "serde_json",
@@ -1118,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2036,7 +2036,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2301,7 +2301,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -435,7 +435,6 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
         validator: None,
         kind: proto_to_core_schema_kind(s.kind),
         name_attribute: s.name_attribute.clone(),
-        force_replace: s.force_replace,
         operation_config: s.operation_config.as_ref().map(|c| CoreOperationConfig {
             delete_timeout_secs: c.delete_timeout_secs,
             delete_max_retries: c.delete_max_retries,
@@ -610,7 +609,6 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
         description: s.description.clone(),
         kind: core_to_proto_schema_kind(s.kind),
         name_attribute: s.name_attribute.clone(),
-        force_replace: s.force_replace,
         operation_config: s.operation_config.as_ref().map(|c| ProtoOperationConfig {
             delete_timeout_secs: c.delete_timeout_secs,
             delete_max_retries: c.delete_max_retries,

--- a/carina-provider-aws/src/schemas/generated/acm/certificate.rs
+++ b/carina-provider-aws/src/schemas/generated/acm/certificate.rs
@@ -111,7 +111,7 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
     vec![("DISABLED".to_string(), "disabled".to_string()), ("ENABLED".to_string(), "enabled".to_string())],
     None,
     None,
-)).with_description("You can opt out of certificate transparency logging by specifying the DISABLED option. Opt in by specifying ENABLED.").with_provider_name("CertificateTransparencyLoggingPreference"),
+)).with_description("This parameter has been deprecated. Certificate transparency logging opt-out is no longer available. All public certificates are recorded in a certifi...").with_provider_name("CertificateTransparencyLoggingPreference"),
                     StructField::new("export", AttributeType::enum_(
     carina_core::schema::enum_identity("Export", Some("aws.acm.Certificate.CertificateOptions")),
     Some(vec!["DISABLED".to_string(), "ENABLED".to_string()]),
@@ -122,7 +122,7 @@ pub fn acm_certificate_config() -> AwsSchemaConfig {
                     ],
                 ))
                 .create_only()
-                .with_description("You can use this parameter to specify whether to add the certificate to a certificate transparency log and export your certificate. Certificate transp...")
+                .with_description("You can use this parameter to specify whether to export your certificate. Certificate transparency logging opt-out is no longer available. All public ...")
                 .with_provider_name("Options"),
         )
         .attribute(


### PR DESCRIPTION
Bumps the carina git-dependency pin from `1b95cdf2` to `0a70d5bf` (carina#3452–#3474) and removes the now-invalid `force_replace: s.force_replace,` mappings in `convert.rs` — the field was deleted from `carina_provider_protocol::ResourceSchema` by carina#3473 (the force_replace mechanism was dead end-to-end after awscc#347 removed the only setters).

This provider never set the flag true, so behavior is unchanged. The two `force_replace` lines are the only compile errors the bump produces.

## Verification

- `cargo test`: all pass (multiple test suites, 0 failed)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `CARINA_CORE_DIR=... ./scripts/check-carina-pin.sh`: OK
- `./scripts/check-string-enum-aliases.sh`: OK
- `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`: OK (1m34s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
