### PR TITLE
chore(ec2): remove dead peer_region create-side read on VpcPeeringConnection (#447)

### DIFF
--- a/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
@@ -87,11 +87,12 @@ impl AwsProvider {
             req = req.peer_owner_id(owner_id);
         }
 
-        if let Some(Value::Concrete(ConcreteValue::String(region))) =
-            resource.get_attr("peer_region")
-        {
-            req = req.peer_region(region);
-        }
+        // `peer_region` is excluded from the schema (resource_defs.rs
+        // `exclude_fields: ["DryRun", "TagSpecifications", "PeerRegion"]`),
+        // so a valid DSL cannot set it and this read would never fire.
+        // Cross-region peering would need `peer_region` declared as a
+        // schema attribute + a matching read-side projection;
+        // carina-provider-aws#447.
 
         // Apply tags via TagSpecifications
         if let Some(tag_spec) = build_tag_specification(


### PR DESCRIPTION
## Why

`carina-provider-aws/src/services/ec2/vpc_peering_connection.rs::create_ec2_vpc_peering_connection` reads `resource.get_attr("peer_region")` and passes it to `CreateVpcPeeringConnection.peer_region(...)`. The schema does NOT declare `peer_region` as a top-level attribute (it is in `exclude_fields: ["DryRun", "TagSpecifications", "PeerRegion"]` in `carina-codegen-aws/src/resource_defs.rs`). Carina-core rejects unknown attributes during DSL validation, so a user writing `peer_region = "us-west-2"` gets `unknown attribute peer_region` and the resource never reaches the provider. **The create-side read is unreachable from valid DSL — dead code.**

The read-side counterpart was removed in carina-provider-aws#444 (FromStruct schema-existence check caught the orphan `DerivedAttribute`); the create-side read was missed because the new codegen-time check only inspects derived/read sites.

## Decision: option (b) — delete the dead read

The Issue proposed two options:

| Lens | (a) restore `peer_region` as a real schema attribute (enables cross-region peering as a feature) | (b) delete the dead create-side read (this PR) |
|---|---|---|
| Long-term | enables AWS feature but expands scope to feature work | keeps schema as source of truth; cross-region peering can be a separate feature PR |
| Type-safety | needs a new `DerivedSource` shape or read-side projection — non-trivial codegen | removes the dead-code class |
| Root-cause | re-introduces codegen↔schema asymmetry that #444 was about closing | restores schema↔code consistency |

Option (b) was selected. Cross-region peering as a new feature is out of scope for a dead-code cleanup PR. It can be filed as a separate Issue if/when needed.

## Diff

7 lines — one `if let Some(...) = resource.get_attr("peer_region")` block removed, replaced with a brief comment naming the schema-exclude mechanism and pointing to this Issue. No other production code touched. Pre-existing negative tests in `carina-provider-aws/src/tests.rs:1313` and `carina-codegen-aws/src/main.rs:5667` already pin that `peer_region` is NOT extracted to state, so the comment's claim is type-checked by the test suite.

## Verify

```
cargo nextest run -p carina-provider-aws         # 305 passed (unchanged)
cargo clippy --workspace --all-targets -- -D warnings  # green
bash scripts/check-examples.sh                   # green
bash scripts/check-string-enum-aliases.sh        # green
```

Closes #447
