### PR TITLE
Bump carina to 857fdf9644d8 (#3484)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
+source = "git+https://github.com/carina-rs/carina?rev=857fdf9644d8ca4bfc915570c3eef878c7bc585c#857fdf9644d8ca4bfc915570c3eef878c7bc585c"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
+source = "git+https://github.com/carina-rs/carina?rev=857fdf9644d8ca4bfc915570c3eef878c7bc585c#857fdf9644d8ca4bfc915570c3eef878c7bc585c"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
+source = "git+https://github.com/carina-rs/carina?rev=857fdf9644d8ca4bfc915570c3eef878c7bc585c#857fdf9644d8ca4bfc915570c3eef878c7bc585c"
 dependencies = [
  "serde",
  "serde_json",
@@ -1120,7 +1120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2038,7 +2038,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2303,7 +2303,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "857fdf9644d8ca4bfc915570c3eef878c7bc585c" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "857fdf9644d8ca4bfc915570c3eef878c7bc585c" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "857fdf9644d8ca4bfc915570c3eef878c7bc585c" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "857fdf9644d8ca4bfc915570c3eef878c7bc585c" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

Bumps `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` pins in this repo from `d8947f40a667` to `857fdf9644d8`, picking up carina-rs/carina#3484 (the new built-in DSL custom type `http_response_status_code`).

## Why

Prerequisite for the awscc-side fix of carina-rs/carina-provider-awscc#353. Without this bump, awscc cannot bump its own carina-core pin past #3484 without ending up with two `carina-core` versions in `Cargo.lock` — `carina-aws-types` (consumed by awscc as a git dependency) would still pin the pre-#3484 rev. That is the documented awscc#255 type-mismatch failure mode (354 `E0308` errors).

## Test plan

- [x] `cargo nextest run --workspace` (474 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (carina-pin OK on the new rev, examples / string-enum-aliases all OK)