### PR TITLE
feat(provider): follow Provider::create to CreateOutcome (carina#3567)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b63267e#1b63267ea9ee3e30519bfd4ac4d499a1c1c5ac9c"
+source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b63267e#1b63267ea9ee3e30519bfd4ac4d499a1c1c5ac9c"
+source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b63267e#1b63267ea9ee3e30519bfd4ac4d499a1c1c5ac9c"
+source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
 dependencies = [
  "serde",
  "serde_json",
@@ -1122,7 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2040,7 +2040,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2305,7 +2305,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b63267e" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b63267e" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "1b63267e" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "1b63267e" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use carina_core::provider::CreateOutcome as CoreCreateOutcome;
 use carina_core::resource::{
     ConcreteValue, DataSource as CoreDataSource, DeferredValue, Directives as CoreDirectives,
     Resource as CoreResource, ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
@@ -18,10 +19,12 @@ use carina_core::schema::{
 };
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
-    Directives as ProtoDirectives, OperationConfig as ProtoOperationConfig,
-    Resource as ProtoResource, ResourceId as ProtoResourceId,
-    ResourceSchema as ProtoResourceSchema, SchemaKind as ProtoSchemaKind, State as ProtoState,
-    StructField as ProtoStructField, Value as ProtoValue,
+    CreateOutcome as ProtoCreateOutcome, Directives as ProtoDirectives,
+    OperationConfig as ProtoOperationConfig,
+    PartialCreateDiagnostic as ProtoPartialCreateDiagnostic, Resource as ProtoResource,
+    ResourceId as ProtoResourceId, ResourceSchema as ProtoResourceSchema,
+    SchemaKind as ProtoSchemaKind, State as ProtoState, StructField as ProtoStructField,
+    Value as ProtoValue,
 };
 
 // -- ResourceId --
@@ -160,6 +163,25 @@ pub fn proto_to_core_state(s: &ProtoState) -> CoreState {
         state
     } else {
         CoreState::not_found(id)
+    }
+}
+
+// -- CreateOutcome --
+
+pub fn core_to_proto_create_outcome(outcome: CoreCreateOutcome) -> ProtoCreateOutcome {
+    match outcome {
+        CoreCreateOutcome::Success { state } => ProtoCreateOutcome::Success {
+            state: core_to_proto_state(&state),
+        },
+        CoreCreateOutcome::PartialSuccess { state, diagnostic } => {
+            ProtoCreateOutcome::PartialSuccess {
+                state: core_to_proto_state(&state),
+                diagnostic: ProtoPartialCreateDiagnostic {
+                    reason: diagnostic.reason().to_string(),
+                    missing_attributes: diagnostic.missing_attributes().to_vec(),
+                },
+            }
+        }
     }
 }
 

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -5,9 +5,9 @@ use carina_plugin_sdk::CarinaProvider;
 use carina_provider_protocol::types as proto;
 
 use carina_core::provider::{
-    CreateRequest as CoreCreateRequest, DeleteRequest as CoreDeleteRequest, PatchOp as CorePatchOp,
-    PatchOpKind as CorePatchOpKind, Provider, ProviderError as CoreProviderError,
-    ProviderNormalizer, ReadRequest as CoreReadRequest, UpdatePatch as CoreUpdatePatch,
+    DeleteRequest as CoreDeleteRequest, PatchOp as CorePatchOp, PatchOpKind as CorePatchOpKind,
+    Provider, ProviderError as CoreProviderError, ProviderNormalizer,
+    ReadRequest as CoreReadRequest, UpdatePatch as CoreUpdatePatch,
     UpdateRequest as CoreUpdateRequest,
 };
 use carina_core::resource::{ConcreteValue, Value as CoreValue};
@@ -294,10 +294,9 @@ impl CarinaProvider for AwsProcessProvider {
 
     fn create(
         &self,
-        id: &proto::ResourceId,
+        _id: &proto::ResourceId,
         request: proto::CreateRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
-        let core_id = convert::proto_to_core_resource_id(id);
+    ) -> Result<proto::CreateOutcome, proto::ProviderError> {
         let core_resource = convert::proto_to_core_resource(&request.resource);
         let schemas = Self::schema_registry();
         let core_resource = self.runtime.block_on(
@@ -309,14 +308,11 @@ impl CarinaProvider for AwsProcessProvider {
                 &schemas,
             ),
         );
-        let core_request = CoreCreateRequest {
-            resource: core_resource,
-        };
         let result = self
             .runtime
-            .block_on(self.provider().create(&core_id, core_request));
+            .block_on(self.provider().create_resource(core_resource.as_resource()));
         match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Ok(outcome) => Ok(convert::core_to_proto_create_outcome(outcome)),
             Err(e) => Err(Self::convert_error(e)),
         }
     }

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -2,13 +2,92 @@
 
 use carina_core::effect::PlanOp;
 use carina_core::provider::{
-    BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderResult, ReadRequest,
-    UpdateRequest,
+    BoxFuture, CreateOutcome, CreateRequest, DeleteRequest, Provider, ProviderError,
+    ProviderResult, ReadRequest, UpdateRequest,
 };
-use carina_core::resource::{DataSource, ResourceId, State};
+use carina_core::resource::{DataSource, Resource, ResourceId, State};
 
 use crate::AwsProvider;
 use crate::helpers::apply_patch_to_state;
+
+impl AwsProvider {
+    pub async fn create_resource(&self, resource: &Resource) -> ProviderResult<CreateOutcome> {
+        let state = match resource.id.resource_type.as_str() {
+            "s3.Bucket" => self.create_s3_bucket(resource).await,
+            "s3.BucketPolicy" => self.create_s3_bucket_policy(resource).await,
+            "s3.BucketPublicAccessBlock" => {
+                self.create_s3_bucket_public_access_block(resource).await
+            }
+            "s3.BucketVersioning" => self.create_s3_bucket_versioning(resource).await,
+            "s3.BucketServerSideEncryptionConfiguration" => {
+                self.create_s3_bucket_server_side_encryption_configuration(resource)
+                    .await
+            }
+            "s3.BucketAcl" => self.create_s3_bucket_acl(resource).await,
+            "s3.BucketOwnershipControls" => {
+                self.create_s3_bucket_ownership_controls(resource).await
+            }
+            "s3.BucketReplicationConfiguration" => {
+                self.create_s3_bucket_replication_configuration(resource)
+                    .await
+            }
+            "s3.BucketLifecycleConfiguration" => {
+                self.create_s3_bucket_lifecycle_configuration(resource)
+                    .await
+            }
+            "s3.BucketWebsiteConfiguration" => {
+                self.create_s3_bucket_website_configuration(resource).await
+            }
+            "s3.BucketCorsConfiguration" => {
+                self.create_s3_bucket_cors_configuration(resource).await
+            }
+            "s3.BucketNotificationConfiguration" => {
+                self.create_s3_bucket_notification_configuration(resource)
+                    .await
+            }
+            "s3.BucketLogging" => self.create_s3_bucket_logging(resource).await,
+            "ec2.Eip" => self.create_ec2_eip(resource).await,
+            "ec2.Vpc" => self.create_ec2_vpc(resource).await,
+            "ec2.Subnet" => self.create_ec2_subnet(resource).await,
+            "ec2.InternetGateway" => self.create_ec2_internet_gateway(resource).await,
+            "ec2.NatGateway" => self.create_ec2_nat_gateway(resource).await,
+            "ec2.RouteTable" => self.create_ec2_route_table(resource).await,
+            "ec2.Route" => self.create_ec2_route(resource).await,
+            "ec2.SecurityGroup" => self.create_ec2_security_group(resource).await,
+            "ec2.SecurityGroupIngress" => self.create_ec2_security_group_ingress(resource).await,
+            "ec2.SecurityGroupEgress" => self.create_ec2_security_group_egress(resource).await,
+            "ec2.SubnetRouteTableAssociation" => {
+                self.create_ec2_subnet_route_table_association(resource)
+                    .await
+            }
+            "ec2.FlowLog" => self.create_ec2_flow_log(resource).await,
+            "ec2.VpcEndpoint" => self.create_ec2_vpc_endpoint(resource).await,
+            "ec2.VpcGatewayAttachment" => self.create_ec2_vpc_gateway_attachment(resource).await,
+            "ec2.VpnGateway" => self.create_ec2_vpn_gateway(resource).await,
+            "ec2.TransitGateway" => self.create_ec2_transit_gateway(resource).await,
+            "ec2.TransitGatewayAttachment" => {
+                self.create_ec2_transit_gateway_attachment(resource).await
+            }
+            "ec2.VpcPeeringConnection" => self.create_ec2_vpc_peering_connection(resource).await,
+            "ec2.EgressOnlyInternetGateway" => {
+                self.create_ec2_egress_only_internet_gateway(resource).await
+            }
+            "organizations.Account" => self.create_organizations_account(resource).await,
+            "organizations.Organization" => self.create_organizations_organization(resource).await,
+            "iam.Role" => self.create_iam_role(resource).await,
+            "logs.LogGroup" => self.create_logs_log_group(resource).await,
+            "route53.RecordSet" => self.create_route53_record_set(resource).await,
+            "acm.Certificate" => self.create_acm_certificate(resource).await,
+            "sqs.Queue" => self.create_sqs_queue(resource).await,
+            _ => Err(ProviderError::internal(format!(
+                "Unknown resource type: {}",
+                resource.id.resource_type
+            ))
+            .for_resource(resource.id.clone())),
+        }?;
+        Ok(CreateOutcome::Success { state })
+    }
+}
 
 impl Provider for AwsProvider {
     fn name(&self) -> &str {
@@ -162,92 +241,9 @@ impl Provider for AwsProvider {
         &self,
         _id: &ResourceId,
         request: CreateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<CreateOutcome>> {
         let resource = request.resource;
-        Box::pin(async move {
-            let resource = resource.as_resource();
-            match resource.id.resource_type.as_str() {
-                "s3.Bucket" => self.create_s3_bucket(resource).await,
-                "s3.BucketPolicy" => self.create_s3_bucket_policy(resource).await,
-                "s3.BucketPublicAccessBlock" => {
-                    self.create_s3_bucket_public_access_block(resource).await
-                }
-                "s3.BucketVersioning" => self.create_s3_bucket_versioning(resource).await,
-                "s3.BucketServerSideEncryptionConfiguration" => {
-                    self.create_s3_bucket_server_side_encryption_configuration(resource)
-                        .await
-                }
-                "s3.BucketAcl" => self.create_s3_bucket_acl(resource).await,
-                "s3.BucketOwnershipControls" => {
-                    self.create_s3_bucket_ownership_controls(resource).await
-                }
-                "s3.BucketReplicationConfiguration" => {
-                    self.create_s3_bucket_replication_configuration(resource)
-                        .await
-                }
-                "s3.BucketLifecycleConfiguration" => {
-                    self.create_s3_bucket_lifecycle_configuration(resource)
-                        .await
-                }
-                "s3.BucketWebsiteConfiguration" => {
-                    self.create_s3_bucket_website_configuration(resource).await
-                }
-                "s3.BucketCorsConfiguration" => {
-                    self.create_s3_bucket_cors_configuration(resource).await
-                }
-                "s3.BucketNotificationConfiguration" => {
-                    self.create_s3_bucket_notification_configuration(resource)
-                        .await
-                }
-                "s3.BucketLogging" => self.create_s3_bucket_logging(resource).await,
-                "ec2.Eip" => self.create_ec2_eip(resource).await,
-                "ec2.Vpc" => self.create_ec2_vpc(resource).await,
-                "ec2.Subnet" => self.create_ec2_subnet(resource).await,
-                "ec2.InternetGateway" => self.create_ec2_internet_gateway(resource).await,
-                "ec2.NatGateway" => self.create_ec2_nat_gateway(resource).await,
-                "ec2.RouteTable" => self.create_ec2_route_table(resource).await,
-                "ec2.Route" => self.create_ec2_route(resource).await,
-                "ec2.SecurityGroup" => self.create_ec2_security_group(resource).await,
-                "ec2.SecurityGroupIngress" => {
-                    self.create_ec2_security_group_ingress(resource).await
-                }
-                "ec2.SecurityGroupEgress" => self.create_ec2_security_group_egress(resource).await,
-                "ec2.SubnetRouteTableAssociation" => {
-                    self.create_ec2_subnet_route_table_association(resource)
-                        .await
-                }
-                "ec2.FlowLog" => self.create_ec2_flow_log(resource).await,
-                "ec2.VpcEndpoint" => self.create_ec2_vpc_endpoint(resource).await,
-                "ec2.VpcGatewayAttachment" => {
-                    self.create_ec2_vpc_gateway_attachment(resource).await
-                }
-                "ec2.VpnGateway" => self.create_ec2_vpn_gateway(resource).await,
-                "ec2.TransitGateway" => self.create_ec2_transit_gateway(resource).await,
-                "ec2.TransitGatewayAttachment" => {
-                    self.create_ec2_transit_gateway_attachment(resource).await
-                }
-                "ec2.VpcPeeringConnection" => {
-                    self.create_ec2_vpc_peering_connection(resource).await
-                }
-                "ec2.EgressOnlyInternetGateway" => {
-                    self.create_ec2_egress_only_internet_gateway(resource).await
-                }
-                "organizations.Account" => self.create_organizations_account(resource).await,
-                "organizations.Organization" => {
-                    self.create_organizations_organization(resource).await
-                }
-                "iam.Role" => self.create_iam_role(resource).await,
-                "logs.LogGroup" => self.create_logs_log_group(resource).await,
-                "route53.RecordSet" => self.create_route53_record_set(resource).await,
-                "acm.Certificate" => self.create_acm_certificate(resource).await,
-                "sqs.Queue" => self.create_sqs_queue(resource).await,
-                _ => Err(ProviderError::internal(format!(
-                    "Unknown resource type: {}",
-                    resource.id.resource_type
-                ))
-                .for_resource(resource.id.clone())),
-            }
-        })
+        Box::pin(async move { self.create_resource(resource.as_resource()).await })
     }
 
     fn update(


### PR DESCRIPTION
## Summary

Mechanical follow of carina-rs/carina#3567 (which introduced
`CreateOutcome` on `Provider::create`). The aws provider does not split
create into separate write + post-create-read steps the way
CloudControl does, so every `create_*` path returns
`CreateOutcome::Success { state }`. No partial-success path is wired up;
if a future SDK-direct resource grows one, the `partial_success(...)`
constructor on `carina_core::provider::CreateOutcome` is already
available.

This PR is step 3 of the chain:

1. carina-rs/carina-plugin-wit#25 — WIT `create-outcome` (merged: `ed41fc6`).
2. carina-rs/carina#3569 — Rust trait, executor, state schema, CLI surfacing (merged: `474ce867`).
3. **This PR** — aws provider follow.
4. carina-rs/carina-provider-awscc#369 — structural `ProgressEvent.identifier`
   detection that actually emits `PartialSuccess`.

## Changes

- Bump `carina-core`, `carina-plugin-sdk`, `carina-provider-protocol`
  to `474ce867` (PR1b merge commit) in both `Cargo.toml` files.
- Bump `carina-plugin-wit` submodule to `ed41fc6` (PR1a merge commit).
- `Provider::create` returns `ProviderResult<CreateOutcome>`; the
  per-resource `create_*` paths now wrap their `State` in
  `CreateOutcome::Success { state }` at the dispatcher seam.
- Add `core_to_proto_create_outcome` in `convert.rs` so the
  separate-binary mode (`main.rs`) round-trips the outcome through the
  protocol layer, exhaustively matching both variants.

## Test plan

- `cargo nextest run --all-features`: 531 passed.
- `cargo test --workspace --doc`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `bash scripts/check-*.sh`: all pass (carina-pin verified, examples
  full, no orphan enums).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
