### PR TITLE
feat(provider): add empty required_permissions impl (carina#3496)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=28bc698e2c4aad0875ee44b8ef3372a92e8213a4#28bc698e2c4aad0875ee44b8ef3372a92e8213a4"
+source = "git+https://github.com/carina-rs/carina?rev=156b5e2f#156b5e2f4808bb90c49c4ea26a8e05e0cf9f8265"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -835,13 +835,14 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-util",
  "uuid",
 ]
 
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=28bc698e2c4aad0875ee44b8ef3372a92e8213a4#28bc698e2c4aad0875ee44b8ef3372a92e8213a4"
+source = "git+https://github.com/carina-rs/carina?rev=156b5e2f#156b5e2f4808bb90c49c4ea26a8e05e0cf9f8265"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -894,7 +895,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=28bc698e2c4aad0875ee44b8ef3372a92e8213a4#28bc698e2c4aad0875ee44b8ef3372a92e8213a4"
+source = "git+https://github.com/carina-rs/carina?rev=156b5e2f#156b5e2f4808bb90c49c4ea26a8e05e0cf9f8265"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "28bc698e2c4aad0875ee44b8ef3372a92e8213a4" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "156b5e2f" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "28bc698e2c4aad0875ee44b8ef3372a92e8213a4" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "156b5e2f" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "28bc698e2c4aad0875ee44b8ef3372a92e8213a4" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "28bc698e2c4aad0875ee44b8ef3372a92e8213a4" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "156b5e2f" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "156b5e2f" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -227,6 +227,14 @@ impl CarinaProvider for AwsProcessProvider {
         vec!["region".to_string()]
     }
 
+    fn required_permissions(
+        &self,
+        _id: &proto::ResourceId,
+        _op: carina_plugin_sdk::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
+
     fn enum_aliases(&self) -> HashMap<String, HashMap<String, HashMap<String, String>>> {
         carina_provider_aws::schemas::generated::build_enum_aliases_map()
     }

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -1,5 +1,6 @@
 //! Provider trait implementation for AWS
 
+use carina_core::effect::PlanOp;
 use carina_core::provider::{
     BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderResult, ReadRequest,
     UpdateRequest,
@@ -12,6 +13,10 @@ use crate::helpers::apply_patch_to_state;
 impl Provider for AwsProvider {
     fn name(&self) -> &str {
         "aws"
+    }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: PlanOp) -> Vec<String> {
+        Vec::new()
     }
 
     fn read(

--- a/carina-provider-aws/tests/sts_caller_identity_winterbaume.rs
+++ b/carina-provider-aws/tests/sts_caller_identity_winterbaume.rs
@@ -34,8 +34,9 @@ use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sqs::Client as SqsClient;
 use aws_sdk_sts::Client as StsClient;
 
+use carina_core::effect::PlanOp;
 use carina_core::provider::Provider;
-use carina_core::resource::{ConcreteValue, DataSource, Value};
+use carina_core::resource::{ConcreteValue, DataSource, ResourceId, Value};
 use carina_provider_aws::AwsProvider;
 use winterbaume_core::MockAws;
 use winterbaume_sts::StsService;
@@ -47,6 +48,35 @@ const TEST_REGION: &str = "us-east-1";
 /// on this string verbatim; using `sts.caller_identity` (snake_case)
 /// would fall into the default "not implemented" arm.
 const STS_CALLER_IDENTITY_TYPE: &str = "sts.CallerIdentity";
+
+#[tokio::test]
+async fn required_permissions_returns_empty_vec() {
+    let mock = MockAws::builder().with_service(StsService::new()).build();
+    let sdk_config = mock.sdk_config(TEST_REGION).await;
+
+    let provider = AwsProvider::from_clients(
+        TEST_REGION.to_string(),
+        Vec::new(),
+        Vec::new(),
+        S3Client::new(&sdk_config),
+        Ec2Client::new(&sdk_config),
+        IamClient::new(&sdk_config),
+        CloudWatchLogsClient::new(&sdk_config),
+        StsClient::new(&sdk_config),
+        OrganizationsClient::new(&sdk_config),
+        IdentityStoreClient::new(&sdk_config),
+        Route53Client::new(&sdk_config),
+        AcmClient::new(&sdk_config),
+        SqsClient::new(&sdk_config),
+    );
+
+    let id = ResourceId::with_provider("aws", "s3.Bucket", "example", None);
+
+    assert_eq!(
+        provider.required_permissions(&id, PlanOp::Create),
+        Vec::<String>::new()
+    );
+}
 
 #[tokio::test]
 async fn sts_caller_identity_data_source_returns_account_arn_user_id_from_winterbaume() {


### PR DESCRIPTION
Refs carina-rs/carina#3496

PR#3 of a 4-PR chain for carina-rs/carina#3496 (plan-time IAM permission check).

PR#1 ([carina#3517](https://github.com/carina-rs/carina/pull/3517), merged) added the provider boundary: every `Provider` impl must now declare required IAM permissions for the given `ResourceId` / `PlanOp` pair. The aws provider uses the AWS SDK directly (not CloudControl), so there is no CFN-handlers data source to mine for permissions. Returns empty `Vec` for now; richer per-resource permissions can be derived from SDK operation models in a separate issue per the design doc.

## Chain

1. carina-rs/carina#3517 (merged) — trait + WIT + flag scaffolding
2. carina-provider-awscc PR (pending) — handlers extraction + impl
3. **This PR** — aws empty impl
4. carina-rs/carina PR (pending) — provider rev bump + `iam_preflight` body. **Closes carina#3496.**

## Changes

- Bump `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` to carina rev `156b5e2f` (post-PR#1).
- Bump `carina-plugin-wit` submodule pointer to `208082b` (post-WIT#21/22).
- Empty `required_permissions` impl on both sides:
  - `carina_core::Provider for AwsProvider` (host trait)
  - `carina_plugin_sdk::CarinaProvider for AwsProcessProvider` (sdk process-mode trait)
- Contract test asserts empty `Vec` for any `ResourceId + PlanOp`.

## Verify

- `cargo check --workspace`
- `cargo nextest run --workspace` — 475 passed
- `cargo test --workspace --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bash scripts/check-carina-pin.sh` — OK
