### PR TITLE
fix(helpers): complete nested-struct-field helper set + sweep subnet inline walk (#445)

### DIFF
--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -147,6 +147,60 @@ pub(crate) fn optional_int_struct_field(
     }
 }
 
+/// Return the `bool` value of a `Bool`-typed field inside the nested
+/// struct attribute `struct_attr`. Same shape contract as
+/// [`enum_struct_field_str`]: outer must be a `Map`, missing
+/// outer/field/wrong-shape returns `None`. Narrowed to a single
+/// `Value` shape: `ConcreteValue::Bool`.
+///
+/// Sibling of [`optional_enum_struct_field`] /
+/// [`optional_int_struct_field`] /
+/// [`optional_string_list_struct_field`] /
+/// [`optional_string_struct_field`]. carina-rs/carina-provider-aws#445.
+pub(crate) fn optional_bool_struct_field(
+    resource: &Resource,
+    struct_attr: &str,
+    field_name: &str,
+) -> Option<bool> {
+    let Some(Value::Concrete(ConcreteValue::Map(m))) = resource.get_attr(struct_attr) else {
+        return None;
+    };
+    match m.get(field_name)? {
+        Value::Concrete(ConcreteValue::Bool(b)) => Some(*b),
+        _ => None,
+    }
+}
+
+/// Return the `&str` value of a plain-`String`-typed field inside the
+/// nested struct attribute `struct_attr`. Same shape contract as
+/// [`enum_struct_field_str`]: outer must be a `Map`, missing
+/// outer/field/wrong-shape returns `None`. Narrowed to
+/// `ConcreteValue::String` only - DO NOT use for enum-shaped fields;
+/// use [`optional_enum_struct_field`] for those so the
+/// `EnumIdentifier` / `CanonicalEnum` Value variants the canonicalize
+/// pipeline can produce are not silently dropped.
+///
+/// carina-rs/carina-provider-aws#445 added this helper as the
+/// symmetric sibling of [`optional_bool_struct_field`] to close the
+/// nested-struct-field helper set; `#[allow(dead_code)]` because no
+/// current resource has a plain-`String` child inside a nested struct
+/// attribute. The helper is exercised by unit tests; do not remove
+/// when grepping for unused functions.
+#[allow(dead_code)]
+pub(crate) fn optional_string_struct_field<'a>(
+    resource: &'a Resource,
+    struct_attr: &str,
+    field_name: &str,
+) -> Option<&'a str> {
+    let Some(Value::Concrete(ConcreteValue::Map(m))) = resource.get_attr(struct_attr) else {
+        return None;
+    };
+    match m.get(field_name)? {
+        Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
 /// Return the `Vec<String>` value of a `List<String>`-typed field
 /// inside the nested struct attribute `struct_attr`. Accepts both
 /// `ConcreteValue::StringList` (the canonical shape after carina-core
@@ -709,6 +763,30 @@ mod tests {
     }
 
     #[test]
+    fn test_optional_bool_struct_field_bool() {
+        let resource = make_resource_with_struct_field(
+            "enable_resource_name_dns_a_record",
+            Value::Concrete(ConcreteValue::Bool(true)),
+        );
+        assert_eq!(
+            optional_bool_struct_field(&resource, "options", "enable_resource_name_dns_a_record"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_optional_string_struct_field_string() {
+        let resource = make_resource_with_struct_field(
+            "domain_name",
+            Value::Concrete(ConcreteValue::String("example.com".to_string())),
+        );
+        assert_eq!(
+            optional_string_struct_field(&resource, "options", "domain_name"),
+            Some("example.com")
+        );
+    }
+
+    #[test]
     fn test_optional_string_list_struct_field_string_list() {
         let resource = make_resource_with_struct_field(
             "transit_gateway_cidr_blocks",
@@ -746,6 +824,14 @@ mod tests {
             None
         );
         assert_eq!(
+            optional_bool_struct_field(&resource, "options", "enable_resource_name_dns_a_record"),
+            None
+        );
+        assert_eq!(
+            optional_string_struct_field(&resource, "options", "domain_name"),
+            None
+        );
+        assert_eq!(
             optional_string_list_struct_field(&resource, "options", "transit_gateway_cidr_blocks"),
             None
         );
@@ -763,6 +849,14 @@ mod tests {
         );
         assert_eq!(
             optional_int_struct_field(&resource, "options", "amazon_side_asn"),
+            None
+        );
+        assert_eq!(
+            optional_bool_struct_field(&resource, "options", "enable_resource_name_dns_a_record"),
+            None
+        );
+        assert_eq!(
+            optional_string_struct_field(&resource, "options", "domain_name"),
             None
         );
         assert_eq!(
@@ -786,6 +880,14 @@ mod tests {
             None
         );
         assert_eq!(
+            optional_bool_struct_field(&resource, "options", "enable_resource_name_dns_a_record"),
+            None
+        );
+        assert_eq!(
+            optional_string_struct_field(&resource, "options", "domain_name"),
+            None
+        );
+        assert_eq!(
             optional_string_list_struct_field(&resource, "options", "transit_gateway_cidr_blocks"),
             None
         );
@@ -805,6 +907,16 @@ mod tests {
             "transit_gateway_cidr_blocks",
             Value::Concrete(ConcreteValue::Int(1)),
         );
+        let bool_resource = make_resource_with_struct_field(
+            "enable_resource_name_dns_a_record",
+            Value::Concrete(ConcreteValue::String("true".to_string())),
+        );
+        let string_resource =
+            make_resource_with_struct_field("domain_name", Value::Concrete(ConcreteValue::Int(1)));
+        let string_enum_identifier_resource = make_resource_with_struct_field(
+            "domain_name",
+            Value::Concrete(ConcreteValue::enum_identifier("example")),
+        );
         let mixed_list_resource = make_resource_with_struct_field(
             "transit_gateway_cidr_blocks",
             Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
@@ -817,6 +929,26 @@ mod tests {
         );
         assert_eq!(
             optional_int_struct_field(&int_resource, "options", "amazon_side_asn"),
+            None
+        );
+        assert_eq!(
+            optional_bool_struct_field(
+                &bool_resource,
+                "options",
+                "enable_resource_name_dns_a_record"
+            ),
+            None
+        );
+        assert_eq!(
+            optional_string_struct_field(&string_resource, "options", "domain_name"),
+            None
+        );
+        assert_eq!(
+            optional_string_struct_field(
+                &string_enum_identifier_resource,
+                "options",
+                "domain_name"
+            ),
             None
         );
         assert_eq!(

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -5,7 +5,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::require_string_attr;
+use crate::helpers::{optional_bool_struct_field, optional_enum_struct_field, require_string_attr};
 use aws_sdk_ec2::types::{AttributeBooleanValue, HostnameType};
 
 // `read_ec2_subnet` must store `availability_zone` as the AWS canonical
@@ -100,7 +100,7 @@ impl AwsProvider {
             .await?;
 
         // Apply subnet attributes that require ModifySubnetAttribute
-        self.modify_subnet_attributes(&resource.id, subnet_id, &attrs)
+        self.modify_subnet_attributes(&resource.id, subnet_id, resource)
             .await?;
 
         // Read back using subnet ID (reliable identifier)
@@ -117,8 +117,7 @@ impl AwsProvider {
     ) -> ProviderResult<State> {
         // Apply subnet attributes that require ModifySubnetAttribute
         let attrs = to.resolved_attributes();
-        self.modify_subnet_attributes(&id, identifier, &attrs)
-            .await?;
+        self.modify_subnet_attributes(&id, identifier, &to).await?;
 
         // Update tags
         self.apply_ec2_tags(&id, identifier, &attrs, Some(&from.attributes))
@@ -133,10 +132,10 @@ impl AwsProvider {
         &self,
         id: &ResourceId,
         subnet_id: &str,
-        attributes: &HashMap<String, Value>,
+        resource: &Resource,
     ) -> ProviderResult<()> {
         if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            attributes.get("map_public_ip_on_launch")
+            resource.get_attr("map_public_ip_on_launch")
         {
             self.ec2_client
                 .modify_subnet_attribute()
@@ -155,7 +154,7 @@ impl AwsProvider {
         }
 
         if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            attributes.get("assign_ipv6_address_on_creation")
+            resource.get_attr("assign_ipv6_address_on_creation")
         {
             self.ec2_client
                 .modify_subnet_attribute()
@@ -175,7 +174,8 @@ impl AwsProvider {
                 })?;
         }
 
-        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) = attributes.get("enable_dns64")
+        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
+            resource.get_attr("enable_dns64")
         {
             self.ec2_client
                 .modify_subnet_attribute()
@@ -195,65 +195,71 @@ impl AwsProvider {
 
         // The ModifySubnetAttribute API only allows modifying one attribute at a time.
         // Each private_dns_name_options_on_launch field must be a separate API call.
-        if let Some(Value::Concrete(ConcreteValue::Map(fields))) =
-            attributes.get("private_dns_name_options_on_launch")
-        {
-            if let Some(Value::Concrete(ConcreteValue::String(ht))) = fields.get("hostname_type") {
-                self.ec2_client
-                    .modify_subnet_attribute()
-                    .subnet_id(subnet_id)
-                    .private_dns_hostname_type_on_launch(HostnameType::from(ht.as_str()))
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        api_error_with_meta(
-                            "Failed to set private_dns_name_options_on_launch.hostname_type",
-                            "ec2.ModifySubnetAttribute",
-                            e,
-                        )
-                        .for_resource(id.clone())
-                    })?;
-            }
-            if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
-                fields.get("enable_resource_name_dns_a_record")
-            {
-                self.ec2_client
-                    .modify_subnet_attribute()
-                    .subnet_id(subnet_id)
-                    .enable_resource_name_dns_a_record_on_launch(
-                        AttributeBooleanValue::builder().value(*v).build(),
+        if let Some(ht) = optional_enum_struct_field(
+            resource,
+            "private_dns_name_options_on_launch",
+            "hostname_type",
+        ) {
+            self.ec2_client
+                .modify_subnet_attribute()
+                .subnet_id(subnet_id)
+                .private_dns_hostname_type_on_launch(HostnameType::from(ht))
+                .send()
+                .await
+                .map_err(|e| {
+                    api_error_with_meta(
+                        "Failed to set private_dns_name_options_on_launch.hostname_type",
+                        "ec2.ModifySubnetAttribute",
+                        e,
                     )
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        api_error_with_meta(
-                            "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_a_record",
-                            "ec2.ModifySubnetAttribute",
-                            e,
-                        )
-                        .for_resource(id.clone())
-                    })?;
-            }
-            if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
-                fields.get("enable_resource_name_dns_aaaa_record")
-            {
-                self.ec2_client
-                    .modify_subnet_attribute()
-                    .subnet_id(subnet_id)
-                    .enable_resource_name_dns_aaaa_record_on_launch(
-                        AttributeBooleanValue::builder().value(*v).build(),
+                    .for_resource(id.clone())
+                })?;
+        }
+
+        if let Some(v) = optional_bool_struct_field(
+            resource,
+            "private_dns_name_options_on_launch",
+            "enable_resource_name_dns_a_record",
+        ) {
+            self.ec2_client
+                .modify_subnet_attribute()
+                .subnet_id(subnet_id)
+                .enable_resource_name_dns_a_record_on_launch(
+                    AttributeBooleanValue::builder().value(v).build(),
+                )
+                .send()
+                .await
+                .map_err(|e| {
+                    api_error_with_meta(
+                        "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_a_record",
+                        "ec2.ModifySubnetAttribute",
+                        e,
                     )
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        api_error_with_meta(
-                            "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_aaaa_record",
-                            "ec2.ModifySubnetAttribute",
-                            e,
-                        )
-                        .for_resource(id.clone())
-                    })?;
-            }
+                    .for_resource(id.clone())
+                })?;
+        }
+
+        if let Some(v) = optional_bool_struct_field(
+            resource,
+            "private_dns_name_options_on_launch",
+            "enable_resource_name_dns_aaaa_record",
+        ) {
+            self.ec2_client
+                .modify_subnet_attribute()
+                .subnet_id(subnet_id)
+                .enable_resource_name_dns_aaaa_record_on_launch(
+                    AttributeBooleanValue::builder().value(v).build(),
+                )
+                .send()
+                .await
+                .map_err(|e| {
+                    api_error_with_meta(
+                        "Failed to set private_dns_name_options_on_launch.enable_resource_name_dns_aaaa_record",
+                        "ec2.ModifySubnetAttribute",
+                        e,
+                    )
+                    .for_resource(id.clone())
+                })?;
         }
 
         Ok(())


### PR DESCRIPTION
## Why

The nested-struct-field helper set introduced by [carina-provider-aws#441 / #442](https://github.com/carina-rs/carina-provider-aws/issues/441) covered `enum` / `int` / `string_list` but left two natural variants unimplemented:

- `optional_bool_struct_field` for `Bool` children
- `optional_string_struct_field` for plain-`String` children (no enum semantics)

`services/ec2/subnet.rs::modify_subnet_attributes` was the only remaining service file that hand-walked a nested struct attribute (`private_dns_name_options_on_launch`) inline. That inline pattern is the precedent that perpetuates the same-class-as-#441 drift if left unswept — every new resource with a similar nested Bool/String would either copy the inline shape or build a third helper variant.

This PR closes the helper set and sweeps the last inline walk.

## Scope

**Helpers** (`carina-provider-aws/src/helpers.rs`):

- `optional_bool_struct_field(resource: &Resource, struct_attr: &str, field_name: &str) -> Option<bool>` — `pub(crate)`, narrow to `ConcreteValue::Bool`.
- `optional_string_struct_field(resource: &Resource, struct_attr: &str, field_name: &str) -> Option<&str>` — `pub(crate)`, narrow to `ConcreteValue::String`. Docstring explicitly forbids use for enum-shaped fields (use `optional_enum_struct_field` so `EnumIdentifier` / `CanonicalEnum` variants are not silently dropped). The test suite pins that contract by rejecting `EnumIdentifier` at the field position.
- `#[allow(dead_code)]` on `optional_string_struct_field` because no current resource has a plain-`String` child inside a nested struct attribute. The helper is added preemptively as the symmetric sibling of `optional_bool_struct_field`; the docstring explains the rationale so a future contributor doesn't strip it as unused.

Unit tests for each helper cover the standard shape matrix (present-Map with correct shape / outer absent / outer non-Map / inner absent / inner wrong-shape).

**Sweep** (`carina-provider-aws/src/services/ec2/subnet.rs`):

- `modify_subnet_attributes` signature changed from `attributes: &HashMap<String, Value>` to `resource: &Resource`. Both callers (`create_ec2_subnet`, `update_ec2_subnet`) pass `&resource` / `&to` directly. The existing `let attrs = ...resolved_attributes()` bindings are still needed for `apply_ec2_tags` and remain unchanged.
- Three nested-struct reads inside the `private_dns_name_options_on_launch` block migrated to the helpers: `optional_enum_struct_field` for `hostname_type`, `optional_bool_struct_field` for `enable_resource_name_dns_a_record` and `enable_resource_name_dns_aaaa_record`.
- The outer `if let Some(Value::Concrete(ConcreteValue::Map(fields))) = ...` wrapper is gone — each helper handles the outer-Map gate internally.

**Strict-correctness improvement**: switching `hostname_type` from `ConcreteValue::String(ht)` to `optional_enum_struct_field(..)` also accepts the `EnumIdentifier` / `CanonicalEnum` variants the carina-core canonicalize pipeline can produce. Pre-PR the inline match silently dropped those shapes — same bug class as the original #441 silent drop, latent here because the schema-typed `hostname_type` enum is normally canonicalized before reaching the provider, but a defense-in-depth improvement nonetheless.

## Three lenses

Three implementation options were considered for the sweep:

- (A) Change `modify_subnet_attributes` signature to `&Resource` (this PR)
- (B) Add `HashMap<String, Value>`-shaped sibling helpers
- (C) Wrap the HashMap in a temporary `Resource` for the helper call

| Lens | (A) `&Resource` signature | (B) HashMap helpers | (C) wrapper |
|---|---|---|---|
| Long-term view | helpers + service code align on `&Resource`; future struct sweeps reuse the same shape | every new helper needs two versions; drift surface doubles | wrapper noise at every call site |
| Type safety | direct uniform access | same | wrapper might lose attributes silently |
| Root cause | inline walk gone, drift closed | helpers exist but the inline walk path stays inviting | inline walk replaced with wrapper boilerplate |

All three lenses uniquely select (A). The signature change is local (one function, two call sites) and behaviour-preserving (`get_attr` reads the same `IndexMap` that `resolved_attributes()` cloned).

## Tests

`cargo nextest run -p carina-provider-aws`: 305 passed (+5 over the #450 main).

## Verify

```
cargo check -p carina-provider-aws                            # green
cargo nextest run -p carina-provider-aws                      # 305 passed
cargo test --workspace --doc                                  # green
cargo clippy --workspace --all-targets -- -D warnings         # green
bash scripts/check-examples.sh                                # green
bash scripts/check-string-enum-aliases.sh                     # green
```

## Out of scope (filed separately)

- carina-provider-aws#451 — add `optional_bool_attr` top-level helper and sweep the remaining inline top-level `Value::Concrete(ConcreteValue::Bool(..))` pattern matches in `subnet.rs` (`map_public_ip_on_launch`, `assign_ipv6_address_on_creation`, `enable_dns64`) and any sibling reads in other services. This PR is symmetric helper completion at the **nested** level; #451 closes the symmetric completion at the **top** level.
- Other nested Map walks in `services/s3/*.rs` and `services/organizations/account.rs` are not the same shape (they walk into list-of-struct or arbitrary tag maps, not flat scalar children of a nested struct), so they are not covered by this helper set.
- The deeper Rust-type-level reshape (`Resource::get_struct_attr(name) -> StructAttr<'_>`) that would make the broken `match Value::Concrete(ConcreteValue::Bool(..))` shape literally unrepresentable lives in carina-core and is tracked in [carina-rs/carina#3555](https://github.com/carina-rs/carina/issues/3555).

Closes #445
