### PR TITLE
fix(acm): stop silently dropping enum attributes at the helper layer (#440)

### DIFF
--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -38,19 +38,50 @@ pub fn require_string_attr(resource: &Resource, attr_name: &str) -> ProviderResu
     }
 }
 
-/// Extract a required enum attribute from a resource.
+/// Return the AWS API canonical spelling for a schema-typed enum
+/// attribute, accepting every `Value` shape the carina-core canonicalize
+/// pipeline can produce at the provider boundary:
 ///
-/// Core rewrites every schema-known enum value to its AWS API-canonical
-/// spelling (`Enabled`, `VPC`, `STANDARD_IA`) before the provider sees it,
-/// so the caller can feed the result straight to an SDK builder like
-/// `BucketVersioningStatus::from(...)`.
+/// - `ConcreteValue::String(s)` — quoted-string DSL form
+///   (`validation_method = 'DNS'`) or a state-read echo
+/// - `ConcreteValue::EnumIdentifier(raw)` — bare DSL identifier form
+///   (`validation_method = dns`, post-carina#3463)
+/// - `ConcreteValue::CanonicalEnum(c)` — typed witness produced by
+///   `canonicalize_resources_with_schemas` for schema-known values
+///   (carina#3438)
 ///
-/// Equivalent to `require_string_attr` today — the alias historically
-/// stripped a DSL namespace prefix, but normalization now happens
-/// upstream and namespaces never reach the provider. The helper is
-/// kept so caller intent stays readable.
+/// Returns `None` for any other shape or a missing attribute. Use this
+/// (or its wrappers below) for any schema attribute declared as
+/// `AttributeType::enum_(..)`. Plain `value_as_str` /
+/// `require_string_attr` match only `ConcreteValue::String` and silently
+/// drop the other two variants, which is the carina-rs/carina-provider-aws#440
+/// failure mode.
+pub(crate) fn enum_attr_str<'a>(resource: &'a Resource, attr_name: &str) -> Option<&'a str> {
+    match resource.get_attr(attr_name)? {
+        Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
+        Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => Some(raw.as_str()),
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => Some(c.api_value()),
+        _ => None,
+    }
+}
+
+/// Required-attribute wrapper around [`enum_attr_str`]. Returns the
+/// AWS API canonical spelling, or `ProviderError::invalid_input`
+/// when the attribute is absent or carries a non-enum-shaped value.
 pub fn require_enum_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
-    require_string_attr(resource, attr_name)
+    enum_attr_str(resource, attr_name)
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            ProviderError::invalid_input(format!("{} is required", attr_name))
+                .for_resource(resource.id.clone())
+        })
+}
+
+/// Optional-attribute wrapper around [`enum_attr_str`] for readability
+/// at call sites where the enum is optional (e.g. ACM
+/// `validation_method`, `key_algorithm`).
+pub fn optional_enum_attr<'a>(resource: &'a Resource, attr_name: &str) -> Option<&'a str> {
+    enum_attr_str(resource, attr_name)
 }
 
 /// Build an EC2 `TagSpecification` from DSL tags for a given resource type.
@@ -334,7 +365,7 @@ mod tests {
     use super::*;
 
     fn make_test_resource(attrs: Vec<(&str, &str)>) -> Resource {
-        let mut resource = Resource::new("route53.RecordSet", "test");
+        let mut resource = Resource::new("acm.Certificate", "test");
         for (k, v) in attrs {
             resource.attributes.insert(
                 k.to_string(),
@@ -342,6 +373,29 @@ mod tests {
             );
         }
         resource
+    }
+
+    fn make_resource_with_value(attr_name: &str, value: Value) -> Resource {
+        let mut resource = Resource::new("acm.Certificate", "test");
+        resource.attributes.insert(attr_name.to_string(), value);
+        resource
+    }
+
+    fn canonical_validation_method_value() -> Value {
+        use carina_core::schema::{AttributeType, Schema, enum_identity};
+
+        let attr_type = AttributeType::enum_(
+            enum_identity("ValidationMethod", Some("aws.acm.Certificate")),
+            Some(vec!["DNS".to_string(), "EMAIL".to_string()]),
+            vec![
+                ("DNS".to_string(), "dns".to_string()),
+                ("EMAIL".to_string(), "email".to_string()),
+            ],
+            None,
+            None,
+        );
+        let schema = Schema::flat(attr_type);
+        schema.canonicalize(Value::Concrete(ConcreteValue::enum_identifier("dns")))
     }
 
     #[test]
@@ -424,23 +478,69 @@ mod tests {
     }
 
     #[test]
-    fn test_require_enum_attr_returns_canonical_value() {
-        // Core sends enum attributes in AWS API-canonical spelling.
-        // require_enum_attr just passes it through.
-        let resource = make_test_resource(vec![("type", "A")]);
-        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "A");
+    fn test_require_enum_attr_string() {
+        let resource = make_test_resource(vec![("type", "DNS")]);
+        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "DNS");
     }
 
     #[test]
-    fn test_require_enum_attr_plain_value() {
-        let resource = make_test_resource(vec![("type", "AAAA")]);
-        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "AAAA");
+    fn test_require_enum_attr_enum_identifier() {
+        let resource = make_resource_with_value(
+            "type",
+            Value::Concrete(ConcreteValue::enum_identifier("dns")),
+        );
+        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "dns");
     }
 
     #[test]
