### PR TITLE
feat(provider): follow Provider::update to UpdateOutcome (carina#3571)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
+source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
+source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
+source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
 dependencies = [
  "serde",
  "serde_json",
@@ -1122,7 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2040,7 +2040,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2305,7 +2305,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -6,7 +6,9 @@
 
 use std::collections::HashMap;
 
-use carina_core::provider::CreateOutcome as CoreCreateOutcome;
+use carina_core::provider::{
+    CreateOutcome as CoreCreateOutcome, UpdateOutcome as CoreUpdateOutcome,
+};
 use carina_core::resource::{
     ConcreteValue, DataSource as CoreDataSource, DeferredValue, Directives as CoreDirectives,
     Resource as CoreResource, ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
@@ -20,11 +22,10 @@ use carina_core::schema::{
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
     CreateOutcome as ProtoCreateOutcome, Directives as ProtoDirectives,
-    OperationConfig as ProtoOperationConfig,
-    PartialCreateDiagnostic as ProtoPartialCreateDiagnostic, Resource as ProtoResource,
-    ResourceId as ProtoResourceId, ResourceSchema as ProtoResourceSchema,
-    SchemaKind as ProtoSchemaKind, State as ProtoState, StructField as ProtoStructField,
-    Value as ProtoValue,
+    OperationConfig as ProtoOperationConfig, PartialReadDiagnostic as ProtoPartialReadDiagnostic,
+    Resource as ProtoResource, ResourceId as ProtoResourceId,
+    ResourceSchema as ProtoResourceSchema, SchemaKind as ProtoSchemaKind, State as ProtoState,
+    StructField as ProtoStructField, UpdateOutcome as ProtoUpdateOutcome, Value as ProtoValue,
 };
 
 // -- ResourceId --
@@ -176,7 +177,26 @@ pub fn core_to_proto_create_outcome(outcome: CoreCreateOutcome) -> ProtoCreateOu
         CoreCreateOutcome::PartialSuccess { state, diagnostic } => {
             ProtoCreateOutcome::PartialSuccess {
                 state: core_to_proto_state(&state),
-                diagnostic: ProtoPartialCreateDiagnostic {
+                diagnostic: ProtoPartialReadDiagnostic {
+                    reason: diagnostic.reason().to_string(),
+                    missing_attributes: diagnostic.missing_attributes().to_vec(),
+                },
+            }
+        }
+    }
+}
+
+// -- UpdateOutcome --
+
+pub fn core_to_proto_update_outcome(outcome: CoreUpdateOutcome) -> ProtoUpdateOutcome {
+    match outcome {
+        CoreUpdateOutcome::Success { state } => ProtoUpdateOutcome::Success {
+            state: core_to_proto_state(&state),
+        },
+        CoreUpdateOutcome::PartialSuccess { state, diagnostic } => {
+            ProtoUpdateOutcome::PartialSuccess {
+                state: core_to_proto_state(&state),
+                diagnostic: ProtoPartialReadDiagnostic {
                     reason: diagnostic.reason().to_string(),
                     missing_attributes: diagnostic.missing_attributes().to_vec(),
                 },

--- a/carina-provider-aws/src/main.rs
+++ b/carina-provider-aws/src/main.rs
@@ -322,7 +322,7 @@ impl CarinaProvider for AwsProcessProvider {
         id: &proto::ResourceId,
         identifier: &str,
         request: proto::UpdateRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> Result<proto::UpdateOutcome, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_from = convert::proto_to_core_state(&request.from);
         let core_patch = CoreUpdatePatch {
@@ -349,7 +349,7 @@ impl CarinaProvider for AwsProcessProvider {
             self.runtime
                 .block_on(self.provider().update(&core_id, identifier, core_request));
         match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Ok(outcome) => Ok(convert::core_to_proto_update_outcome(outcome)),
             Err(e) => Err(Self::convert_error(e)),
         }
     }

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -3,7 +3,7 @@
 use carina_core::effect::PlanOp;
 use carina_core::provider::{
     BoxFuture, CreateOutcome, CreateRequest, DeleteRequest, Provider, ProviderError,
-    ProviderResult, ReadRequest, UpdateRequest,
+    ProviderResult, ReadRequest, UpdateOutcome, UpdateRequest,
 };
 use carina_core::resource::{DataSource, Resource, ResourceId, State};
 
@@ -251,7 +251,7 @@ impl Provider for AwsProvider {
         id: &ResourceId,
         identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
         let id = id.clone();
         let identifier = identifier.to_string();
         let from = request.from.clone();
@@ -263,7 +263,7 @@ impl Provider for AwsProvider {
         // for partial-update API paths once those are wired in.
         let to = apply_patch_to_state(&request.from, &request.patch);
         Box::pin(async move {
-            match id.resource_type.as_str() {
+            let state = match id.resource_type.as_str() {
                 "s3.Bucket" => self.update_s3_bucket(id, &identifier, &from, to).await,
                 "s3.BucketPolicy" => {
                     self.update_s3_bucket_policy(id, &identifier, &from, to)
@@ -398,7 +398,9 @@ impl Provider for AwsProvider {
                     id.resource_type
                 ))
                 .for_resource(id.clone())),
-            }
+            }?;
+
+            Ok(UpdateOutcome::Success { state })
         })
     }
 


### PR DESCRIPTION
## Summary

Mechanical follow of carina-rs/carina#3574 (which introduced
`UpdateOutcome` on `Provider::update`). The aws provider does not
split update into separate mutate + post-update-read steps the way
CloudControl does, so every `update_*` path returns
`UpdateOutcome::Success { state }`. No partial-success path is wired
up; if a future SDK-direct resource grows one, the
`UpdateOutcome::partial_success(...)` constructor on
`carina_core::provider::UpdateOutcome` is already available.

This PR is step 3 of the update chain:

1. carina-rs/carina-plugin-wit#26 — WIT `update-outcome` (merged: `53469e8`).
2. carina-rs/carina#3574 — Rust trait, executor, mock + e2e (merged: `c5231c06`).
3. **This PR** — aws provider follow.
4. carina-rs/carina-provider-awscc#371 — structural detection that
   actually emits `UpdateOutcome::PartialSuccess`.

## Changes

- Bump `carina-core`, `carina-plugin-sdk`, `carina-provider-protocol`
  to `c5231c06` in both `Cargo.toml` files.
- Bump `carina-plugin-wit` submodule to `53469e8`.
- `Provider::update` returns `ProviderResult<UpdateOutcome>`; the
  per-resource `update_*` paths wrap their `State` in
  `UpdateOutcome::Success { state }` at the dispatcher seam.
- `convert.rs` follows the `PartialCreateDiagnostic` →
  `PartialReadDiagnostic` rename and adds `core_to_proto_update_outcome`.

## Test plan

- `cargo nextest run --all-features`: 531 passed.
- `cargo test --workspace --doc`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `bash scripts/check-*.sh`: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
