### PR TITLE
Bump carina to 28bc698e (#3494)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=857fdf9644d8ca4bfc915570c3eef878c7bc585c#857fdf9644d8ca4bfc915570c3eef878c7bc585c"
+source = "git+https://github.com/carina-rs/carina?rev=28bc698e2c4aad0875ee44b8ef3372a92e8213a4#28bc698e2c4aad0875ee44b8ef3372a92e8213a4"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=857fdf9644d8ca4bfc915570c3eef878c7bc585c#857fdf9644d8ca4bfc915570c3eef878c7bc585c"
+source = "git+https://github.com/carina-rs/carina?rev=28bc698e2c4aad0875ee44b8ef3372a92e8213a4#28bc698e2c4aad0875ee44b8ef3372a92e8213a4"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=857fdf9644d8ca4bfc915570c3eef878c7bc585c#857fdf9644d8ca4bfc915570c3eef878c7bc585c"
+source = "git+https://github.com/carina-rs/carina?rev=28bc698e2c4aad0875ee44b8ef3372a92e8213a4#28bc698e2c4aad0875ee44b8ef3372a92e8213a4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1120,7 +1120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2038,7 +2038,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2303,7 +2303,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "857fdf9644d8ca4bfc915570c3eef878c7bc585c" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "28bc698e2c4aad0875ee44b8ef3372a92e8213a4" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "857fdf9644d8ca4bfc915570c3eef878c7bc585c" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "28bc698e2c4aad0875ee44b8ef3372a92e8213a4" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "857fdf9644d8ca4bfc915570c3eef878c7bc585c" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "857fdf9644d8ca4bfc915570c3eef878c7bc585c" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "28bc698e2c4aad0875ee44b8ef3372a92e8213a4" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "28bc698e2c4aad0875ee44b8ef3372a92e8213a4" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

Pulls in the five `redirect_*` built-in DSL custom types from [carina-rs/carina#3494](https://github.com/carina-rs/carina/pull/3494):

- `redirect_protocol` — accepts `HTTP`, `HTTPS`, or `#{protocol}`
- `redirect_host` — 1..=128 chars + the `#{host}` placeholder
- `redirect_port` — decimal 1..=65535 or `#{port}`
- `redirect_path` — 1..=128 chars, starts with `/`, plus `#{host}` / `#{port}` / `#{path}`
- `redirect_query` — 0..=128 chars, plus all five ELBv2 placeholders

## Why now

This is a prerequisite for the awscc-side fix of
[carina-rs/carina-provider-awscc#363](https://github.com/carina-rs/carina-provider-awscc/issues/363).
Without this bump, awscc cannot bump its own carina-core pin past
carina#3494 without ending up with two `carina_core` copies in
`Cargo.lock` (carina-aws-types here pins the pre-#3494 rev), which
triggers the documented [awscc#255](https://github.com/carina-rs/carina-provider-awscc/issues/255)
type-mismatch failure mode (two `carina_core` versions in the same
build → E0308 between `ResourceSchema`/`AttributeType`/etc.).

## Test plan

- [x] `cargo check` — pass
- [x] `cargo nextest run --all-features` — pass
- [x] `cargo test --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass
- [x] `bash scripts/check-carina-pin.sh` — all 4 pins on rev 28bc698e, ancestry verified
- [x] `bash scripts/check-examples.sh` — pass
- [x] `bash scripts/check-string-enum-aliases.sh` — pass

Pure dep bump; no code changes.