-    fn test_require_enum_attr_missing() {
+    fn test_require_enum_attr_canonical_enum() {
+        let resource = make_resource_with_value("type", canonical_validation_method_value());
+        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "DNS");
+    }
+
+    #[test]
+    fn test_require_enum_attr_missing_is_err() {
         let resource = make_test_resource(vec![]);
         assert!(require_enum_attr(&resource, "type").is_err());
+    }
+
+    #[test]
+    fn test_require_enum_attr_non_enum_shape_is_err() {
+        let resource = make_resource_with_value("type", Value::Concrete(ConcreteValue::Int(1)));
+        assert!(require_enum_attr(&resource, "type").is_err());
+    }
+
+    #[test]
+    fn test_optional_enum_attr_string() {
+        let resource = make_test_resource(vec![("type", "DNS")]);
+        assert_eq!(optional_enum_attr(&resource, "type"), Some("DNS"));
+    }
+
+    #[test]
+    fn test_optional_enum_attr_enum_identifier() {
+        let resource = make_resource_with_value(
+            "type",
+            Value::Concrete(ConcreteValue::enum_identifier("dns")),
+        );
+        assert_eq!(optional_enum_attr(&resource, "type"), Some("dns"));
+    }
+
+    #[test]
+    fn test_optional_enum_attr_canonical_enum() {
+        let resource = make_resource_with_value("type", canonical_validation_method_value());
+        assert_eq!(optional_enum_attr(&resource, "type"), Some("DNS"));
+    }
+
+    #[test]
+    fn test_optional_enum_attr_missing_is_none() {
+        let resource = make_test_resource(vec![]);
+        assert_eq!(optional_enum_attr(&resource, "type"), None);
+    }
+
+    #[test]
+    fn test_optional_enum_attr_non_enum_shape_is_none() {
+        let resource = make_resource_with_value("type", Value::Concrete(ConcreteValue::Bool(true)));
+        assert_eq!(optional_enum_attr(&resource, "type"), None);
     }
 
     #[test]

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -20,15 +20,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{require_string_attr, sdk_error_message};
-
-fn extract_string(value: &Value) -> Option<&str> {
-    if let Value::Concrete(ConcreteValue::String(s)) = value {
-        Some(s.as_str())
-    } else {
-        None
-    }
-}
+use crate::helpers::{optional_enum_attr, require_string_attr, sdk_error_message};
 
 fn extract_string_list(value: &Value) -> Vec<String> {
     if let Value::Concrete(ConcreteValue::List(items)) = value {
@@ -251,10 +243,8 @@ impl AwsProvider {
             .request_certificate()
             .domain_name(domain_name);
 
-        if let Some(method) = resource
-            .get_attr("validation_method")
-            .and_then(extract_string)
-            .and_then(parse_validation_method)
+        if let Some(method) =
+            optional_enum_attr(resource, "validation_method").and_then(parse_validation_method)
         {
             req = req.validation_method(method);
         }
@@ -265,7 +255,7 @@ impl AwsProvider {
         for san in sans {
             req = req.subject_alternative_names(san);
         }
-        if let Some(key_algorithm) = resource.get_attr("key_algorithm").and_then(extract_string) {
+        if let Some(key_algorithm) = optional_enum_attr(resource, "key_algorithm") {
             // Pass the AWS canonical form through verbatim — schema
             // narrowing has already validated it.
             req = req.key_algorithm(key_algorithm.into());
@@ -310,10 +300,8 @@ impl AwsProvider {
                 .for_resource(id.clone())
         })?;
 
-        let validation_method = resource
-            .get_attr("validation_method")
-            .and_then(extract_string)
-            .and_then(parse_validation_method);
+        let validation_method =
+            optional_enum_attr(resource, "validation_method").and_then(parse_validation_method);
 
         // DNS validation populates DomainValidationOptions[].ResourceRecord
         // asynchronously after RequestCertificate. Wait so the post-create
@@ -437,10 +425,7 @@ impl AwsProvider {
         from: &State,
         to: Resource,
     ) -> ProviderResult<State> {
-        if let Some(pref) = to
-            .get_attr("certificate_transparency_logging_preference")
-            .and_then(extract_string)
-        {
+        if let Some(pref) = optional_enum_attr(&to, "certificate_transparency_logging_preference") {
             self.acm_client
                 .update_certificate_options()
                 .certificate_arn(identifier)
@@ -925,6 +910,123 @@ mod tests {
         );
         // Project absent from desired → remove
         assert_eq!(to_remove, vec!["Project".to_string()]);
+    }
+
+    /// carina-provider-aws#440: `validation_method = dns` was reaching AWS
+    /// as `EMAIL` (default) because the host canonicalize pass wraps the
+    /// schema-typed enum string as `CanonicalEnum("DNS")` before it crosses
+    /// the WIT boundary. Inside the provider, `apply_desired_normalization`
+    /// runs `canonicalize_resources_with_schemas` again, so by the time
+    /// `create_acm_certificate` reads `validation_method`, the value is
+    /// `ConcreteValue::CanonicalEnum`, not `ConcreteValue::String`.
+    ///
+    /// The old local string extractor matched only `ConcreteValue::String`, so the
+    /// `validation_method(...)` call was silently skipped on the SDK
+    /// request. AWS defaulted to `EMAIL`, the read-back persisted that
+    /// to state, and every subsequent plan showed a permanent
+    /// `EMAIL → DNS (forces replacement)` diff. The replacement-created
+    /// cert hit the same bug, so the loop never converged.
+    ///
+    /// The fix is at the helper layer: a request-side extractor for an
+    /// enum-typed attribute must accept the three variants the
+    /// canonicalize pipeline can produce — `String` (e.g. via a quoted
+    /// DSL spelling `validation_method = 'DNS'`), `EnumIdentifier`
+    /// (raw, when canonicalize didn't resolve), and `CanonicalEnum`
+    /// (the typed witness the canonicalize pass produces for schema-known
+    /// values). This test pins all three.
+    ///
+    /// This assertion goes through the production
+    /// `helpers::optional_enum_attr` path so helper regressions are caught here.
+    #[test]
+    fn validation_method_canonical_enum_reaches_request() {
+        use carina_core::schema::{AttributeType, Schema, enum_identity};
+
+        let attr_type = AttributeType::enum_(
+            enum_identity("ValidationMethod", Some("aws.acm.Certificate")),
+            Some(vec![
+                "DNS".to_string(),
+                "EMAIL".to_string(),
+                "HTTP".to_string(),
+            ]),
+            vec![
+                ("DNS".to_string(), "dns".to_string()),
+                ("EMAIL".to_string(), "email".to_string()),
+                ("HTTP".to_string(), "http".to_string()),
+            ],
+            None,
+            None,
+        );
+        let schema = Schema::flat(attr_type);
+
+        // DSL-side enum identifier `validation_method = dns` reaches the
+        // schema-typed canonicalize pass as `EnumIdentifier("dns")`.
+        let canonical = schema.canonicalize(Value::Concrete(ConcreteValue::enum_identifier("dns")));
+        assert!(
+            matches!(&canonical, Value::Concrete(ConcreteValue::CanonicalEnum(c))
+                if c.api_value() == "DNS"),
+            "schema canonicalize must produce CanonicalEnum(DNS) from \
+             EnumIdentifier(\"dns\"); got {canonical:?}"
+        );
+
+        // The fix: extracting the validation method from a Resource whose
+        // `validation_method` is a `CanonicalEnum` must yield
+        // `ValidationMethod::Dns`. Pre-fix the extract→parse chain
+        // silently returned None.
+        let mut resource = Resource::with_provider("aws", "acm.Certificate", "test-cert", None);
+        resource.set_attr("validation_method".to_string(), canonical);
+        let parsed = crate::helpers::optional_enum_attr(&resource, "validation_method")
+            .and_then(parse_validation_method);
+        assert_eq!(
+            parsed,
+            Some(ValidationMethod::Dns),
+            "validation_method CanonicalEnum(DNS) must extract to \
+             ValidationMethod::Dns; pre-fix the silent drop caused AWS to \
+             default to EMAIL (issue #440)"
+        );
+    }
+
+    /// Sibling shape: post-#3463 raw enum identifier carrying the bare
+    /// DSL alias spelling (`dns`) may reach the provider without
+    /// canonicalization when host-side resolution fails for any reason.
+    /// The extract→parse chain must still recover the validation method
+    /// rather than silently dropping it.
+    ///
+    /// This assertion goes through the production
+    /// `helpers::optional_enum_attr` path so helper regressions are caught here.
+    #[test]
+    fn validation_method_enum_identifier_reaches_request() {
+        let mut resource = Resource::with_provider("aws", "acm.Certificate", "test-cert", None);
+        resource.set_attr(
+            "validation_method".to_string(),
+            Value::Concrete(ConcreteValue::enum_identifier("dns")),
+        );
+        let parsed = crate::helpers::optional_enum_attr(&resource, "validation_method")
+            .and_then(parse_validation_method);
+        assert_eq!(
+            parsed,
+            Some(ValidationMethod::Dns),
+            "validation_method EnumIdentifier(\"dns\") must extract to \
+             ValidationMethod::Dns; the parser-emitted enum identifier \
+             shape must not be silently dropped"
+        );
+    }
+
+    /// Quoted-string DSL form `validation_method = 'DNS'` continues to
+    /// work — pin it so the enum-variant additions above can't regress
+    /// the documented example in `examples/acm_certificate/main.crn`.
+    ///
+    /// This assertion goes through the production
+    /// `helpers::optional_enum_attr` path so helper regressions are caught here.
+    #[test]
+    fn validation_method_string_still_reaches_request() {
+        let mut resource = Resource::with_provider("aws", "acm.Certificate", "test-cert", None);
+        resource.set_attr(
+            "validation_method".to_string(),
+            Value::Concrete(ConcreteValue::String("DNS".to_string())),
+        );
+        let parsed = crate::helpers::optional_enum_attr(&resource, "validation_method")
+            .and_then(parse_validation_method);
+        assert_eq!(parsed, Some(ValidationMethod::Dns));
     }
 
     #[test]

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::resource::{Resource, ResourceId, State};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
+use crate::helpers::optional_enum_attr;
 
 impl AwsProvider {
     /// Read an EC2 Elastic IP
@@ -61,9 +62,9 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_eip(&self, resource: &Resource) -> ProviderResult<State> {
         let mut req = self.ec2_client.allocate_address();
 
-        if let Some(Value::Concrete(ConcreteValue::String(domain))) = resource.get_attr("domain") {
+        if let Some(domain) = optional_enum_attr(resource, "domain") {
             use aws_sdk_ec2::types::DomainType;
-            req = req.domain(DomainType::from(domain.as_str()));
+            req = req.domain(DomainType::from(domain));
         } else {
             // Default to VPC
             req = req.domain(aws_sdk_ec2::types::DomainType::Vpc);

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::build_tag_specification;
+use crate::helpers::{build_tag_specification, optional_enum_attr, require_enum_attr};
 
 impl AwsProvider {
     /// Read an EC2 Flow Log
@@ -95,13 +95,7 @@ impl AwsProvider {
             .for_resource(resource.id.clone()));
         }
 
-        let resource_type_val = match resource.get_attr("resource_type") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
-            _ => {
-                return Err(ProviderError::invalid_input("resource_type is required")
-                    .for_resource(resource.id.clone()));
-            }
-        };
+        let resource_type_val = require_enum_attr(resource, "resource_type")?;
 
         let mut req = self
             .ec2_client
@@ -111,18 +105,14 @@ impl AwsProvider {
                 resource_type_val.as_str(),
             ));
 
-        if let Some(Value::Concrete(ConcreteValue::String(traffic_type))) =
-            resource.get_attr("traffic_type")
-        {
+        if let Some(traffic_type) = optional_enum_attr(resource, "traffic_type") {
             use aws_sdk_ec2::types::TrafficType;
-            req = req.traffic_type(TrafficType::from(traffic_type.as_str()));
+            req = req.traffic_type(TrafficType::from(traffic_type));
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(log_dest_type))) =
-            resource.get_attr("log_destination_type")
-        {
+        if let Some(log_dest_type) = optional_enum_attr(resource, "log_destination_type") {
             use aws_sdk_ec2::types::LogDestinationType;
-            req = req.log_destination_type(LogDestinationType::from(log_dest_type.as_str()));
+            req = req.log_destination_type(LogDestinationType::from(log_dest_type));
         }
 
         if let Some(Value::Concrete(ConcreteValue::String(log_dest))) =

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -8,7 +8,8 @@ use aws_sdk_ec2::types::NatGatewayState;
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{
-    PollState, RetryPolicy, require_string_attr, retry_aws_operation, wait_for_ec2_state,
+    PollState, RetryPolicy, optional_enum_attr, require_string_attr, retry_aws_operation,
+    wait_for_ec2_state,
 };
 
 impl AwsProvider {
@@ -86,11 +87,9 @@ impl AwsProvider {
             req = req.allocation_id(alloc_id);
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(conn_type))) =
-            resource.get_attr("connectivity_type")
-        {
+        if let Some(conn_type) = optional_enum_attr(resource, "connectivity_type") {
             use aws_sdk_ec2::types::ConnectivityType;
-            req = req.connectivity_type(ConnectivityType::from(conn_type.as_str()));
+            req = req.connectivity_type(ConnectivityType::from(conn_type));
         }
 
         let rid = resource.id.clone();

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{PollState, build_tag_specification, wait_for_ec2_state};
+use crate::helpers::{PollState, build_tag_specification, optional_enum_attr, wait_for_ec2_state};
 
 impl AwsProvider {
     /// Read an EC2 Transit Gateway
@@ -82,46 +82,36 @@ impl AwsProvider {
             has_options = true;
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(v))) =
-            resource.get_attr("auto_accept_shared_attachments")
-        {
+        if let Some(v) = optional_enum_attr(resource, "auto_accept_shared_attachments") {
             use aws_sdk_ec2::types::AutoAcceptSharedAttachmentsValue;
-            options = options
-                .auto_accept_shared_attachments(AutoAcceptSharedAttachmentsValue::from(v.as_str()));
+            options =
+                options.auto_accept_shared_attachments(AutoAcceptSharedAttachmentsValue::from(v));
             has_options = true;
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(v))) =
-            resource.get_attr("default_route_table_association")
-        {
+        if let Some(v) = optional_enum_attr(resource, "default_route_table_association") {
             use aws_sdk_ec2::types::DefaultRouteTableAssociationValue;
-            options = options.default_route_table_association(
-                DefaultRouteTableAssociationValue::from(v.as_str()),
-            );
+            options =
+                options.default_route_table_association(DefaultRouteTableAssociationValue::from(v));
             has_options = true;
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(v))) =
-            resource.get_attr("default_route_table_propagation")
-        {
+        if let Some(v) = optional_enum_attr(resource, "default_route_table_propagation") {
             use aws_sdk_ec2::types::DefaultRouteTablePropagationValue;
-            options = options.default_route_table_propagation(
-                DefaultRouteTablePropagationValue::from(v.as_str()),
-            );
+            options =
+                options.default_route_table_propagation(DefaultRouteTablePropagationValue::from(v));
             has_options = true;
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(v))) = resource.get_attr("dns_support") {
+        if let Some(v) = optional_enum_attr(resource, "dns_support") {
             use aws_sdk_ec2::types::DnsSupportValue;
-            options = options.dns_support(DnsSupportValue::from(v.as_str()));
+            options = options.dns_support(DnsSupportValue::from(v));
             has_options = true;
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(v))) =
-            resource.get_attr("vpn_ecmp_support")
-        {
+        if let Some(v) = optional_enum_attr(resource, "vpn_ecmp_support") {
             use aws_sdk_ec2::types::VpnEcmpSupportValue;
-            options = options.vpn_ecmp_support(VpnEcmpSupportValue::from(v.as_str()));
+            options = options.vpn_ecmp_support(VpnEcmpSupportValue::from(v));
             has_options = true;
         }
 

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
+use crate::helpers::{RetryPolicy, optional_enum_attr, require_string_attr, retry_aws_operation};
 
 impl AwsProvider {
     /// Read an EC2 VPC
@@ -96,10 +96,8 @@ impl AwsProvider {
         let mut create_vpc_builder = self.ec2_client.create_vpc().cidr_block(&cidr_block);
 
         // Handle instance_tenancy if specified
-        if let Some(Value::Concrete(ConcreteValue::String(tenancy))) =
-            resource.get_attr("instance_tenancy")
-        {
-            let tenancy_enum = match tenancy.as_str() {
+        if let Some(tenancy) = optional_enum_attr(resource, "instance_tenancy") {
+            let tenancy_enum = match tenancy {
                 "dedicated" => aws_sdk_ec2::types::Tenancy::Dedicated,
                 "host" => aws_sdk_ec2::types::Tenancy::Host,
                 _ => aws_sdk_ec2::types::Tenancy::Default,

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
+use crate::helpers::{RetryPolicy, optional_enum_attr, require_string_attr, retry_aws_operation};
 
 impl AwsProvider {
     /// Read an EC2 VPC Endpoint
@@ -74,11 +74,9 @@ impl AwsProvider {
             .vpc_id(&vpc_id)
             .service_name(&service_name);
 
-        if let Some(Value::Concrete(ConcreteValue::String(ep_type))) =
-            resource.get_attr("vpc_endpoint_type")
-        {
+        if let Some(ep_type) = optional_enum_attr(resource, "vpc_endpoint_type") {
             use aws_sdk_ec2::types::VpcEndpointType;
-            req = req.vpc_endpoint_type(VpcEndpointType::from(ep_type.as_str()));
+            req = req.vpc_endpoint_type(VpcEndpointType::from(ep_type));
         }
 
         if let Some(Value::Concrete(ConcreteValue::List(ids))) =

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -5,6 +5,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_enum_attr;
 
 impl AwsProvider {
     /// Read an EC2 VPN Gateway
@@ -70,13 +71,7 @@ impl AwsProvider {
         &self,
         resource: &Resource,
     ) -> ProviderResult<State> {
-        let gw_type = match resource.get_attr("type") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
-            _ => {
-                return Err(ProviderError::invalid_input("type is required")
-                    .for_resource(resource.id.clone()));
-            }
-        };
+        let gw_type = require_enum_attr(resource, "type")?;
 
         let mut req = self
             .ec2_client

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -6,7 +6,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::require_string_attr;
+use crate::helpers::{optional_enum_attr, require_string_attr};
 
 impl AwsProvider {
     /// Read a CloudWatch Logs Log Group
@@ -126,11 +126,9 @@ impl AwsProvider {
             req = req.kms_key_id(kms_key);
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(class))) =
-            resource.get_attr("log_group_class")
-        {
+        if let Some(class) = optional_enum_attr(resource, "log_group_class") {
             use aws_sdk_cloudwatchlogs::types::LogGroupClass;
-            req = req.log_group_class(LogGroupClass::from(class.as_str()));
+            req = req.log_group_class(LogGroupClass::from(class));
         }
 
         if let Some(Value::Concrete(ConcreteValue::Map(tag_map))) = resource.get_attr("tags") {

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -6,7 +6,9 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{PollState, require_string_attr, sdk_error_message, wait_for_ec2_state};
+use crate::helpers::{
+    PollState, optional_enum_attr, require_string_attr, sdk_error_message, wait_for_ec2_state,
+};
 
 impl AwsProvider {
     /// Extract attributes from an Organizations Account object
@@ -171,11 +173,8 @@ impl AwsProvider {
             .account_name(&name)
             .email(&email);
 
-        if let Some(Value::Concrete(ConcreteValue::String(iam_billing))) =
-            resource.get_attr("iam_user_access_to_billing")
-        {
-            let val =
-                aws_sdk_organizations::types::IamUserAccessToBilling::from(iam_billing.as_str());
+        if let Some(iam_billing) = optional_enum_attr(resource, "iam_user_access_to_billing") {
+            let val = aws_sdk_organizations::types::IamUserAccessToBilling::from(iam_billing);
             req = req.iam_user_access_to_billing(val);
         }
 

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -5,6 +5,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
+use crate::helpers::optional_enum_attr;
 
 impl AwsProvider {
     /// Extract attributes from an Organizations Organization object
@@ -110,11 +111,8 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         let mut req = self.organizations_client.create_organization();
 
-        if let Some(Value::Concrete(ConcreteValue::String(feature_set))) =
-            resource.get_attr("feature_set")
-        {
-            let fs =
-                aws_sdk_organizations::types::OrganizationFeatureSet::from(feature_set.as_str());
+        if let Some(feature_set) = optional_enum_attr(resource, "feature_set") {
+            let fs = aws_sdk_organizations::types::OrganizationFeatureSet::from(feature_set);
             req = req.feature_set(fs);
         }
 

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -545,6 +545,31 @@ mod tests {
     }
 
     #[test]
+    fn build_record_set_accepts_canonical_enum_type() {
+        use carina_core::schema::{AttributeType, Schema, enum_identity};
+
+        let attr_type = AttributeType::enum_(
+            enum_identity("RrType", Some("aws.route53.RecordSet")),
+            Some(vec!["A".to_string(), "AAAA".to_string()]),
+            vec![
+                ("A".to_string(), "a".to_string()),
+                ("AAAA".to_string(), "aaaa".to_string()),
+            ],
+            None,
+            None,
+        );
+        let schema = Schema::flat(attr_type);
+        let canonical =
+            schema.canonicalize(Value::Concrete(ConcreteValue::enum_identifier("aaaa")));
+
+        let mut r = record_set("registry.example.com");
+        r.set_attr("type".to_string(), canonical);
+        let record_set = build_record_set(&r).expect("canonical enum type should build");
+
+        assert_eq!(record_set.r#type().as_str(), "AAAA");
+    }
+
+    #[test]
     fn strips_trailing_dot_on_alias_target_dns_name() {
         let mut r = record_set("alias.example.com");
         let mut alias: IndexMap<String, Value> = IndexMap::new();

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
 use aws_sdk_s3::types::{BucketCannedAcl, Grant, Permission, Type as GranteeType};
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::ProviderResult;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
+use crate::helpers::{RetryPolicy, require_enum_attr, require_string_attr, retry_aws_operation};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 /// AWS group URIs used to identify canned-ACL grant patterns.
@@ -164,14 +164,7 @@ impl AwsProvider {
         bucket: &str,
         resource: &Resource,
     ) -> ProviderResult<State> {
-        let acl_str = match resource.get_attr("acl") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => s.to_string(),
-            _ => {
-                return Err(
-                    ProviderError::invalid_input("acl is required").for_resource(id.clone())
-                );
-            }
-        };
+        let acl_str = require_enum_attr(resource, "acl")?;
 
         self.s3_client
             .put_bucket_acl()

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -6,7 +6,9 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{
+    RetryPolicy, require_enum_attr, require_string_attr, retry_aws_operation, sdk_error_message,
+};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -87,13 +89,7 @@ impl AwsProvider {
         bucket: &str,
         resource: &Resource,
     ) -> ProviderResult<State> {
-        let ownership_str = match resource.get_attr("object_ownership") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
-            _ => {
-                return Err(ProviderError::invalid_input("object_ownership is required")
-                    .for_resource(id.clone()));
-            }
-        };
+        let ownership_str = require_enum_attr(resource, "object_ownership")?;
 
         let rule = OwnershipControlsRule::builder()
             .object_ownership(ObjectOwnership::from(ownership_str.as_str()))

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -2,10 +2,12 @@ use std::collections::HashMap;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
+use crate::helpers::{
+    RetryPolicy, optional_enum_attr, require_enum_attr, require_string_attr, retry_aws_operation,
+};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 use aws_sdk_s3::types::{BucketVersioningStatus, MfaDelete, VersioningConfiguration};
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::ProviderResult;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 impl AwsProvider {
@@ -91,19 +93,12 @@ impl AwsProvider {
         bucket: &str,
         resource: &Resource,
     ) -> ProviderResult<State> {
-        let status_str = match resource.get_attr("status") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
-            _ => {
-                return Err(
-                    ProviderError::invalid_input("status is required").for_resource(id.clone())
-                );
-            }
-        };
+        let status_str = require_enum_attr(resource, "status")?;
         let status = BucketVersioningStatus::from(status_str.as_str());
 
         let mut config_builder = VersioningConfiguration::builder().status(status);
-        if let Some(Value::Concrete(ConcreteValue::String(s))) = resource.get_attr("mfa_delete") {
-            config_builder = config_builder.mfa_delete(MfaDelete::from(s.as_str()));
+        if let Some(s) = optional_enum_attr(resource, "mfa_delete") {
+            config_builder = config_builder.mfa_delete(MfaDelete::from(s));
         }
 
         self.s3_client


### PR DESCRIPTION
## Summary

`aws.acm.Certificate` with `validation_method = dns` was reaching AWS as the `EMAIL` default. The provider canonicalizes schema-typed enum values into `ConcreteValue::CanonicalEnum`, but the local ACM `extract_string` and the shared `helpers::require_enum_attr` only matched `ConcreteValue::String`. The SDK `.validation_method(...)` call was silently skipped, AWS defaulted to `EMAIL`, state read back `EMAIL`, and every plan thereafter showed a permanent `EMAIL → DNS (forces replacement)` diff. The replacement cert hit the same bug, so the loop never converged; downstream, the `for opt in cert.domain_validation_options` block evaluated to zero iterations and the DNS validation `wait` was unsatisfiable from the start.

## Root cause

The provider's `apply_desired_normalization` runs `canonicalize_resources_with_schemas`, which wraps schema-typed enum values as `ConcreteValue::CanonicalEnum` (carina#3438). Three `Value` shapes can legitimately reach a provider-side enum-attr read:

- `ConcreteValue::String(s)` — quoted-DSL form `validation_method = 'DNS'`, or a state-read echo.
- `ConcreteValue::EnumIdentifier(raw)` — bare-DSL identifier `validation_method = dns` (post-carina#3463).
- `ConcreteValue::CanonicalEnum(c)` — the typed witness from canonicalize.

The previous extractors only matched the first. The other two were silently dropped — the #440 failure mode.

`helpers::require_enum_attr`'s old doc said it was "equivalent to `require_string_attr` today" because "Core rewrites every schema-known enum value to its AWS API-canonical spelling before the provider sees it". That claim was stale (carina#3438 introduced the typed `CanonicalEnum` witness specifically so the provider would receive a structured value, not a raw string). The stale claim is what let the helper happily reject the typed shape.

## Changes

**Helper layer** (`carina-provider-aws/src/helpers.rs`):

- `enum_attr_str` (`pub(crate)`) — single seam covering all three `Value` variants, returns the AWS API canonical string.
- `require_enum_attr` rewritten to use `enum_attr_str`; returns `ProviderResult<String>` and a clear `invalid_input` error on missing.
- `optional_enum_attr` — readability wrapper for optional enums (call-site intent distinct from `require_*`).
- Stale doc replaced with one that names every accepted shape and explicitly contrasts `value_as_str` / `require_string_attr` (still correct for non-enum string attributes).

**ACM** (`carina-provider-aws/src/services/acm/certificate.rs`):

- Delete the local `extract_string` (it duplicated `value_as_str` and was the immediate bug site).
- Route `validation_method`, `key_algorithm`, and `certificate_transparency_logging_preference` through the new helpers.

**Sweep** — every top-level enum-attribute read across the provider is now routed through the new helpers:

| Service | File |
|---|---|
| ACM | `services/acm/certificate.rs` |
| EC2 | `services/ec2/{eip, flow_log, nat_gateway, transit_gateway, vpc, vpc_endpoint, vpn_gateway}.rs` |
| Logs | `services/logs/log_group.rs` |
| Organizations | `services/organizations/{account, organization}.rs` |
| Route 53 | `services/route53/record_set.rs` |
| S3 | `services/s3/{bucket_acl, bucket_ownership_controls, bucket_versioning}.rs` |

## Tests

- `helpers.rs` — 11 new tests cover String / EnumIdentifier / CanonicalEnum / missing / non-enum-shape across both `require_enum_attr` and `optional_enum_attr`. `CanonicalEnum` values are built via `Schema::flat(AttributeType::enum_(...)).canonicalize(...)` so the test exercises the real canonicalize path.
- `services/acm/certificate.rs` — three end-to-end tests trace the issue's reproducer:
  - `validation_method_canonical_enum_reaches_request` — post-canonicalize shape `CanonicalEnum("DNS")` → `optional_enum_attr` → `parse_validation_method` = `Some(Dns)`.
  - `validation_method_enum_identifier_reaches_request` — un-canonicalized fallthrough shape `EnumIdentifier("dns")` → same chain → `Some(Dns)`.
  - `validation_method_string_still_reaches_request` — pins the quoted-DSL `'DNS'` form (the documented example in `examples/acm_certificate/main.crn`).
- `services/route53/record_set.rs` — `build_record_set_accepts_canonical_enum_type` pins that `CanonicalEnum` reaches the SDK for an existing `require_enum_attr` consumer.

All three ACM tests call the production helper (`crate::helpers::optional_enum_attr`), so a future regression in the helper turns the acceptance tests red.

## Verify

```
cargo check -p carina-provider-aws                          # green
cargo nextest run -p carina-provider-aws                    # 270 passed, 0 failed
cargo test -p carina-provider-aws --doc                     # green
cargo clippy --workspace --all-targets -- -D warnings       # green
bash scripts/check-examples.sh                              # green
bash scripts/check-string-enum-aliases.sh                   # green
```

## Out of scope (filed separately)

- carina-provider-aws#441 — `ec2.TransitGateway` reads `options { dns_support / vpn_ecmp_support / auto_accept_shared_attachments / ... }` as top-level keys, but the schema declares them as `StructField`s inside the `options` struct. The DSL spelling matching the schema is silently ignored. Same shape of bug as #440 (provider↔schema shape mismatch), different mechanism (struct-field nesting); pre-existing, preserved by the sweep.
- carina-provider-aws#442 — `acm.Certificate.update_acm_certificate` reads `certificate_transparency_logging_preference` at top level, but the schema declares it inside the `options` struct. `UpdateCertificateOptions` is never called for the CT-logging path. Same class as #441; pre-existing.
- carina-rs/carina#3555 — typed `Resource::get_enum_attr` accessor so the raw `Value` path becomes statically unreachable for enum-typed attributes. The current PR closes #440 at the helper layer (the right seam carina-provider-aws controls); the type-safety hazard remaining is that a future contributor can still write `match resource.get_attr("foo") { Some(Value::Concrete(ConcreteValue::String(s))) => ... }` and re-introduce the bug class. Closing that requires a carina-core API change.

Closes #440
