### PR TITLE
feat(helpers): add optional_bool_attr top-level helper + sweep inline Bool reads (#451)

### DIFF
--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -84,6 +84,18 @@ pub fn optional_enum_attr<'a>(resource: &'a Resource, attr_name: &str) -> Option
     enum_attr_str(resource, attr_name)
 }
 
+/// Return the `bool` value of a top-level `Bool`-typed attribute.
+/// Returns `None` if the attribute is absent or carries any other
+/// `Value` shape. Sibling of [`optional_enum_attr`] /
+/// [`value_as_str`]; closes the symmetric top-level helper set for
+/// Bool reads (carina-rs/carina-provider-aws#451).
+pub(crate) fn optional_bool_attr(resource: &Resource, attr_name: &str) -> Option<bool> {
+    match resource.get_attr(attr_name)? {
+        Value::Concrete(ConcreteValue::Bool(b)) => Some(*b),
+        _ => None,
+    }
+}
+
 /// Return the AWS API canonical spelling for a schema-typed enum
 /// attribute that lives inside a nested struct attribute (the
 /// `Map`-shaped value at `struct_attr`). Accepts every `Value` shape the
@@ -704,6 +716,34 @@ mod tests {
     fn test_optional_enum_attr_non_enum_shape_is_none() {
         let resource = make_resource_with_value("type", Value::Concrete(ConcreteValue::Bool(true)));
         assert_eq!(optional_enum_attr(&resource, "type"), None);
+    }
+
+    #[test]
+    fn test_optional_bool_attr_bool() {
+        let true_resource =
+            make_resource_with_value("enabled", Value::Concrete(ConcreteValue::Bool(true)));
+        let false_resource =
+            make_resource_with_value("enabled", Value::Concrete(ConcreteValue::Bool(false)));
+        assert_eq!(optional_bool_attr(&true_resource, "enabled"), Some(true));
+        assert_eq!(optional_bool_attr(&false_resource, "enabled"), Some(false));
+    }
+
+    #[test]
+    fn test_optional_bool_attr_missing_is_none() {
+        let resource = make_test_resource(vec![]);
+        assert_eq!(optional_bool_attr(&resource, "enabled"), None);
+    }
+
+    #[test]
+    fn test_optional_bool_attr_wrong_shape_is_none() {
+        let string_resource = make_resource_with_value(
+            "enabled",
+            Value::Concrete(ConcreteValue::String("true".into())),
+        );
+        let int_resource =
+            make_resource_with_value("enabled", Value::Concrete(ConcreteValue::Int(1)));
+        assert_eq!(optional_bool_attr(&string_resource, "enabled"), None);
+        assert_eq!(optional_bool_attr(&int_resource, "enabled"), None);
     }
 
     #[test]

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -5,7 +5,9 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{optional_bool_struct_field, optional_enum_struct_field, require_string_attr};
+use crate::helpers::{
+    optional_bool_attr, optional_bool_struct_field, optional_enum_struct_field, require_string_attr,
+};
 use aws_sdk_ec2::types::{AttributeBooleanValue, HostnameType};
 
 // `read_ec2_subnet` must store `availability_zone` as the AWS canonical
@@ -134,13 +136,11 @@ impl AwsProvider {
         subnet_id: &str,
         resource: &Resource,
     ) -> ProviderResult<()> {
-        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            resource.get_attr("map_public_ip_on_launch")
-        {
+        if let Some(enabled) = optional_bool_attr(resource, "map_public_ip_on_launch") {
             self.ec2_client
                 .modify_subnet_attribute()
                 .subnet_id(subnet_id)
-                .map_public_ip_on_launch(AttributeBooleanValue::builder().value(*enabled).build())
+                .map_public_ip_on_launch(AttributeBooleanValue::builder().value(enabled).build())
                 .send()
                 .await
                 .map_err(|e| {
@@ -153,14 +153,12 @@ impl AwsProvider {
                 })?;
         }
 
-        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            resource.get_attr("assign_ipv6_address_on_creation")
-        {
+        if let Some(enabled) = optional_bool_attr(resource, "assign_ipv6_address_on_creation") {
             self.ec2_client
                 .modify_subnet_attribute()
                 .subnet_id(subnet_id)
                 .assign_ipv6_address_on_creation(
-                    AttributeBooleanValue::builder().value(*enabled).build(),
+                    AttributeBooleanValue::builder().value(enabled).build(),
                 )
                 .send()
                 .await
@@ -174,13 +172,11 @@ impl AwsProvider {
                 })?;
         }
 
-        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            resource.get_attr("enable_dns64")
-        {
+        if let Some(enabled) = optional_bool_attr(resource, "enable_dns64") {
             self.ec2_client
                 .modify_subnet_attribute()
                 .subnet_id(subnet_id)
-                .enable_dns64(AttributeBooleanValue::builder().value(*enabled).build())
+                .enable_dns64(AttributeBooleanValue::builder().value(enabled).build())
                 .send()
                 .await
                 .map_err(|e| {

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -5,7 +5,9 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, optional_enum_attr, require_string_attr, retry_aws_operation};
+use crate::helpers::{
+    RetryPolicy, optional_bool_attr, optional_enum_attr, require_string_attr, retry_aws_operation,
+};
 
 impl AwsProvider {
     /// Read an EC2 VPC
@@ -126,15 +128,13 @@ impl AwsProvider {
             .await?;
 
         // Configure DNS support
-        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            resource.get_attr("enable_dns_support")
-        {
+        if let Some(enabled) = optional_bool_attr(resource, "enable_dns_support") {
             self.ec2_client
                 .modify_vpc_attribute()
                 .vpc_id(vpc_id)
                 .enable_dns_support(
                     aws_sdk_ec2::types::AttributeBooleanValue::builder()
-                        .value(*enabled)
+                        .value(enabled)
                         .build(),
                 )
                 .send()
@@ -146,15 +146,13 @@ impl AwsProvider {
         }
 
         // Configure DNS hostnames
-        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            resource.get_attr("enable_dns_hostnames")
-        {
+        if let Some(enabled) = optional_bool_attr(resource, "enable_dns_hostnames") {
             self.ec2_client
                 .modify_vpc_attribute()
                 .vpc_id(vpc_id)
                 .enable_dns_hostnames(
                     aws_sdk_ec2::types::AttributeBooleanValue::builder()
-                        .value(*enabled)
+                        .value(enabled)
                         .build(),
                 )
                 .send()
@@ -181,15 +179,13 @@ impl AwsProvider {
         let vpc_id = identifier.to_string();
 
         // Update DNS support
-        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            to.get_attr("enable_dns_support")
-        {
+        if let Some(enabled) = optional_bool_attr(&to, "enable_dns_support") {
             self.ec2_client
                 .modify_vpc_attribute()
                 .vpc_id(&vpc_id)
                 .enable_dns_support(
                     aws_sdk_ec2::types::AttributeBooleanValue::builder()
-                        .value(*enabled)
+                        .value(enabled)
                         .build(),
                 )
                 .send()
@@ -201,15 +197,13 @@ impl AwsProvider {
         }
 
         // Update DNS hostnames
-        if let Some(Value::Concrete(ConcreteValue::Bool(enabled))) =
-            to.get_attr("enable_dns_hostnames")
-        {
+        if let Some(enabled) = optional_bool_attr(&to, "enable_dns_hostnames") {
             self.ec2_client
                 .modify_vpc_attribute()
                 .vpc_id(&vpc_id)
                 .enable_dns_hostnames(
                     aws_sdk_ec2::types::AttributeBooleanValue::builder()
-                        .value(*enabled)
+                        .value(enabled)
                         .build(),
                 )
                 .send()

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -5,7 +5,9 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, optional_enum_attr, require_string_attr, retry_aws_operation};
+use crate::helpers::{
+    RetryPolicy, optional_bool_attr, optional_enum_attr, require_string_attr, retry_aws_operation,
+};
 
 impl AwsProvider {
     /// Read an EC2 VPC Endpoint
@@ -107,10 +109,8 @@ impl AwsProvider {
             }
         }
 
-        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
-            resource.get_attr("private_dns_enabled")
-        {
-            req = req.private_dns_enabled(*v);
+        if let Some(v) = optional_bool_attr(resource, "private_dns_enabled") {
+            req = req.private_dns_enabled(v);
         }
 
         if let Some(Value::Concrete(ConcreteValue::String(policy))) =
@@ -309,8 +309,8 @@ impl AwsProvider {
         }
 
         // Update private_dns_enabled
-        if let Some(Value::Concrete(ConcreteValue::Bool(v))) = to.get_attr("private_dns_enabled") {
-            req = req.private_dns_enabled(*v);
+        if let Some(v) = optional_bool_attr(&to, "private_dns_enabled") {
+            req = req.private_dns_enabled(v);
             has_modifications = true;
         }
 

--- a/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/services/s3/bucket_public_access_block.rs
@@ -6,7 +6,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation};
+use crate::helpers::{RetryPolicy, optional_bool_attr, require_string_attr, retry_aws_operation};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -109,25 +109,17 @@ impl AwsProvider {
         resource: &Resource,
     ) -> ProviderResult<State> {
         let mut builder = PublicAccessBlockConfiguration::builder();
-        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
-            resource.get_attr("block_public_acls")
-        {
-            builder = builder.block_public_acls(*v);
+        if let Some(v) = optional_bool_attr(resource, "block_public_acls") {
+            builder = builder.block_public_acls(v);
         }
-        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
-            resource.get_attr("ignore_public_acls")
-        {
-            builder = builder.ignore_public_acls(*v);
+        if let Some(v) = optional_bool_attr(resource, "ignore_public_acls") {
+            builder = builder.ignore_public_acls(v);
         }
-        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
-            resource.get_attr("block_public_policy")
-        {
-            builder = builder.block_public_policy(*v);
+        if let Some(v) = optional_bool_attr(resource, "block_public_policy") {
+            builder = builder.block_public_policy(v);
         }
-        if let Some(Value::Concrete(ConcreteValue::Bool(v))) =
-            resource.get_attr("restrict_public_buckets")
-        {
-            builder = builder.restrict_public_buckets(*v);
+        if let Some(v) = optional_bool_attr(resource, "restrict_public_buckets") {
+            builder = builder.restrict_public_buckets(v);
         }
         let config = builder.build();
 


### PR DESCRIPTION
## Why

carina-provider-aws#440 introduced `optional_enum_attr` for top-level enum reads, and #441/#442/#445 completed the nested-struct-field helper set. The top-level Bool gap remained — inline `if let Some(Value::Concrete(ConcreteValue::Bool(b))) = resource.get_attr(...)` pattern matches were scattered across `services/`.

This Issue is the symmetric completion at the top level. Not a type-safety fix (Bool has no canonicalize-pipeline variant fan-out like Enum), but codebase consistency: a future contributor adding a Bool attribute should find a named helper next to its String/enum siblings, not learn yet another inline idiom.

## Scope

**Helper** (`carina-provider-aws/src/helpers.rs`):

- `optional_bool_attr(resource: &Resource, attr_name: &str) -> Option<bool>`, `pub(crate)` per the #440 visibility hygiene.
- Unit tests covering present-as-Bool / absent / wrong-shape.

**Sweep — 10 call sites across 4 files**:

| File | Attributes migrated |
|---|---|
| `services/ec2/subnet.rs` | `map_public_ip_on_launch`, `assign_ipv6_address_on_creation`, `enable_dns64` |
| `services/ec2/vpc.rs` | `enable_dns_support`, `enable_dns_hostnames` (create + update) |
| `services/ec2/vpc_endpoint.rs` | `private_dns_enabled` (create + update) |
| `services/s3/bucket_public_access_block.rs` | `block_public_acls`, `ignore_public_acls`, `block_public_policy`, `restrict_public_buckets` |

**Intentionally NOT migrated** (verified during the sweep — all 14 residual `ConcreteValue::Bool` matches in `services/` correctly classified):

- AWS state-read construction sites that build `attributes` from SDK responses.
- Nested Map reads inside resource walks (those go through `optional_bool_struct_field` per #445).
- Wire serializers (SQS attribute packer; IAM policy-doc JSON serializer).
- Test fixtures.

## Tests

`cargo nextest run -p carina-provider-aws`: 308 passed (was 305 on main; +3 for the new helper).

## Verify

```
cargo check -p carina-provider-aws                                # green
cargo nextest run -p carina-provider-aws                          # 308 passed
cargo clippy --workspace --all-targets -- -D warnings             # green
bash scripts/check-examples.sh                                    # green
bash scripts/check-string-enum-aliases.sh                         # green
```

## Note on type-safety

Unlike `optional_enum_attr`, this helper does not add type-safety beyond readability — `ConcreteValue::Bool` is the only canonicalize-pipeline-produced shape for a schema-typed Bool attribute (no `EnumIdentifier`/`CanonicalEnum` analogue). The pre-PR inline pattern was already correct; this PR is consistency, not bug-fix. The deeper Rust-type-level reshape (`Resource::get_bool_attr` returning a typed wrapper that makes raw-Value mismatch unrepresentable) lives in carina-rs/carina#3555 and is intentionally out of scope.

Closes #451
