### PR TITLE
Bump carina past #3480 (NormalizedResource typestate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
+source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
+source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
+source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -105,7 +105,7 @@ impl AwsProvider {
     /// Create an EC2 Security Group Rule (shared between ingress and egress)
     pub(crate) async fn create_ec2_security_group_rule(
         &self,
-        resource: Resource,
+        resource: &Resource,
         is_ingress: bool,
     ) -> ProviderResult<State> {
         let sg_id = match resource.get_attr("group_id") {
@@ -283,7 +283,7 @@ impl AwsProvider {
         // Security group rules are immutable - delete and recreate
         self.delete_ec2_security_group_rule(id.clone(), identifier, is_ingress)
             .await?;
-        self.create_ec2_security_group_rule(to, is_ingress).await
+        self.create_ec2_security_group_rule(&to, is_ingress).await
     }
 
     /// Delete an EC2 Security Group Rule (deletes all rules by identifier)

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -74,6 +74,14 @@ impl AwsProcessProvider {
             .as_ref()
             .expect("Provider not initialized; call initialize() first")
     }
+
+    fn schema_registry() -> SchemaRegistry {
+        let mut registry = SchemaRegistry::new();
+        for schema in carina_provider_aws::schemas::all_schemas() {
+            registry.insert("aws", schema);
+        }
+        registry
+    }
 }
 
 impl CarinaProvider for AwsProcessProvider {
@@ -283,6 +291,16 @@ impl CarinaProvider for AwsProcessProvider {
     ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_resource = convert::proto_to_core_resource(&request.resource);
+        let schemas = Self::schema_registry();
+        let core_resource = self.runtime.block_on(
+            carina_core::executor::normalized::apply_desired_normalization(
+                core_resource,
+                &[],
+                &self.normalizer,
+                &[],
+                &schemas,
+            ),
+        );
         let core_request = CoreCreateRequest {
             resource: core_resource,
         };

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -160,6 +160,7 @@ impl Provider for AwsProvider {
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let resource = request.resource;
         Box::pin(async move {
+            let resource = resource.as_resource();
             match resource.id.resource_type.as_str() {
                 "s3.Bucket" => self.create_s3_bucket(resource).await,
                 "s3.BucketPolicy" => self.create_s3_bucket_policy(resource).await,

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -239,9 +239,12 @@ impl AwsProvider {
     /// the validation status is `PENDING_VALIDATION` until the user
     /// satisfies the DNS / EMAIL challenge — typically wired via a
     /// `wait` construct on `cert.status`.
-    pub(crate) async fn create_acm_certificate(&self, resource: Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_acm_certificate(
+        &self,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
         let id = resource.id.clone();
-        let domain_name = require_string_attr(&resource, "domain_name")?;
+        let domain_name = require_string_attr(resource, "domain_name")?;
 
         let mut req = self
             .acm_client

--- a/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
@@ -58,9 +58,9 @@ impl AwsProvider {
     /// Create an EC2 Egress-Only Internet Gateway
     pub(crate) async fn create_ec2_egress_only_internet_gateway(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let vpc_id = require_string_attr(&resource, "vpc_id")?;
+        let vpc_id = require_string_attr(resource, "vpc_id")?;
 
         let mut req = self
             .ec2_client
@@ -69,7 +69,7 @@ impl AwsProvider {
 
         // Apply tags via TagSpecifications
         if let Some(tag_spec) = build_tag_specification(
-            &resource,
+            resource,
             aws_sdk_ec2::types::ResourceType::EgressOnlyInternetGateway,
         ) {
             req = req.tag_specifications(tag_spec);

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -58,7 +58,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Elastic IP
-    pub(crate) async fn create_ec2_eip(&self, resource: Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_eip(&self, resource: &Resource) -> ProviderResult<State> {
         let mut req = self.ec2_client.allocate_address();
 
         if let Some(Value::Concrete(ConcreteValue::String(domain))) = resource.get_attr("domain") {

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -74,7 +74,7 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Flow Log
-    pub(crate) async fn create_ec2_flow_log(&self, resource: Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_flow_log(&self, resource: &Resource) -> ProviderResult<State> {
         let resource_ids_val: Vec<String> = match resource.get_attr("resource_ids") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
@@ -157,7 +157,7 @@ impl AwsProvider {
 
         // Apply tags via TagSpecifications
         if let Some(tag_spec) =
-            build_tag_specification(&resource, aws_sdk_ec2::types::ResourceType::VpcFlowLog)
+            build_tag_specification(resource, aws_sdk_ec2::types::ResourceType::VpcFlowLog)
         {
             req = req.tag_specifications(tag_spec);
         }

--- a/carina-provider-aws/src/services/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/internet_gateway.rs
@@ -75,7 +75,7 @@ impl AwsProvider {
     /// Create an EC2 Internet Gateway
     pub(crate) async fn create_ec2_internet_gateway(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         // Create Internet Gateway
         let result = self

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -72,8 +72,11 @@ impl AwsProvider {
     }
 
     /// Create an EC2 NAT Gateway
-    pub(crate) async fn create_ec2_nat_gateway(&self, resource: Resource) -> ProviderResult<State> {
-        let subnet_id = require_string_attr(&resource, "subnet_id")?;
+    pub(crate) async fn create_ec2_nat_gateway(
+        &self,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let subnet_id = require_string_attr(resource, "subnet_id")?;
 
         let mut req = self.ec2_client.create_nat_gateway().subnet_id(&subnet_id);
 

--- a/carina-provider-aws/src/services/ec2/route.rs
+++ b/carina-provider-aws/src/services/ec2/route.rs
@@ -65,9 +65,9 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Route
-    pub(crate) async fn create_ec2_route(&self, resource: Resource) -> ProviderResult<State> {
-        let route_table_id = require_string_attr(&resource, "route_table_id")?;
-        let destination_cidr = require_string_attr(&resource, "destination_cidr_block")?;
+    pub(crate) async fn create_ec2_route(&self, resource: &Resource) -> ProviderResult<State> {
+        let route_table_id = require_string_attr(resource, "route_table_id")?;
+        let destination_cidr = require_string_attr(resource, "destination_cidr_block")?;
 
         let mut req = self
             .ec2_client

--- a/carina-provider-aws/src/services/ec2/route_table.rs
+++ b/carina-provider-aws/src/services/ec2/route_table.rs
@@ -91,8 +91,11 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Route Table
-    pub(crate) async fn create_ec2_route_table(&self, resource: Resource) -> ProviderResult<State> {
-        let vpc_id = require_string_attr(&resource, "vpc_id")?;
+    pub(crate) async fn create_ec2_route_table(
+        &self,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
+        let vpc_id = require_string_attr(resource, "vpc_id")?;
 
         // Create Route Table
         let result = self

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -65,9 +65,9 @@ impl AwsProvider {
     /// Create an EC2 Security Group
     pub(crate) async fn create_ec2_security_group(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let vpc_id = require_string_attr(&resource, "vpc_id")?;
+        let vpc_id = require_string_attr(resource, "vpc_id")?;
 
         let description = match resource.get_attr("description") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),

--- a/carina-provider-aws/src/services/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/services/ec2/security_group_egress.rs
@@ -17,7 +17,7 @@ impl AwsProvider {
     /// Create an EC2 Security Group Egress Rule
     pub(crate) async fn create_ec2_security_group_egress(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         self.create_ec2_security_group_rule(resource, false).await
     }

--- a/carina-provider-aws/src/services/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/services/ec2/security_group_ingress.rs
@@ -17,7 +17,7 @@ impl AwsProvider {
     /// Create an EC2 Security Group Ingress Rule
     pub(crate) async fn create_ec2_security_group_ingress(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         self.create_ec2_security_group_rule(resource, true).await
     }

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -68,9 +68,9 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Subnet
-    pub(crate) async fn create_ec2_subnet(&self, resource: Resource) -> ProviderResult<State> {
-        let cidr_block = require_string_attr(&resource, "cidr_block")?;
-        let vpc_id = require_string_attr(&resource, "vpc_id")?;
+    pub(crate) async fn create_ec2_subnet(&self, resource: &Resource) -> ProviderResult<State> {
+        let cidr_block = require_string_attr(resource, "cidr_block")?;
+        let vpc_id = require_string_attr(resource, "vpc_id")?;
 
         let mut req = self
             .ec2_client

--- a/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
+++ b/carina-provider-aws/src/services/ec2/subnet_route_table_association.rs
@@ -83,10 +83,10 @@ impl AwsProvider {
     /// Create an EC2 Subnet Route Table Association
     pub(crate) async fn create_ec2_subnet_route_table_association(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let route_table_id = require_string_attr(&resource, "route_table_id")?;
-        let subnet_id = require_string_attr(&resource, "subnet_id")?;
+        let route_table_id = require_string_attr(resource, "route_table_id")?;
+        let subnet_id = require_string_attr(resource, "subnet_id")?;
 
         let result = self
             .ec2_client

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -63,7 +63,7 @@ impl AwsProvider {
     /// Create an EC2 Transit Gateway
     pub(crate) async fn create_ec2_transit_gateway(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let mut req = self.ec2_client.create_transit_gateway();
 
@@ -131,7 +131,7 @@ impl AwsProvider {
 
         // Apply tags via TagSpecifications
         if let Some(tag_spec) =
-            build_tag_specification(&resource, aws_sdk_ec2::types::ResourceType::TransitGateway)
+            build_tag_specification(resource, aws_sdk_ec2::types::ResourceType::TransitGateway)
         {
             req = req.tag_specifications(tag_spec);
         }

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -63,10 +63,10 @@ impl AwsProvider {
     /// Create an EC2 Transit Gateway VPC Attachment
     pub(crate) async fn create_ec2_transit_gateway_attachment(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let transit_gateway_id = require_string_attr(&resource, "transit_gateway_id")?;
-        let vpc_id = require_string_attr(&resource, "vpc_id")?;
+        let transit_gateway_id = require_string_attr(resource, "transit_gateway_id")?;
+        let vpc_id = require_string_attr(resource, "vpc_id")?;
 
         let subnet_ids = match resource.get_attr("subnet_ids") {
             Some(Value::Concrete(ConcreteValue::List(ids))) => {
@@ -100,7 +100,7 @@ impl AwsProvider {
 
         // Apply tags via TagSpecifications
         if let Some(tag_spec) = build_tag_specification(
-            &resource,
+            resource,
             aws_sdk_ec2::types::ResourceType::TransitGatewayAttachment,
         ) {
             req = req.tag_specifications(tag_spec);

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -89,8 +89,8 @@ impl AwsProvider {
     }
 
     /// Create an EC2 VPC
-    pub(crate) async fn create_ec2_vpc(&self, resource: Resource) -> ProviderResult<State> {
-        let cidr_block = require_string_attr(&resource, "cidr_block")?;
+    pub(crate) async fn create_ec2_vpc(&self, resource: &Resource) -> ProviderResult<State> {
+        let cidr_block = require_string_attr(resource, "cidr_block")?;
 
         // Create VPC with optional instance_tenancy
         let mut create_vpc_builder = self.ec2_client.create_vpc().cidr_block(&cidr_block);

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -63,10 +63,10 @@ impl AwsProvider {
     /// Create an EC2 VPC Endpoint
     pub(crate) async fn create_ec2_vpc_endpoint(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let vpc_id = require_string_attr(&resource, "vpc_id")?;
-        let service_name = require_string_attr(&resource, "service_name")?;
+        let vpc_id = require_string_attr(resource, "vpc_id")?;
+        let service_name = require_string_attr(resource, "service_name")?;
 
         let mut req = self
             .ec2_client

--- a/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_gateway_attachment.rs
@@ -147,9 +147,9 @@ impl AwsProvider {
     /// Create an EC2 VPC Gateway Attachment
     pub(crate) async fn create_ec2_vpc_gateway_attachment(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let vpc_id = require_string_attr(&resource, "vpc_id")?;
+        let vpc_id = require_string_attr(resource, "vpc_id")?;
 
         if let Some(Value::Concrete(ConcreteValue::String(igw_id))) =
             resource.get_attr("internet_gateway_id")

--- a/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
@@ -70,10 +70,10 @@ impl AwsProvider {
     /// Create an EC2 VPC Peering Connection
     pub(crate) async fn create_ec2_vpc_peering_connection(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let vpc_id = require_string_attr(&resource, "vpc_id")?;
-        let peer_vpc_id = require_string_attr(&resource, "peer_vpc_id")?;
+        let vpc_id = require_string_attr(resource, "vpc_id")?;
+        let peer_vpc_id = require_string_attr(resource, "peer_vpc_id")?;
 
         let mut req = self
             .ec2_client
@@ -95,7 +95,7 @@ impl AwsProvider {
 
         // Apply tags via TagSpecifications
         if let Some(tag_spec) = build_tag_specification(
-            &resource,
+            resource,
             aws_sdk_ec2::types::ResourceType::VpcPeeringConnection,
         ) {
             req = req.tag_specifications(tag_spec);

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -66,7 +66,10 @@ impl AwsProvider {
     }
 
     /// Create an EC2 VPN Gateway
-    pub(crate) async fn create_ec2_vpn_gateway(&self, resource: Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_vpn_gateway(
+        &self,
+        resource: &Resource,
+    ) -> ProviderResult<State> {
         let gw_type = match resource.get_attr("type") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {

--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -79,11 +79,11 @@ impl AwsProvider {
     }
 
     /// Create an IAM Role
-    pub(crate) async fn create_iam_role(&self, resource: Resource) -> ProviderResult<State> {
-        let role_name = require_string_attr(&resource, "role_name")?;
+    pub(crate) async fn create_iam_role(&self, resource: &Resource) -> ProviderResult<State> {
+        let role_name = require_string_attr(resource, "role_name")?;
 
         let assume_role_policy_document =
-            resolve_iam_policy_attr(&resource, "assume_role_policy_document")?;
+            resolve_iam_policy_attr(resource, "assume_role_policy_document")?;
 
         let mut req = self
             .iam_client

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -112,8 +112,8 @@ impl AwsProvider {
     }
 
     /// Create a CloudWatch Logs Log Group
-    pub(crate) async fn create_logs_log_group(&self, resource: Resource) -> ProviderResult<State> {
-        let log_group_name = require_string_attr(&resource, "log_group_name")?;
+    pub(crate) async fn create_logs_log_group(&self, resource: &Resource) -> ProviderResult<State> {
+        let log_group_name = require_string_attr(resource, "log_group_name")?;
 
         let mut req = self
             .logs_client

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -160,10 +160,10 @@ impl AwsProvider {
     /// Create an Organizations account
     pub(crate) async fn create_organizations_account(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let name = require_string_attr(&resource, "account_name")?;
-        let email = require_string_attr(&resource, "email")?;
+        let name = require_string_attr(resource, "account_name")?;
+        let email = require_string_attr(resource, "email")?;
 
         let mut req = self
             .organizations_client

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -106,7 +106,7 @@ impl AwsProvider {
     /// Create an Organizations organization
     pub(crate) async fn create_organizations_organization(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
         let mut req = self.organizations_client.create_organization();
 
@@ -130,7 +130,7 @@ impl AwsProvider {
         if let Some(org) = response.organization() {
             let mut attributes = HashMap::new();
             let org_id = Self::extract_organizations_organization_attributes(org, &mut attributes);
-            let state = State::existing(resource.id, attributes);
+            let state = State::existing(resource.id.clone(), attributes);
             Ok(if let Some(org_id) = org_id {
                 state.with_identifier(org_id)
             } else {
@@ -139,7 +139,7 @@ impl AwsProvider {
         } else {
             Err(
                 ProviderError::api_error("CreateOrganization returned no organization")
-                    .for_resource(resource.id),
+                    .for_resource(resource.id.clone()),
             )
         }
     }

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -356,13 +356,13 @@ impl AwsProvider {
 
     pub(crate) async fn create_route53_record_set(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let hosted_zone_id = require_string_attr(&resource, "hosted_zone_id")?;
-        let name = require_string_attr(&resource, "name")?;
-        let record_type = require_enum_attr(&resource, "type")?;
+        let hosted_zone_id = require_string_attr(resource, "hosted_zone_id")?;
+        let name = require_string_attr(resource, "name")?;
+        let record_type = require_enum_attr(resource, "type")?;
 
-        let record_set = build_record_set(&resource)?;
+        let record_set = build_record_set(resource)?;
         change_record_set(
             &self.route53_client,
             &hosted_zone_id,

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -67,7 +67,7 @@ impl AwsProvider {
     }
 
     /// Create an S3 bucket
-    pub(crate) async fn create_s3_bucket(&self, resource: Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_s3_bucket(&self, resource: &Resource) -> ProviderResult<State> {
         let bucket_name = match resource.get_attr("bucket") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
             _ => {

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -142,9 +142,9 @@ impl AwsProvider {
         }
     }
 
-    pub(crate) async fn create_s3_bucket_acl(&self, resource: Resource) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_acl(&resource.id, &bucket, &resource)
+    pub(crate) async fn create_s3_bucket_acl(&self, resource: &Resource) -> ProviderResult<State> {
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_acl(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_cors.rs
+++ b/carina-provider-aws/src/services/s3/bucket_cors.rs
@@ -54,10 +54,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_cors_configuration(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_cors(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_cors(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -66,10 +66,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_server_side_encryption_configuration(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_encryption(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_encryption(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -66,10 +66,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_lifecycle_configuration(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_lifecycle(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_lifecycle(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -69,10 +69,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_logging(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_logging(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_logging(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_notification.rs
+++ b/carina-provider-aws/src/services/s3/bucket_notification.rs
@@ -97,10 +97,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_notification_configuration(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_notification(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_notification(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -63,10 +63,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_ownership_controls(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_ownership_controls(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_ownership_controls(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/services/s3/bucket_policy.rs
@@ -66,10 +66,10 @@ impl AwsProvider {
     /// Create an S3 BucketPolicy via PutBucketPolicy.
     pub(crate) async fn create_s3_bucket_policy(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_policy(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_policy(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
@@ -84,10 +84,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_public_access_block(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_public_access_block(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_public_access_block(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -71,10 +71,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_replication_configuration(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_replication(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_replication(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -68,10 +68,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_versioning(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_versioning(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_versioning(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_website.rs
+++ b/carina-provider-aws/src/services/s3/bucket_website.rs
@@ -95,10 +95,10 @@ impl AwsProvider {
 
     pub(crate) async fn create_s3_bucket_website_configuration(
         &self,
-        resource: Resource,
+        resource: &Resource,
     ) -> ProviderResult<State> {
-        let bucket = require_string_attr(&resource, "bucket")?;
-        self.put_s3_bucket_website(&resource.id, &bucket, &resource)
+        let bucket = require_string_attr(resource, "bucket")?;
+        self.put_s3_bucket_website(&resource.id, &bucket, resource)
             .await
     }
 

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -469,8 +469,8 @@ impl AwsProvider {
     }
 
     /// Create an SQS Queue and return its post-create state.
-    pub(crate) async fn create_sqs_queue(&self, resource: Resource) -> ProviderResult<State> {
-        let queue_name = require_string_attr(&resource, "queue_name")?;
+    pub(crate) async fn create_sqs_queue(&self, resource: &Resource) -> ProviderResult<State> {
+        let queue_name = require_string_attr(resource, "queue_name")?;
 
         // Pack every writable attribute the user actually set.
         let mut attr_map: HashMap<QueueAttributeName, String> = HashMap::new();
@@ -485,7 +485,7 @@ impl AwsProvider {
             }
         }
 
-        let tags = resource_tags_map(&resource);
+        let tags = resource_tags_map(resource);
 
         let mut req = self.sqs_client.create_queue().queue_name(&queue_name);
         if !attr_map.is_empty() {


### PR DESCRIPTION
## Summary

Bump `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` (and the in-repo `carina-aws-types`) past `carina-rs/carina#3482`. That PR introduced a `NormalizedResource` typestate on `CreateRequest.resource`, so every `Provider::create` impl needs to unwrap the typestate once at the boundary and thread `&Resource` downstream.

## Changes

- `Provider::create` calls `request.resource.as_resource()` once and dispatches `&Resource` to the per-resource `create_*` helpers (which previously took `Resource` by value but only ever read it).
- Per-resource helpers updated to `&Resource`. Where ownership was actually consumed it was only to call `resource.id`; switched to `resource.id.clone()` at those sites.
- Protocol boundary in `src/main.rs` now converts the proto resource and runs `carina_core::executor::normalized::apply_desired_normalization(...)` to obtain a `NormalizedResource` before constructing `CoreCreateRequest`.

## Test plan

- [x] `cargo build`
- [x] `cargo nextest run` — 474 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build -p carina-provider-aws --target wasm32-wasip2 --release`
