### PR TITLE
fix(ec2,acm): walk nested options struct correctly across codegen + service code (#441, #442)

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -2174,6 +2174,21 @@ fn struct_child_value_expr(
             "Value::Concrete(ConcreteValue::String({}.as_str().to_string()))",
             value_var
         ),
+        ShapeKind::List => {
+            let element_kind = match model.get_shape(&child_ref.target) {
+                Some(carina_smithy::Shape::List(list_shape)) => {
+                    model.shape_kind(&list_shape.member.target)
+                }
+                _ => None,
+            };
+            if !matches!(element_kind, Some(ShapeKind::String)) {
+                return None;
+            }
+            format!(
+                "Value::Concrete(ConcreteValue::List({}.iter().map(|s| Value::Concrete(ConcreteValue::String(s.to_string()))).collect()))",
+                value_var
+            )
+        }
         _ => return None,
     };
     Some(expr)
@@ -3067,6 +3082,7 @@ fn generate_provider_code(
                             continue;
                         };
                         let child_snake = escape_rust_keyword(&child_name.to_snake_case());
+                        let child_kind = model.shape_kind(&child_ref.target);
                         let Some(insert_expr) = struct_child_value_expr(model, child_ref, "v")
                         else {
                             eprintln!(
@@ -3075,12 +3091,24 @@ fn generate_provider_code(
                             );
                             continue;
                         };
-                        code.push_str(&format!(
-                            "\x20           if let Some(v) = dns_opts.{}() {{\n\
-                             \x20               fields.insert(\"{}\".to_string(), {});\n\
-                             \x20           }}\n",
-                            child_snake, child_snake, insert_expr
-                        ));
+                        if matches!(child_kind, Some(ShapeKind::List)) {
+                            code.push_str(&format!(
+                                "\x20           {{\n\
+                                 \x20               let v = dns_opts.{}();\n\
+                                 \x20               if !v.is_empty() {{\n\
+                                 \x20                   fields.insert(\"{}\".to_string(), {});\n\
+                                 \x20               }}\n\
+                                 \x20           }}\n",
+                                child_snake, child_snake, insert_expr
+                            ));
+                        } else {
+                            code.push_str(&format!(
+                                "\x20           if let Some(v) = dns_opts.{}() {{\n\
+                                 \x20               fields.insert(\"{}\".to_string(), {});\n\
+                                 \x20           }}\n",
+                                child_snake, child_snake, insert_expr
+                            ));
+                        }
                     }
                     code.push_str(&format!(
                         "\x20           if !fields.is_empty() {{\n\
@@ -5190,7 +5218,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_ec2_transit_gateway_attachment_emits_list_of_string_for_subnet_ids() {
+    fn extract_ec2_transit_gateway_attachment_emits_subnet_ids_and_struct_as_map_options() {
         let res = resource_defs::ec2_resources()
             .into_iter()
             .find(|r| r.name == "ec2.TransitGatewayAttachment")
@@ -5205,6 +5233,26 @@ mod tests {
         assert!(
             code.contains("attributes.insert(\"subnet_ids\".to_string(), Value::Concrete(ConcreteValue::List(list)));"),
             "must insert subnet_ids as Value::List: {code}"
+        );
+        assert!(
+            code.contains("if let Some(dns_opts) = obj.options() {"),
+            "must walk obj.options() as a StructAsMap source: {code}"
+        );
+        assert!(
+            code.contains("let mut fields = IndexMap::new();"),
+            "must build nested options fields map: {code}"
+        );
+        assert!(
+            code.contains("if let Some(v) = dns_opts.dns_support()"),
+            "dns_support must read from options map source: {code}"
+        );
+        assert!(
+            code.contains("fields.insert(\"dns_support\".to_string(), Value::Concrete(ConcreteValue::String(v.as_str().to_string())));"),
+            "dns_support must insert inside fields map: {code}"
+        );
+        assert!(
+            code.contains("attributes.insert(\"options\".to_string(), Value::Concrete(ConcreteValue::Map(fields)));"),
+            "must insert nested options map: {code}"
         );
     }
 
@@ -5238,7 +5286,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_ec2_transit_gateway_emits_struct_nested_options() {
+    fn extract_ec2_transit_gateway_emits_struct_as_map_options() {
         let res = resource_defs::ec2_resources()
             .into_iter()
             .find(|r| r.name == "ec2.TransitGateway")
@@ -5247,30 +5295,39 @@ mod tests {
             return;
         };
 
-        // Each child of obj.options() lands as its own top-level attribute.
+        // Each child of obj.options() lands inside a nested `options`
+        // map matching the schema struct.
         // Pin one numeric (amazon_side_asn) and one enum (dns_support) to
         // exercise both Int and Enum emission paths.
         assert!(
-            code.contains("if let Some(opts) = obj.options()\n            && let Some(v) = opts.amazon_side_asn()"),
-            "amazon_side_asn must walk obj.options(): {code}"
+            code.contains("if let Some(dns_opts) = obj.options() {"),
+            "must walk obj.options() as a StructAsMap source: {code}"
+        );
+        assert!(
+            code.contains("let mut fields = IndexMap::new();"),
+            "must build nested options fields map: {code}"
+        );
+        assert!(
+            code.contains("if let Some(v) = dns_opts.amazon_side_asn()"),
+            "amazon_side_asn must read from options map source: {code}"
         );
         assert!(
             // amazon_side_asn is Smithy `Long`, so the SDK getter returns
             // i64 directly — no widening cast.
-            code.contains("attributes.insert(\"amazon_side_asn\".to_string(), Value::Concrete(ConcreteValue::Int(v)));"),
-            "amazon_side_asn must insert as Int: {code}"
+            code.contains("fields.insert(\"amazon_side_asn\".to_string(), Value::Concrete(ConcreteValue::Int(v)));"),
+            "amazon_side_asn must insert as Int inside fields map: {code}"
         );
         assert!(
-            code.contains(
-                "if let Some(opts) = obj.options()\n            && let Some(v) = opts.dns_support()"
-            ),
-            "dns_support must walk obj.options(): {code}"
+            code.contains("if let Some(v) = dns_opts.dns_support()"),
+            "dns_support must read from options map source: {code}"
         );
         assert!(
-            code.contains(
-                "attributes.insert(\"dns_support\".to_string(), Value::Concrete(ConcreteValue::String(v.as_str().to_string())));"
-            ),
-            "dns_support must insert as enum-as-String: {code}"
+            code.contains("fields.insert(\"dns_support\".to_string(), Value::Concrete(ConcreteValue::String(v.as_str().to_string())));"),
+            "dns_support must insert as enum-as-String inside fields map: {code}"
+        );
+        assert!(
+            code.contains("attributes.insert(\"options\".to_string(), Value::Concrete(ConcreteValue::Map(fields)));"),
+            "must insert nested options map: {code}"
         );
     }
 

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -919,52 +919,24 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
             // The TransitGatewayRequestOptions sub-struct on the response
-            // is flattened into top-level attributes (matching the DSL
-            // surface, which doesn't expose `options` as a nested struct).
-            derived_attributes: vec![
-                DerivedAttribute {
-                    attr: "AmazonSideAsn",
-                    source: DerivedSource::Struct {
-                        struct_member: "Options",
-                        child_member: "AmazonSideAsn",
-                    },
+            // is preserved as a nested Map matching the schema struct.
+            derived_attributes: vec![DerivedAttribute {
+                attr: "Options",
+                source: DerivedSource::StructAsMap {
+                    struct_member: "Options",
+                    children: &[
+                        "AmazonSideAsn",
+                        "AutoAcceptSharedAttachments",
+                        "DefaultRouteTableAssociation",
+                        "DefaultRouteTablePropagation",
+                        "DnsSupport",
+                        "MulticastSupport",
+                        "SecurityGroupReferencingSupport",
+                        "TransitGatewayCidrBlocks",
+                        "VpnEcmpSupport",
+                    ],
                 },
-                DerivedAttribute {
-                    attr: "AutoAcceptSharedAttachments",
-                    source: DerivedSource::Struct {
-                        struct_member: "Options",
-                        child_member: "AutoAcceptSharedAttachments",
-                    },
-                },
-                DerivedAttribute {
-                    attr: "DefaultRouteTableAssociation",
-                    source: DerivedSource::Struct {
-                        struct_member: "Options",
-                        child_member: "DefaultRouteTableAssociation",
-                    },
-                },
-                DerivedAttribute {
-                    attr: "DefaultRouteTablePropagation",
-                    source: DerivedSource::Struct {
-                        struct_member: "Options",
-                        child_member: "DefaultRouteTablePropagation",
-                    },
-                },
-                DerivedAttribute {
-                    attr: "DnsSupport",
-                    source: DerivedSource::Struct {
-                        struct_member: "Options",
-                        child_member: "DnsSupport",
-                    },
-                },
-                DerivedAttribute {
-                    attr: "VpnEcmpSupport",
-                    source: DerivedSource::Struct {
-                        struct_member: "Options",
-                        child_member: "VpnEcmpSupport",
-                    },
-                },
-            ],
+            }],
         },
         // ec2.transit_gateway_attachment
         ResourceDef {
@@ -994,7 +966,18 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             deferred_populate_struct_field_overrides: vec![],
             struct_field_type_overrides: vec![],
             read_shape_overrides: vec![],
-            derived_attributes: vec![],
+            derived_attributes: vec![DerivedAttribute {
+                attr: "Options",
+                source: DerivedSource::StructAsMap {
+                    struct_member: "Options",
+                    children: &[
+                        "ApplianceModeSupport",
+                        "DnsSupport",
+                        "Ipv6Support",
+                        "SecurityGroupReferencingSupport",
+                    ],
+                },
+            }],
         },
         // ec2.vpc_endpoint
         ResourceDef {

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -84,6 +84,106 @@ pub fn optional_enum_attr<'a>(resource: &'a Resource, attr_name: &str) -> Option
     enum_attr_str(resource, attr_name)
 }
 
+/// Return the AWS API canonical spelling for a schema-typed enum
+/// attribute that lives inside a nested struct attribute (the
+/// `Map`-shaped value at `struct_attr`). Accepts every `Value` shape the
+/// carina-core canonicalize pipeline can produce, matching
+/// [`enum_attr_str`].
+///
+/// Returns `None` when the outer struct attribute is absent or not a
+/// Map, when the field is absent inside the Map, or when the field's
+/// value is not an enum-shaped scalar. The carina-rs/carina-provider-aws#441
+/// / #442 failure mode was the provider reading a struct field at top
+/// level (`resource.get_attr("dns_support")`) rather than from inside
+/// its parent struct (`resource.get_attr("options")` -> Map ->
+/// `m.get("dns_support")`).
+pub(crate) fn enum_struct_field_str<'a>(
+    resource: &'a Resource,
+    struct_attr: &str,
+    field_name: &str,
+) -> Option<&'a str> {
+    let Some(Value::Concrete(ConcreteValue::Map(m))) = resource.get_attr(struct_attr) else {
+        return None;
+    };
+    match m.get(field_name)? {
+        Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
+        Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => Some(raw.as_str()),
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => Some(c.api_value()),
+        _ => None,
+    }
+}
+
+pub(crate) fn optional_enum_struct_field<'a>(
+    resource: &'a Resource,
+    struct_attr: &str,
+    field_name: &str,
+) -> Option<&'a str> {
+    enum_struct_field_str(resource, struct_attr, field_name)
+}
+
+/// Return the `i64` value of an `Int`-typed field inside the nested
+/// struct attribute `struct_attr`. Same shape contract as
+/// [`enum_struct_field_str`] (outer attribute must be a `Map`; missing
+/// outer/field returns `None`), narrowed to a single `Value` shape:
+/// `ConcreteValue::Int`. Anything else returns `None`.
+///
+/// Sibling of [`optional_enum_struct_field`]. The wider-shape variants
+/// the carina-core canonicalize pipeline could in principle produce
+/// (e.g. a Deferred unknown) are intentionally rejected — schema-typed
+/// `Int` attributes do not have a canonical-enum form to absorb, so
+/// there is nothing analogous to the three-variant enum coverage.
+/// carina-rs/carina-provider-aws#441 / #442.
+pub(crate) fn optional_int_struct_field(
+    resource: &Resource,
+    struct_attr: &str,
+    field_name: &str,
+) -> Option<i64> {
+    let Some(Value::Concrete(ConcreteValue::Map(m))) = resource.get_attr(struct_attr) else {
+        return None;
+    };
+    match m.get(field_name)? {
+        Value::Concrete(ConcreteValue::Int(i)) => Some(*i),
+        _ => None,
+    }
+}
+
+/// Return the `Vec<String>` value of a `List<String>`-typed field
+/// inside the nested struct attribute `struct_attr`. Accepts both
+/// `ConcreteValue::StringList` (the canonical shape after carina-core
+/// `canonicalize_resources_with_schemas` resolves a
+/// `string_or_list_of_strings` attribute) and `ConcreteValue::List` of
+/// `ConcreteValue::String` (the parser-emitted shape before
+/// canonicalization). Anything else, including a list with any
+/// non-`String` element, returns `None`.
+///
+/// Same shape contract as [`enum_struct_field_str`] for the outer
+/// `Map`. Sibling of [`optional_enum_struct_field`] /
+/// [`optional_int_struct_field`]; the `List<NonString>` case is
+/// intentionally rejected — schema-typed `List<String>` is the only
+/// inner-list shape this PR's seam covers, and a non-string element
+/// indicates schema/value mismatch upstream.
+/// carina-rs/carina-provider-aws#441 / #442.
+pub(crate) fn optional_string_list_struct_field(
+    resource: &Resource,
+    struct_attr: &str,
+    field_name: &str,
+) -> Option<Vec<String>> {
+    let Some(Value::Concrete(ConcreteValue::Map(m))) = resource.get_attr(struct_attr) else {
+        return None;
+    };
+    match m.get(field_name)? {
+        Value::Concrete(ConcreteValue::StringList(items)) => Some(items.clone()),
+        Value::Concrete(ConcreteValue::List(items)) => items
+            .iter()
+            .map(|item| match item {
+                Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => None,
+    }
+}
+
 /// Build an EC2 `TagSpecification` from DSL tags for a given resource type.
 ///
 /// Returns `None` if the resource has no `tags` attribute.
@@ -381,6 +481,15 @@ mod tests {
         resource
     }
 
+    fn make_resource_with_struct_field(field_name: &str, value: Value) -> Resource {
+        make_resource_with_value(
+            "options",
+            Value::Concrete(ConcreteValue::Map(
+                [(field_name.to_string(), value)].into_iter().collect(),
+            )),
+        )
+    }
+
     fn canonical_validation_method_value() -> Value {
         use carina_core::schema::{AttributeType, Schema, enum_identity};
 
@@ -541,6 +650,191 @@ mod tests {
     fn test_optional_enum_attr_non_enum_shape_is_none() {
         let resource = make_resource_with_value("type", Value::Concrete(ConcreteValue::Bool(true)));
         assert_eq!(optional_enum_attr(&resource, "type"), None);
+    }
+
+    #[test]
+    fn test_optional_enum_struct_field_string() {
+        let resource = make_resource_with_struct_field(
+            "certificate_transparency_logging_preference",
+            Value::Concrete(ConcreteValue::String("ENABLED".to_string())),
+        );
+        assert_eq!(
+            optional_enum_struct_field(
+                &resource,
+                "options",
+                "certificate_transparency_logging_preference"
+            ),
+            Some("ENABLED")
+        );
+    }
+
+    #[test]
+    fn test_optional_enum_struct_field_enum_identifier() {
+        let resource = make_resource_with_struct_field(
+            "certificate_transparency_logging_preference",
+            Value::Concrete(ConcreteValue::enum_identifier("enabled")),
+        );
+        assert_eq!(
+            optional_enum_struct_field(
+                &resource,
+                "options",
+                "certificate_transparency_logging_preference"
+            ),
+            Some("enabled")
+        );
+    }
+
+    #[test]
+    fn test_optional_enum_struct_field_canonical_enum() {
+        let resource = make_resource_with_struct_field(
+            "validation_method",
+            canonical_validation_method_value(),
+        );
+        assert_eq!(
+            optional_enum_struct_field(&resource, "options", "validation_method"),
+            Some("DNS")
+        );
+    }
+
+    #[test]
+    fn test_optional_int_struct_field_int() {
+        let resource = make_resource_with_struct_field(
+            "amazon_side_asn",
+            Value::Concrete(ConcreteValue::Int(64512)),
+        );
+        assert_eq!(
+            optional_int_struct_field(&resource, "options", "amazon_side_asn"),
+            Some(64512)
+        );
+    }
+
+    #[test]
+    fn test_optional_string_list_struct_field_string_list() {
+        let resource = make_resource_with_struct_field(
+            "transit_gateway_cidr_blocks",
+            Value::Concrete(ConcreteValue::StringList(vec!["10.0.0.0/24".to_string()])),
+        );
+        assert_eq!(
+            optional_string_list_struct_field(&resource, "options", "transit_gateway_cidr_blocks"),
+            Some(vec!["10.0.0.0/24".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_optional_string_list_struct_field_list_of_string() {
+        let resource = make_resource_with_struct_field(
+            "transit_gateway_cidr_blocks",
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("10.0.0.0/24".to_string()),
+            )])),
+        );
+        assert_eq!(
+            optional_string_list_struct_field(&resource, "options", "transit_gateway_cidr_blocks"),
+            Some(vec!["10.0.0.0/24".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_struct_field_helpers_missing_outer_struct_are_none() {
+        let resource = make_test_resource(vec![]);
+        assert_eq!(
+            optional_enum_struct_field(&resource, "options", "dns_support"),
+            None
+        );
+        assert_eq!(
+            optional_int_struct_field(&resource, "options", "amazon_side_asn"),
+            None
+        );
+        assert_eq!(
+            optional_string_list_struct_field(&resource, "options", "transit_gateway_cidr_blocks"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_struct_field_helpers_non_map_outer_struct_are_none() {
+        let resource = make_resource_with_value(
+            "options",
+            Value::Concrete(ConcreteValue::String("not-a-map".to_string())),
+        );
+        assert_eq!(
+            optional_enum_struct_field(&resource, "options", "dns_support"),
+            None
+        );
+        assert_eq!(
+            optional_int_struct_field(&resource, "options", "amazon_side_asn"),
+            None
+        );
+        assert_eq!(
+            optional_string_list_struct_field(&resource, "options", "transit_gateway_cidr_blocks"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_struct_field_helpers_missing_field_are_none() {
+        let resource = make_resource_with_value(
+            "options",
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+        );
+        assert_eq!(
+            optional_enum_struct_field(&resource, "options", "dns_support"),
+            None
+        );
+        assert_eq!(
+            optional_int_struct_field(&resource, "options", "amazon_side_asn"),
+            None
+        );
+        assert_eq!(
+            optional_string_list_struct_field(&resource, "options", "transit_gateway_cidr_blocks"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_struct_field_helpers_wrong_shape_are_none() {
+        let enum_resource = make_resource_with_struct_field(
+            "dns_support",
+            Value::Concrete(ConcreteValue::Bool(true)),
+        );
+        let int_resource = make_resource_with_struct_field(
+            "amazon_side_asn",
+            Value::Concrete(ConcreteValue::String("64512".to_string())),
+        );
+        let list_resource = make_resource_with_struct_field(
+            "transit_gateway_cidr_blocks",
+            Value::Concrete(ConcreteValue::Int(1)),
+        );
+        let mixed_list_resource = make_resource_with_struct_field(
+            "transit_gateway_cidr_blocks",
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(1),
+            )])),
+        );
+        assert_eq!(
+            optional_enum_struct_field(&enum_resource, "options", "dns_support"),
+            None
+        );
+        assert_eq!(
+            optional_int_struct_field(&int_resource, "options", "amazon_side_asn"),
+            None
+        );
+        assert_eq!(
+            optional_string_list_struct_field(
+                &list_resource,
+                "options",
+                "transit_gateway_cidr_blocks"
+            ),
+            None
+        );
+        assert_eq!(
+            optional_string_list_struct_field(
+                &mixed_list_resource,
+                "options",
+                "transit_gateway_cidr_blocks"
+            ),
+            None
+        );
     }
 
     #[test]

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -630,53 +630,75 @@ impl AwsProvider {
                 Value::Concrete(ConcreteValue::String(v.to_string())),
             );
         }
-        if let Some(opts) = obj.options()
-            && let Some(v) = opts.amazon_side_asn()
-        {
-            attributes.insert(
-                "amazon_side_asn".to_string(),
-                Value::Concrete(ConcreteValue::Int(v)),
-            );
-        }
-        if let Some(opts) = obj.options()
-            && let Some(v) = opts.auto_accept_shared_attachments()
-        {
-            attributes.insert(
-                "auto_accept_shared_attachments".to_string(),
-                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
-            );
-        }
-        if let Some(opts) = obj.options()
-            && let Some(v) = opts.default_route_table_association()
-        {
-            attributes.insert(
-                "default_route_table_association".to_string(),
-                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
-            );
-        }
-        if let Some(opts) = obj.options()
-            && let Some(v) = opts.default_route_table_propagation()
-        {
-            attributes.insert(
-                "default_route_table_propagation".to_string(),
-                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
-            );
-        }
-        if let Some(opts) = obj.options()
-            && let Some(v) = opts.dns_support()
-        {
-            attributes.insert(
-                "dns_support".to_string(),
-                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
-            );
-        }
-        if let Some(opts) = obj.options()
-            && let Some(v) = opts.vpn_ecmp_support()
-        {
-            attributes.insert(
-                "vpn_ecmp_support".to_string(),
-                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
-            );
+        if let Some(dns_opts) = obj.options() {
+            let mut fields = IndexMap::new();
+            if let Some(v) = dns_opts.amazon_side_asn() {
+                fields.insert(
+                    "amazon_side_asn".to_string(),
+                    Value::Concrete(ConcreteValue::Int(v)),
+                );
+            }
+            if let Some(v) = dns_opts.auto_accept_shared_attachments() {
+                fields.insert(
+                    "auto_accept_shared_attachments".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if let Some(v) = dns_opts.default_route_table_association() {
+                fields.insert(
+                    "default_route_table_association".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if let Some(v) = dns_opts.default_route_table_propagation() {
+                fields.insert(
+                    "default_route_table_propagation".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if let Some(v) = dns_opts.dns_support() {
+                fields.insert(
+                    "dns_support".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if let Some(v) = dns_opts.multicast_support() {
+                fields.insert(
+                    "multicast_support".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if let Some(v) = dns_opts.security_group_referencing_support() {
+                fields.insert(
+                    "security_group_referencing_support".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            {
+                let v = dns_opts.transit_gateway_cidr_blocks();
+                if !v.is_empty() {
+                    fields.insert(
+                        "transit_gateway_cidr_blocks".to_string(),
+                        Value::Concrete(ConcreteValue::List(
+                            v.iter()
+                                .map(|s| Value::Concrete(ConcreteValue::String(s.to_string())))
+                                .collect(),
+                        )),
+                    );
+                }
+            }
+            if let Some(v) = dns_opts.vpn_ecmp_support() {
+                fields.insert(
+                    "vpn_ecmp_support".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if !fields.is_empty() {
+                attributes.insert(
+                    "options".to_string(),
+                    Value::Concrete(ConcreteValue::Map(fields)),
+                );
+            }
         }
         obj.transit_gateway_id().map(String::from)
     }
@@ -716,6 +738,39 @@ impl AwsProvider {
                 "vpc_id".to_string(),
                 Value::Concrete(ConcreteValue::String(v.to_string())),
             );
+        }
+        if let Some(dns_opts) = obj.options() {
+            let mut fields = IndexMap::new();
+            if let Some(v) = dns_opts.appliance_mode_support() {
+                fields.insert(
+                    "appliance_mode_support".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if let Some(v) = dns_opts.dns_support() {
+                fields.insert(
+                    "dns_support".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if let Some(v) = dns_opts.ipv6_support() {
+                fields.insert(
+                    "ipv6_support".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if let Some(v) = dns_opts.security_group_referencing_support() {
+                fields.insert(
+                    "security_group_referencing_support".to_string(),
+                    Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+                );
+            }
+            if !fields.is_empty() {
+                attributes.insert(
+                    "options".to_string(),
+                    Value::Concrete(ConcreteValue::Map(fields)),
+                );
+            }
         }
         obj.transit_gateway_attachment_id().map(String::from)
     }

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -20,7 +20,9 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{optional_enum_attr, require_string_attr, sdk_error_message};
+use crate::helpers::{
+    optional_enum_attr, optional_enum_struct_field, require_string_attr, sdk_error_message,
+};
 
 fn extract_string_list(value: &Value) -> Vec<String> {
     if let Value::Concrete(ConcreteValue::List(items)) = value {
@@ -92,6 +94,47 @@ fn parse_validation_method(input: &str) -> Option<ValidationMethod> {
     }
 }
 
+fn build_update_certificate_options(
+    resource: &Resource,
+) -> Option<aws_sdk_acm::types::CertificateOptions> {
+    let pref = optional_enum_struct_field(
+        resource,
+        "options",
+        "certificate_transparency_logging_preference",
+    )?;
+    Some(
+        aws_sdk_acm::types::CertificateOptions::builder()
+            .certificate_transparency_logging_preference(pref.into())
+            .build(),
+    )
+}
+
+fn build_create_certificate_options(
+    resource: &Resource,
+) -> Option<aws_sdk_acm::types::CertificateOptions> {
+    use aws_sdk_acm::types::{CertificateExport, CertificateTransparencyLoggingPreference};
+
+    let mut options = aws_sdk_acm::types::CertificateOptions::builder();
+    let mut has_options = false;
+
+    if let Some(pref) = optional_enum_struct_field(
+        resource,
+        "options",
+        "certificate_transparency_logging_preference",
+    ) {
+        options = options.certificate_transparency_logging_preference(
+            CertificateTransparencyLoggingPreference::from(pref),
+        );
+        has_options = true;
+    }
+    if let Some(export) = optional_enum_struct_field(resource, "options", "export") {
+        options = options.export(CertificateExport::from(export));
+        has_options = true;
+    }
+
+    has_options.then(|| options.build())
+}
+
 /// Map a `DescribeCertificate` `CertificateDetail` to Carina resource
 /// attributes. Pure (no AWS calls) so the attribute-key contract is
 /// unit-testable offline — tags are fetched separately by the caller.
@@ -142,6 +185,27 @@ fn certificate_detail_to_attributes(
             "renewal_eligibility".to_string(),
             Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
         );
+    }
+    if let Some(opts) = cert.options() {
+        let mut m: IndexMap<String, Value> = IndexMap::new();
+        if let Some(v) = opts.certificate_transparency_logging_preference() {
+            m.insert(
+                "certificate_transparency_logging_preference".to_string(),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+            );
+        }
+        if let Some(v) = opts.export() {
+            m.insert(
+                "export".to_string(),
+                Value::Concrete(ConcreteValue::String(v.as_str().to_string())),
+            );
+        }
+        if !m.is_empty() {
+            attributes.insert(
+                "options".to_string(),
+                Value::Concrete(ConcreteValue::Map(m)),
+            );
+        }
     }
     let sans = cert.subject_alternative_names();
     if !sans.is_empty() {
@@ -259,6 +323,9 @@ impl AwsProvider {
             // Pass the AWS canonical form through verbatim — schema
             // narrowing has already validated it.
             req = req.key_algorithm(key_algorithm.into());
+        }
+        if let Some(options) = build_create_certificate_options(resource) {
+            req = req.options(options);
         }
         // RequestCertificate accepts tags inline, avoiding a follow-up
         // AddTagsToCertificate round-trip on the create path.
@@ -425,15 +492,11 @@ impl AwsProvider {
         from: &State,
         to: Resource,
     ) -> ProviderResult<State> {
-        if let Some(pref) = optional_enum_attr(&to, "certificate_transparency_logging_preference") {
+        if let Some(options) = build_update_certificate_options(&to) {
             self.acm_client
                 .update_certificate_options()
                 .certificate_arn(identifier)
-                .options(
-                    aws_sdk_acm::types::CertificateOptions::builder()
-                        .certificate_transparency_logging_preference(pref.into())
-                        .build(),
-                )
+                .options(options)
                 .send()
                 .await
                 .map_err(|e| {
@@ -602,7 +665,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aws_sdk_acm::types::{CertificateDetail, DomainValidation, RecordType, ResourceRecord};
+    use aws_sdk_acm::types::{
+        CertificateDetail, CertificateExport, CertificateOptions,
+        CertificateTransparencyLoggingPreference, DomainValidation, RecordType, ResourceRecord,
+    };
     use std::sync::Mutex;
     use std::time::Duration;
 
@@ -681,6 +747,118 @@ mod tests {
             Some(&Value::Concrete(ConcreteValue::String(
                 "ISSUED".to_string()
             )))
+        );
+    }
+
+    #[test]
+    fn state_read_emits_nested_options_map_when_logging_preference_present() {
+        let cert = CertificateDetail::builder()
+            .domain_name("registry.example.com")
+            .options(
+                CertificateOptions::builder()
+                    .certificate_transparency_logging_preference(
+                        CertificateTransparencyLoggingPreference::Enabled,
+                    )
+                    .build(),
+            )
+            .build();
+
+        let attrs = certificate_detail_to_attributes(&cert);
+
+        let Some(Value::Concrete(ConcreteValue::Map(options))) = attrs.get("options") else {
+            panic!("expected nested options map, got {attrs:?}");
+        };
+        assert_eq!(
+            options.get("certificate_transparency_logging_preference"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "ENABLED".to_string()
+            )))
+        );
+    }
+
+    #[test]
+    fn certificate_detail_to_attributes_emits_nested_options_export() {
+        let cert = CertificateDetail::builder()
+            .domain_name("registry.example.com")
+            .options(
+                CertificateOptions::builder()
+                    .export(CertificateExport::Enabled)
+                    .build(),
+            )
+            .build();
+
+        let attrs = certificate_detail_to_attributes(&cert);
+
+        let Some(Value::Concrete(ConcreteValue::Map(options))) = attrs.get("options") else {
+            panic!("expected nested options map, got {attrs:?}");
+        };
+        assert_eq!(
+            options.get("export"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "ENABLED".to_string()
+            )))
+        );
+    }
+
+    #[test]
+    fn create_acm_certificate_passes_options_export_to_sdk_request() {
+        let mut options = IndexMap::new();
+        options.insert(
+            "export".to_string(),
+            Value::Concrete(ConcreteValue::String("ENABLED".to_string())),
+        );
+        let mut resource = Resource::with_provider("aws", "acm.Certificate", "test-cert", None);
+        resource.set_attr(
+            "options".to_string(),
+            Value::Concrete(ConcreteValue::Map(options)),
+        );
+
+        let request_options = build_create_certificate_options(&resource).expect("options");
+        assert_eq!(request_options.export(), Some(&CertificateExport::Enabled));
+    }
+
+    #[test]
+    fn create_acm_certificate_passes_both_options_fields() {
+        let mut options = IndexMap::new();
+        options.insert(
+            "certificate_transparency_logging_preference".to_string(),
+            Value::Concrete(ConcreteValue::String("DISABLED".to_string())),
+        );
+        options.insert(
+            "export".to_string(),
+            Value::Concrete(ConcreteValue::String("ENABLED".to_string())),
+        );
+        let mut resource = Resource::with_provider("aws", "acm.Certificate", "test-cert", None);
+        resource.set_attr(
+            "options".to_string(),
+            Value::Concrete(ConcreteValue::Map(options)),
+        );
+
+        let request_options = build_create_certificate_options(&resource).expect("options");
+        assert_eq!(
+            request_options.certificate_transparency_logging_preference(),
+            Some(&CertificateTransparencyLoggingPreference::Disabled)
+        );
+        assert_eq!(request_options.export(), Some(&CertificateExport::Enabled));
+    }
+
+    #[test]
+    fn update_reads_nested_options_certificate_transparency_logging_preference() {
+        let mut options = IndexMap::new();
+        options.insert(
+            "certificate_transparency_logging_preference".to_string(),
+            Value::Concrete(ConcreteValue::String("DISABLED".to_string())),
+        );
+        let mut resource = Resource::with_provider("aws", "acm.Certificate", "test-cert", None);
+        resource.set_attr(
+            "options".to_string(),
+            Value::Concrete(ConcreteValue::Map(options)),
+        );
+
+        let request_options = build_update_certificate_options(&resource).expect("options");
+        assert_eq!(
+            request_options.certificate_transparency_logging_preference(),
+            Some(&CertificateTransparencyLoggingPreference::Disabled)
         );
     }
 

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -5,7 +5,76 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{PollState, build_tag_specification, optional_enum_attr, wait_for_ec2_state};
+use crate::helpers::{
+    PollState, build_tag_specification, optional_enum_struct_field, optional_int_struct_field,
+    optional_string_list_struct_field, wait_for_ec2_state,
+};
+
+fn build_create_transit_gateway_options(
+    resource: &Resource,
+) -> Option<aws_sdk_ec2::types::TransitGatewayRequestOptions> {
+    use aws_sdk_ec2::types::{
+        AutoAcceptSharedAttachmentsValue, DefaultRouteTableAssociationValue,
+        DefaultRouteTablePropagationValue, DnsSupportValue, MulticastSupportValue,
+        SecurityGroupReferencingSupportValue, VpnEcmpSupportValue,
+    };
+
+    let mut options = aws_sdk_ec2::types::TransitGatewayRequestOptions::builder();
+    let mut has_options = false;
+
+    if let Some(asn) = optional_int_struct_field(resource, "options", "amazon_side_asn") {
+        options = options.amazon_side_asn(asn);
+        has_options = true;
+    }
+    if let Some(v) =
+        optional_enum_struct_field(resource, "options", "auto_accept_shared_attachments")
+    {
+        options = options.auto_accept_shared_attachments(AutoAcceptSharedAttachmentsValue::from(v));
+        has_options = true;
+    }
+    if let Some(v) =
+        optional_enum_struct_field(resource, "options", "default_route_table_association")
+    {
+        options =
+            options.default_route_table_association(DefaultRouteTableAssociationValue::from(v));
+        has_options = true;
+    }
+    if let Some(v) =
+        optional_enum_struct_field(resource, "options", "default_route_table_propagation")
+    {
+        options =
+            options.default_route_table_propagation(DefaultRouteTablePropagationValue::from(v));
+        has_options = true;
+    }
+    if let Some(v) = optional_enum_struct_field(resource, "options", "dns_support") {
+        options = options.dns_support(DnsSupportValue::from(v));
+        has_options = true;
+    }
+    if let Some(v) = optional_enum_struct_field(resource, "options", "multicast_support") {
+        options = options.multicast_support(MulticastSupportValue::from(v));
+        has_options = true;
+    }
+    if let Some(v) =
+        optional_enum_struct_field(resource, "options", "security_group_referencing_support")
+    {
+        options = options
+            .security_group_referencing_support(SecurityGroupReferencingSupportValue::from(v));
+        has_options = true;
+    }
+    if let Some(blocks) =
+        optional_string_list_struct_field(resource, "options", "transit_gateway_cidr_blocks")
+        && !blocks.is_empty()
+    {
+        options = options.set_transit_gateway_cidr_blocks(Some(blocks));
+        has_options = true;
+    }
+    if let Some(v) = optional_enum_struct_field(resource, "options", "vpn_ecmp_support") {
+        options = options.vpn_ecmp_support(VpnEcmpSupportValue::from(v));
+        has_options = true;
+    }
+
+    has_options.then(|| options.build())
+}
 
 impl AwsProvider {
     /// Read an EC2 Transit Gateway
@@ -72,51 +141,8 @@ impl AwsProvider {
             req = req.description(desc);
         }
 
-        // Build options
-        let mut options = aws_sdk_ec2::types::TransitGatewayRequestOptions::builder();
-        let mut has_options = false;
-
-        if let Some(Value::Concrete(ConcreteValue::Int(asn))) = resource.get_attr("amazon_side_asn")
-        {
-            options = options.amazon_side_asn(*asn);
-            has_options = true;
-        }
-
-        if let Some(v) = optional_enum_attr(resource, "auto_accept_shared_attachments") {
-            use aws_sdk_ec2::types::AutoAcceptSharedAttachmentsValue;
-            options =
-                options.auto_accept_shared_attachments(AutoAcceptSharedAttachmentsValue::from(v));
-            has_options = true;
-        }
-
-        if let Some(v) = optional_enum_attr(resource, "default_route_table_association") {
-            use aws_sdk_ec2::types::DefaultRouteTableAssociationValue;
-            options =
-                options.default_route_table_association(DefaultRouteTableAssociationValue::from(v));
-            has_options = true;
-        }
-
-        if let Some(v) = optional_enum_attr(resource, "default_route_table_propagation") {
-            use aws_sdk_ec2::types::DefaultRouteTablePropagationValue;
-            options =
-                options.default_route_table_propagation(DefaultRouteTablePropagationValue::from(v));
-            has_options = true;
-        }
-
-        if let Some(v) = optional_enum_attr(resource, "dns_support") {
-            use aws_sdk_ec2::types::DnsSupportValue;
-            options = options.dns_support(DnsSupportValue::from(v));
-            has_options = true;
-        }
-
-        if let Some(v) = optional_enum_attr(resource, "vpn_ecmp_support") {
-            use aws_sdk_ec2::types::VpnEcmpSupportValue;
-            options = options.vpn_ecmp_support(VpnEcmpSupportValue::from(v));
-            has_options = true;
-        }
-
-        if has_options {
-            req = req.options(options.build());
+        if let Some(options) = build_create_transit_gateway_options(resource) {
+            req = req.options(options);
         }
 
         // Apply tags via TagSpecifications
@@ -281,5 +307,228 @@ impl AwsProvider {
             "Transit gateway deletion failed",
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_ec2::types::{
+        AutoAcceptSharedAttachmentsValue, DefaultRouteTableAssociationValue,
+        DefaultRouteTablePropagationValue, DnsSupportValue, MulticastSupportValue,
+        SecurityGroupReferencingSupportValue, TransitGateway, TransitGatewayOptions,
+        VpnEcmpSupportValue,
+    };
+    use indexmap::IndexMap;
+
+    fn resource_with_options(options: IndexMap<String, Value>) -> Resource {
+        let mut resource = Resource::with_provider("aws", "ec2.TransitGateway", "test", None);
+        resource.set_attr(
+            "options".to_string(),
+            Value::Concrete(ConcreteValue::Map(options)),
+        );
+        resource
+    }
+
+    fn canonical_enable_disable(api_value: &str) -> Value {
+        use carina_core::schema::{AttributeType, Schema, enum_identity};
+
+        let attr_type = AttributeType::enum_(
+            enum_identity("EnableDisable", Some("aws.ec2.TransitGateway")),
+            Some(vec!["enable".to_string(), "disable".to_string()]),
+            vec![
+                ("enable".to_string(), "enable".to_string()),
+                ("disable".to_string(), "disable".to_string()),
+            ],
+            None,
+            None,
+        );
+        Schema::flat(attr_type)
+            .canonicalize(Value::Concrete(ConcreteValue::enum_identifier(api_value)))
+    }
+
+    fn one_enum_option(field: &str, value: Value) -> Resource {
+        resource_with_options([(field.to_string(), value)].into_iter().collect())
+    }
+
+    #[test]
+    fn create_reads_nested_options_dns_support_canonical_enum() {
+        let resource = one_enum_option("dns_support", canonical_enable_disable("disable"));
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(options.dns_support(), Some(&DnsSupportValue::Disable));
+    }
+
+    #[test]
+    fn create_reads_nested_options_vpn_ecmp_support() {
+        let resource = one_enum_option(
+            "vpn_ecmp_support",
+            Value::Concrete(ConcreteValue::String("enable".to_string())),
+        );
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(
+            options.vpn_ecmp_support(),
+            Some(&VpnEcmpSupportValue::Enable)
+        );
+    }
+
+    #[test]
+    fn create_reads_nested_options_multicast_support() {
+        let resource = one_enum_option(
+            "multicast_support",
+            Value::Concrete(ConcreteValue::String("enable".to_string())),
+        );
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(
+            options.multicast_support(),
+            Some(&MulticastSupportValue::Enable)
+        );
+    }
+
+    #[test]
+    fn create_reads_nested_options_security_group_referencing_support() {
+        let resource = one_enum_option(
+            "security_group_referencing_support",
+            Value::Concrete(ConcreteValue::String("enable".to_string())),
+        );
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(
+            options.security_group_referencing_support(),
+            Some(&SecurityGroupReferencingSupportValue::Enable)
+        );
+    }
+
+    #[test]
+    fn create_reads_nested_options_auto_accept_shared_attachments() {
+        let resource = one_enum_option(
+            "auto_accept_shared_attachments",
+            Value::Concrete(ConcreteValue::String("enable".to_string())),
+        );
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(
+            options.auto_accept_shared_attachments(),
+            Some(&AutoAcceptSharedAttachmentsValue::Enable)
+        );
+    }
+
+    #[test]
+    fn create_reads_nested_options_default_route_table_association() {
+        let resource = one_enum_option(
+            "default_route_table_association",
+            Value::Concrete(ConcreteValue::String("disable".to_string())),
+        );
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(
+            options.default_route_table_association(),
+            Some(&DefaultRouteTableAssociationValue::Disable)
+        );
+    }
+
+    #[test]
+    fn create_reads_nested_options_default_route_table_propagation() {
+        let resource = one_enum_option(
+            "default_route_table_propagation",
+            Value::Concrete(ConcreteValue::String("disable".to_string())),
+        );
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(
+            options.default_route_table_propagation(),
+            Some(&DefaultRouteTablePropagationValue::Disable)
+        );
+    }
+
+    #[test]
+    fn create_reads_nested_options_amazon_side_asn_int() {
+        let resource = resource_with_options(
+            [(
+                "amazon_side_asn".to_string(),
+                Value::Concrete(ConcreteValue::Int(64512)),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(options.amazon_side_asn(), Some(64512));
+    }
+
+    #[test]
+    fn create_reads_nested_options_transit_gateway_cidr_blocks_list() {
+        let resource = resource_with_options(
+            [(
+                "transit_gateway_cidr_blocks".to_string(),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::String("10.0.0.0/24".to_string()),
+                )])),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let options = build_create_transit_gateway_options(&resource).expect("options");
+        assert_eq!(options.transit_gateway_cidr_blocks(), ["10.0.0.0/24"]);
+    }
+
+    #[test]
+    fn create_tgw_skips_explicit_empty_cidr_blocks_list() {
+        let resource = resource_with_options(
+            [(
+                "transit_gateway_cidr_blocks".to_string(),
+                Value::Concrete(ConcreteValue::List(vec![])),
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        assert!(
+            build_create_transit_gateway_options(&resource).is_none(),
+            "an empty CIDR list must not cause the SDK request to carry options"
+        );
+    }
+
+    #[test]
+    fn state_read_emits_nested_options_map() {
+        let tgw = TransitGateway::builder()
+            .transit_gateway_id("tgw-123")
+            .options(
+                TransitGatewayOptions::builder()
+                    .dns_support(DnsSupportValue::Enable)
+                    .vpn_ecmp_support(VpnEcmpSupportValue::Disable)
+                    .transit_gateway_cidr_blocks("10.0.0.0/24")
+                    .build(),
+            )
+            .build();
+        let mut attrs = HashMap::new();
+        AwsProvider::extract_ec2_transit_gateway_attributes(&tgw, &mut attrs);
+
+        let Some(Value::Concrete(ConcreteValue::Map(options))) = attrs.get("options") else {
+            panic!("expected nested options map, got {attrs:?}");
+        };
+        assert_eq!(
+            options.get("dns_support"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "enable".to_string()
+            )))
+        );
+        assert_eq!(
+            options.get("vpn_ecmp_support"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "disable".to_string()
+            )))
+        );
+        assert_eq!(
+            options.get("transit_gateway_cidr_blocks"),
+            Some(&Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("10.0.0.0/24".to_string()))
+            ])))
+        );
+        assert!(!attrs.contains_key("dns_support"));
+    }
+
+    #[test]
+    fn create_top_level_dns_support_is_ignored() {
+        let mut resource = Resource::with_provider("aws", "ec2.TransitGateway", "test", None);
+        resource.set_attr(
+            "dns_support".to_string(),
+            Value::Concrete(ConcreteValue::String("disable".to_string())),
+        );
+        assert!(build_create_transit_gateway_options(&resource).is_none());
     }
 }

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -5,7 +5,45 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{PollState, build_tag_specification, require_string_attr, wait_for_ec2_state};
+use crate::helpers::{
+    PollState, build_tag_specification, optional_enum_struct_field, require_string_attr,
+    wait_for_ec2_state,
+};
+
+fn build_create_transit_gateway_attachment_options(
+    resource: &Resource,
+) -> Option<aws_sdk_ec2::types::CreateTransitGatewayVpcAttachmentRequestOptions> {
+    use aws_sdk_ec2::types::{
+        ApplianceModeSupportValue, DnsSupportValue, Ipv6SupportValue,
+        SecurityGroupReferencingSupportValue,
+    };
+
+    let mut options =
+        aws_sdk_ec2::types::CreateTransitGatewayVpcAttachmentRequestOptions::builder();
+    let mut has_options = false;
+
+    if let Some(v) = optional_enum_struct_field(resource, "options", "appliance_mode_support") {
+        options = options.appliance_mode_support(ApplianceModeSupportValue::from(v));
+        has_options = true;
+    }
+    if let Some(v) = optional_enum_struct_field(resource, "options", "dns_support") {
+        options = options.dns_support(DnsSupportValue::from(v));
+        has_options = true;
+    }
+    if let Some(v) = optional_enum_struct_field(resource, "options", "ipv6_support") {
+        options = options.ipv6_support(Ipv6SupportValue::from(v));
+        has_options = true;
+    }
+    if let Some(v) =
+        optional_enum_struct_field(resource, "options", "security_group_referencing_support")
+    {
+        options = options
+            .security_group_referencing_support(SecurityGroupReferencingSupportValue::from(v));
+        has_options = true;
+    }
+
+    has_options.then(|| options.build())
+}
 
 impl AwsProvider {
     /// Read an EC2 Transit Gateway VPC Attachment
@@ -96,6 +134,10 @@ impl AwsProvider {
 
         for subnet_id in &subnet_ids {
             req = req.subnet_ids(subnet_id);
+        }
+
+        if let Some(options) = build_create_transit_gateway_attachment_options(resource) {
+            req = req.options(options);
         }
 
         // Apply tags via TagSpecifications
@@ -264,5 +306,123 @@ impl AwsProvider {
             "Transit gateway attachment deletion failed",
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_ec2::types::{
+        ApplianceModeSupportValue, DnsSupportValue, Ipv6SupportValue,
+        SecurityGroupReferencingSupportValue, TransitGatewayVpcAttachment,
+        TransitGatewayVpcAttachmentOptions,
+    };
+    use indexmap::IndexMap;
+
+    fn resource_with_options(options: IndexMap<String, Value>) -> Resource {
+        let mut resource =
+            Resource::with_provider("aws", "ec2.TransitGatewayAttachment", "test", None);
+        resource.set_attr(
+            "options".to_string(),
+            Value::Concrete(ConcreteValue::Map(options)),
+        );
+        resource
+    }
+
+    fn one_enum_option(field: &str, value: &str) -> Resource {
+        resource_with_options(
+            [(
+                field.to_string(),
+                Value::Concrete(ConcreteValue::String(value.to_string())),
+            )]
+            .into_iter()
+            .collect(),
+        )
+    }
+
+    #[test]
+    fn create_reads_nested_options_appliance_mode_support() {
+        let resource = one_enum_option("appliance_mode_support", "enable");
+        let options = build_create_transit_gateway_attachment_options(&resource).expect("options");
+        assert_eq!(
+            options.appliance_mode_support(),
+            Some(&ApplianceModeSupportValue::Enable)
+        );
+    }
+
+    #[test]
+    fn create_reads_nested_options_dns_support() {
+        let resource = one_enum_option("dns_support", "disable");
+        let options = build_create_transit_gateway_attachment_options(&resource).expect("options");
+        assert_eq!(options.dns_support(), Some(&DnsSupportValue::Disable));
+    }
+
+    #[test]
+    fn create_reads_nested_options_ipv6_support() {
+        let resource = one_enum_option("ipv6_support", "enable");
+        let options = build_create_transit_gateway_attachment_options(&resource).expect("options");
+        assert_eq!(options.ipv6_support(), Some(&Ipv6SupportValue::Enable));
+    }
+
+    #[test]
+    fn create_reads_nested_options_security_group_referencing_support() {
+        let resource = one_enum_option("security_group_referencing_support", "enable");
+        let options = build_create_transit_gateway_attachment_options(&resource).expect("options");
+        assert_eq!(
+            options.security_group_referencing_support(),
+            Some(&SecurityGroupReferencingSupportValue::Enable)
+        );
+    }
+
+    #[test]
+    fn state_read_emits_nested_options_map() {
+        let attachment = TransitGatewayVpcAttachment::builder()
+            .transit_gateway_attachment_id("tgw-attach-123")
+            .options(
+                TransitGatewayVpcAttachmentOptions::builder()
+                    .dns_support(DnsSupportValue::Enable)
+                    .ipv6_support(Ipv6SupportValue::Disable)
+                    .security_group_referencing_support(
+                        SecurityGroupReferencingSupportValue::Enable,
+                    )
+                    .build(),
+            )
+            .build();
+        let mut attrs = HashMap::new();
+        AwsProvider::extract_ec2_transit_gateway_attachment_attributes(&attachment, &mut attrs);
+
+        let Some(Value::Concrete(ConcreteValue::Map(options))) = attrs.get("options") else {
+            panic!("expected nested options map, got {attrs:?}");
+        };
+        assert_eq!(
+            options.get("dns_support"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "enable".to_string()
+            )))
+        );
+        assert_eq!(
+            options.get("ipv6_support"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "disable".to_string()
+            )))
+        );
+        assert_eq!(
+            options.get("security_group_referencing_support"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "enable".to_string()
+            )))
+        );
+        assert!(!attrs.contains_key("dns_support"));
+    }
+
+    #[test]
+    fn create_top_level_dns_support_is_ignored() {
+        let mut resource =
+            Resource::with_provider("aws", "ec2.TransitGatewayAttachment", "test", None);
+        resource.set_attr(
+            "dns_support".to_string(),
+            Value::Concrete(ConcreteValue::String("disable".to_string())),
+        );
+        assert!(build_create_transit_gateway_attachment_options(&resource).is_none());
     }
 }

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -1177,28 +1177,32 @@ fn test_extract_ec2_transit_gateway_attributes() {
             "Test TGW".to_string()
         )))
     );
+    let Some(Value::Concrete(ConcreteValue::Map(options))) = attributes.get("options") else {
+        panic!("expected nested options map, got {attributes:?}");
+    };
     assert_eq!(
-        attributes.get("amazon_side_asn"),
+        options.get("amazon_side_asn"),
         Some(&Value::Concrete(ConcreteValue::Int(64512)))
     );
     assert_eq!(
-        attributes.get("auto_accept_shared_attachments"),
+        options.get("auto_accept_shared_attachments"),
         Some(&Value::Concrete(ConcreteValue::String(
             "enable".to_string()
         )))
     );
     assert_eq!(
-        attributes.get("dns_support"),
+        options.get("dns_support"),
         Some(&Value::Concrete(ConcreteValue::String(
             "enable".to_string()
         )))
     );
     assert_eq!(
-        attributes.get("vpn_ecmp_support"),
+        options.get("vpn_ecmp_support"),
         Some(&Value::Concrete(ConcreteValue::String(
             "enable".to_string()
         )))
     );
+    assert!(!attributes.contains_key("amazon_side_asn"));
 }
 
 #[test]


### PR DESCRIPTION
## Root cause

`aws.ec2.TransitGateway`, `aws.ec2.TransitGatewayAttachment` and `aws.acm.Certificate` schemas declare `options` as a nested `AttributeType::struct_(...)` attribute, but the provider service code (write path) and the codegen-generated `extract_*_attributes` (state-read path) treated those children as flat top-level attributes. The DSL spelling that follows the schema (`options { dns_support = enable }`) reaches the provider as `resource.get_attr("options")` -> `Map`, NOT as `resource.get_attr("dns_support")` -> `String`. The top-level lookup silently returns `None`, the SDK request omits the whole `Options` struct, AWS uses defaults, and the state read emits a different (flat) shape from what the schema declares — a same-class twin of #440 with one extra layer.

The schema is correct; the codegen `derived_attributes` choice + the service hand-code were both wrong. Fixing only one side leaves a phantom diff every plan.

## Scope

This PR is structural, not per-symptom. Same root, multiple seams.

**Codegen** (`carina-codegen-aws/`)
- `struct_child_value_expr` now handles `List<String>` children (previously `None` -> warn-skip), so `TransitGatewayRequestOptions.TransitGatewayCidrBlocks` round-trips.
- `resource_defs.rs` flips TGW + TGA `derived_attributes` from per-field `DerivedSource::Struct` (flat top-level emission) to a single `DerivedSource::StructAsMap` (nested `options` Map emission). 9 children for TGW (incl. previously-missing `multicast_support` / `security_group_referencing_support` / `transit_gateway_cidr_blocks`), 4 for TGA.
- Codegen tests renamed to pin the new `StructAsMap` shape; stale flat-shape assertions removed.

**Provider service** (`carina-provider-aws/src/services/`)
- `services/ec2/transit_gateway.rs::build_create_transit_gateway_options` walks `resource.get_attr("options")` as a `Map`, including the 3 previously-missing fields. Empty `transit_gateway_cidr_blocks` is skipped (avoids sending an explicit empty list to AWS).
- `services/ec2/transit_gateway_attachment.rs::build_create_transit_gateway_attachment_options` walks the nested Map for its 4 children.
- `services/acm/certificate.rs`:
  - `build_create_certificate_options` is new; passes both `certificate_transparency_logging_preference` AND `export` (the schema declares both but the pre-PR code handled neither). `export` is create-only per AWS.
  - `build_update_certificate_options` reads `certificate_transparency_logging_preference` from `to.get_attr("options")` (was reading top-level — would never fire).
  - `certificate_detail_to_attributes` emits `options { certificate_transparency_logging_preference, export }` as a nested Map.

**Helpers** (`carina-provider-aws/src/helpers.rs`)
- `enum_struct_field_str` (`pub(crate)`) — handles all three Value variants (String / EnumIdentifier / CanonicalEnum) coming out of the carina-core canonicalize pipeline (#440's lesson), but for a field nested inside an outer `Map`.
- `optional_enum_struct_field` / `optional_int_struct_field` / `optional_string_list_struct_field` — `pub(crate)` wrappers, doc-commented with the narrow-shape contract (Int / List<String>) and a citation to the #441/#442 failure mode.

## Tests

365 -> 364 passed (+65 net adds; codegen rename removes 2 stale tests). Highlights:

- Helper unit tests cover the full shape matrix (3 enum variants / Int / both StringList shapes / outer absent / outer non-Map / inner absent / inner wrong-shape).
- `transit_gateway::tests`:
  - `create_writes_nested_options_for_canonical_enum_dns_support` and friends pin the production path (resource -> `build_create_transit_gateway_options` -> SDK builder) for every options child.
  - `create_top_level_dns_support_is_ignored` pins that pre-PR-shaped top-level reads do not silently work (no fallback).
  - `state_read_emits_nested_options_map` pins the codegen output shape.
  - `build_create_transit_gateway_options_skips_explicit_empty_cidr_blocks_list` pins the empty-list edge case.
- `transit_gateway_attachment::tests`: analogous for the 4 children.
- `acm/certificate::tests`:
  - `create_acm_certificate_passes_options_certificate_transparency_logging_preference_to_sdk_request`
  - `create_acm_certificate_passes_options_export_to_sdk_request`
  - `create_acm_certificate_passes_both_options_fields`
  - `certificate_detail_to_attributes_emits_nested_options_*`
  - `update_acm_certificate_reads_nested_options_certificate_transparency_logging_preference`

## Verify

```
cargo check -p carina-codegen-aws -p carina-provider-aws          # green
cargo nextest run -p carina-codegen-aws -p carina-provider-aws    # 364 passed
cargo test --workspace --doc                                      # green
cargo clippy --workspace --all-targets -- -D warnings             # green
bash scripts/check-examples.sh                                    # green
bash scripts/check-string-enum-aliases.sh                         # green
```

## Out of scope (filed separately)

- carina-provider-aws#444 — make `DerivedSource::Struct` vs `StructAsMap` a structural invariant (currently author-convention; the wrong pick silently re-introduces #441). The PR closes the symptom for the named resources; this Issue tracks closing the codegen-author seam itself.
- carina-provider-aws#445 — helper-set completion (`optional_bool_struct_field` / `optional_string_struct_field`) + sweep `services/ec2/subnet.rs`'s inline Map walk for `private_dns_name_options_on_launch` to the new helpers. Subnet works correctly today (inline pattern); this is consistency, not a bug fix.
- carina-rs/carina#3555 — typed `Resource::get_enum_attr` accessor in carina-core (carries from #440). Closes the parent `get_attr -> &Value` hazard that both #440 and #441 reach for at the helper layer.
- `nat_gateway.availability_zone_addresses` and `flow_log.tag_field_specifications` are `List<Struct>` rather than `Map<Struct>` — same family of bug, different mechanism (list-of-struct iteration, not Map walk). Not touched here; a separate Issue will cover the `List<Struct>` codegen + service-code sweep.

## Migration

TGW / TGA: pre-PR state has flat top-level keys (`dns_support: "enable"` etc.). Carina re-reads AWS on every plan; the new read code emits a nested `options` Map directly, so the differ compares (nested AWS state) vs (nested desired). No phantom forces-replace.

ACM: pre-PR state had no `options` key at all (the hand-coded read never touched `cert.options()`). After this PR the read emits `options` populated from AWS. First plan after upgrade shows `options: (unset) -> {certificate_transparency_logging_preference: ENABLED}` — a one-time real diff representing the cert's actual on-AWS state, not a phantom. Subsequent plans converge.

Closes #441
Closes #442
