### PR TITLE
feat(helpers): require ResourceSchema for enum reads, sweep raw-match sites (carina#3555 PR2/PR3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
+source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
+source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
+source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
 dependencies = [
  "serde",
  "serde_json",
@@ -1122,7 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2040,7 +2040,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2305,7 +2305,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/ec2_security_group_rules.rs
+++ b/carina-provider-aws/src/ec2_security_group_rules.rs
@@ -4,9 +4,11 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
+use crate::helpers::require_enum_attr;
 
 impl AwsProvider {
     /// Read an EC2 Security Group Rule (shared between ingress and egress)
@@ -106,6 +108,7 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_security_group_rule(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
         is_ingress: bool,
     ) -> ProviderResult<State> {
         let sg_id = match resource.get_attr("group_id") {
@@ -118,10 +121,8 @@ impl AwsProvider {
             }
         };
 
-        let protocol = match resource.get_attr("ip_protocol") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
-            _ => "-1".to_string(),
-        };
+        let protocol =
+            require_enum_attr(resource, schema, "ip_protocol").unwrap_or_else(|_| "-1".to_string());
 
         let from_port = match resource.get_attr("from_port") {
             Some(Value::Concrete(ConcreteValue::Int(n))) => *n as i32,
@@ -278,12 +279,14 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         to: Resource,
+        schema: &ResourceSchema,
         is_ingress: bool,
     ) -> ProviderResult<State> {
         // Security group rules are immutable - delete and recreate
         self.delete_ec2_security_group_rule(id.clone(), identifier, is_ingress)
             .await?;
-        self.create_ec2_security_group_rule(&to, is_ingress).await
+        self.create_ec2_security_group_rule(&to, schema, is_ingress)
+            .await
     }
 
     /// Delete an EC2 Security Group Rule (deletes all rules by identifier)

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -14,7 +14,8 @@ use aws_smithy_types::retry::ProvideErrorKind;
 use tokio::time::sleep;
 
 use carina_core::provider::{PatchOpKind, ProviderError, ProviderResult, UpdatePatch};
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, EnumValueResolver, Resource, ResourceId, State, Value};
+use carina_core::schema::{AttributeType, ResourceSchema, Shape, ShapeWalkBudget};
 
 /// Borrow a `Value` as `&str` if it is a concrete string, otherwise `None`.
 pub fn value_as_str(v: &Value) -> Option<&str> {
@@ -38,38 +39,25 @@ pub fn require_string_attr(resource: &Resource, attr_name: &str) -> ProviderResu
     }
 }
 
-/// Return the AWS API canonical spelling for a schema-typed enum
-/// attribute, accepting every `Value` shape the carina-core canonicalize
-/// pipeline can produce at the provider boundary:
-///
-/// - `ConcreteValue::String(s)` — quoted-string DSL form
-///   (`validation_method = 'DNS'`) or a state-read echo
-/// - `ConcreteValue::EnumIdentifier(raw)` — bare DSL identifier form
-///   (`validation_method = dns`, post-carina#3463)
-/// - `ConcreteValue::CanonicalEnum(c)` — typed witness produced by
-///   `canonicalize_resources_with_schemas` for schema-known values
-///   (carina#3438)
-///
-/// Returns `None` for any other shape or a missing attribute. Use this
-/// (or its wrappers below) for any schema attribute declared as
-/// `AttributeType::enum_(..)`. Plain `value_as_str` /
-/// `require_string_attr` match only `ConcreteValue::String` and silently
-/// drop the other two variants, which is the carina-rs/carina-provider-aws#440
-/// failure mode.
-pub(crate) fn enum_attr_str<'a>(resource: &'a Resource, attr_name: &str) -> Option<&'a str> {
-    match resource.get_attr(attr_name)? {
-        Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
-        Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => Some(raw.as_str()),
-        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => Some(c.api_value()),
-        _ => None,
-    }
+pub(crate) fn enum_attr_str<'a>(
+    resource: &'a Resource,
+    schema: &'a ResourceSchema,
+    attr_name: &str,
+) -> Option<&'a str> {
+    resource
+        .get_enum_attr(schema, attr_name)
+        .map(|a| a.api_value())
 }
 
 /// Required-attribute wrapper around [`enum_attr_str`]. Returns the
 /// AWS API canonical spelling, or `ProviderError::invalid_input`
 /// when the attribute is absent or carries a non-enum-shaped value.
-pub fn require_enum_attr(resource: &Resource, attr_name: &str) -> ProviderResult<String> {
-    enum_attr_str(resource, attr_name)
+pub fn require_enum_attr(
+    resource: &Resource,
+    schema: &ResourceSchema,
+    attr_name: &str,
+) -> ProviderResult<String> {
+    enum_attr_str(resource, schema, attr_name)
         .map(|s| s.to_string())
         .ok_or_else(|| {
             ProviderError::invalid_input(format!("{} is required", attr_name))
@@ -80,8 +68,12 @@ pub fn require_enum_attr(resource: &Resource, attr_name: &str) -> ProviderResult
 /// Optional-attribute wrapper around [`enum_attr_str`] for readability
 /// at call sites where the enum is optional (e.g. ACM
 /// `validation_method`, `key_algorithm`).
-pub fn optional_enum_attr<'a>(resource: &'a Resource, attr_name: &str) -> Option<&'a str> {
-    enum_attr_str(resource, attr_name)
+pub fn optional_enum_attr<'a>(
+    resource: &'a Resource,
+    schema: &'a ResourceSchema,
+    attr_name: &str,
+) -> Option<&'a str> {
+    enum_attr_str(resource, schema, attr_name)
 }
 
 /// Return the `bool` value of a top-level `Bool`-typed attribute.
@@ -111,26 +103,69 @@ pub(crate) fn optional_bool_attr(resource: &Resource, attr_name: &str) -> Option
 /// `m.get("dns_support")`).
 pub(crate) fn enum_struct_field_str<'a>(
     resource: &'a Resource,
+    schema: &'a ResourceSchema,
     struct_attr: &str,
     field_name: &str,
 ) -> Option<&'a str> {
-    let Some(Value::Concrete(ConcreteValue::Map(m))) = resource.get_attr(struct_attr) else {
-        return None;
-    };
-    match m.get(field_name)? {
-        Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
-        Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => Some(raw.as_str()),
-        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => Some(c.api_value()),
-        _ => None,
-    }
+    resource
+        .get_enum_struct_field(schema, struct_attr, field_name)
+        .map(|a| a.api_value())
 }
 
 pub(crate) fn optional_enum_struct_field<'a>(
     resource: &'a Resource,
+    schema: &'a ResourceSchema,
     struct_attr: &str,
     field_name: &str,
 ) -> Option<&'a str> {
-    enum_struct_field_str(resource, struct_attr, field_name)
+    enum_struct_field_str(resource, schema, struct_attr, field_name)
+}
+
+pub(crate) fn optional_enum_value_at_schema_path(
+    schema: &ResourceSchema,
+    root_attr: &str,
+    path: &[&str],
+    value: &Value,
+) -> Option<String> {
+    let attr_type = enum_attr_type_at_schema_path(schema, root_attr, path)?;
+    let Shape::Enum { identity, .. } = schema.shape_of(attr_type) else {
+        return None;
+    };
+    let resolver = EnumValueResolver::with_defs(attr_type, &schema.defs);
+    match value {
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) if c.identity() == identity => {
+            Some(c.api_value().to_string())
+        }
+        Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => resolver
+            .resolve_raw(raw)
+            .ok()
+            .map(|c| c.api_value().to_string()),
+        Value::Concrete(ConcreteValue::String(s)) => resolver
+            .resolve_state_text(s)
+            .ok()
+            .map(|c| c.api_value().to_string()),
+        _ => None,
+    }
+}
+
+fn enum_attr_type_at_schema_path<'a>(
+    schema: &'a ResourceSchema,
+    root_attr: &str,
+    path: &[&str],
+) -> Option<&'a AttributeType> {
+    let mut attr_type = &schema.attributes.get(root_attr)?.attr_type;
+    for segment in path {
+        while let Shape::List { element_type, .. } = schema.shape_of(attr_type) {
+            attr_type = element_type;
+        }
+        let mut budget = ShapeWalkBudget::new(64);
+        let fields = schema.struct_fields_with_budget(attr_type, &mut budget)?;
+        attr_type = &fields
+            .iter()
+            .find(|field| field.name == *segment)?
+            .field_type;
+    }
+    Some(attr_type)
 }
 
 /// Return the `i64` value of an `Int`-typed field inside the nested
@@ -556,6 +591,10 @@ mod tests {
         )
     }
 
+    fn acm_schema() -> ResourceSchema {
+        crate::schemas::generated::acm::certificate::acm_certificate_config().schema
+    }
+
     fn canonical_validation_method_value() -> Value {
         use carina_core::schema::{AttributeType, Schema, enum_identity};
 
@@ -571,6 +610,26 @@ mod tests {
         );
         let schema = Schema::flat(attr_type);
         schema.canonicalize(Value::Concrete(ConcreteValue::enum_identifier("dns")))
+    }
+
+    fn canonical_certificate_transparency_value() -> Value {
+        use carina_core::schema::{AttributeType, Schema, enum_identity};
+
+        let attr_type = AttributeType::enum_(
+            enum_identity(
+                "CertificateTransparencyLoggingPreference",
+                Some("aws.acm.Certificate.CertificateOptions"),
+            ),
+            Some(vec!["DISABLED".to_string(), "ENABLED".to_string()]),
+            vec![
+                ("DISABLED".to_string(), "disabled".to_string()),
+                ("ENABLED".to_string(), "enabled".to_string()),
+            ],
+            None,
+            None,
+        );
+        let schema = Schema::flat(attr_type);
+        schema.canonicalize(Value::Concrete(ConcreteValue::enum_identifier("enabled")))
     }
 
     #[test]
@@ -654,68 +713,108 @@ mod tests {
 
     #[test]
     fn test_require_enum_attr_string() {
-        let resource = make_test_resource(vec![("type", "DNS")]);
-        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "DNS");
+        let schema = acm_schema();
+        let resource = make_test_resource(vec![("validation_method", "DNS")]);
+        assert_eq!(
+            require_enum_attr(&resource, &schema, "validation_method").unwrap(),
+            "DNS"
+        );
     }
 
     #[test]
     fn test_require_enum_attr_enum_identifier() {
+        let schema = acm_schema();
         let resource = make_resource_with_value(
-            "type",
+            "validation_method",
             Value::Concrete(ConcreteValue::enum_identifier("dns")),
         );
-        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "dns");
+        assert_eq!(
+            require_enum_attr(&resource, &schema, "validation_method").unwrap(),
+            "DNS"
+        );
     }
 
     #[test]
     fn test_require_enum_attr_canonical_enum() {
-        let resource = make_resource_with_value("type", canonical_validation_method_value());
-        assert_eq!(require_enum_attr(&resource, "type").unwrap(), "DNS");
+        let schema = acm_schema();
+        let resource =
+            make_resource_with_value("validation_method", canonical_validation_method_value());
+        assert_eq!(
+            require_enum_attr(&resource, &schema, "validation_method").unwrap(),
+            "DNS"
+        );
     }
 
     #[test]
     fn test_require_enum_attr_missing_is_err() {
+        let schema = acm_schema();
         let resource = make_test_resource(vec![]);
-        assert!(require_enum_attr(&resource, "type").is_err());
+        assert!(require_enum_attr(&resource, &schema, "validation_method").is_err());
     }
 
     #[test]
     fn test_require_enum_attr_non_enum_shape_is_err() {
-        let resource = make_resource_with_value("type", Value::Concrete(ConcreteValue::Int(1)));
-        assert!(require_enum_attr(&resource, "type").is_err());
+        let schema = acm_schema();
+        let resource =
+            make_resource_with_value("validation_method", Value::Concrete(ConcreteValue::Int(1)));
+        assert!(require_enum_attr(&resource, &schema, "validation_method").is_err());
     }
 
     #[test]
     fn test_optional_enum_attr_string() {
-        let resource = make_test_resource(vec![("type", "DNS")]);
-        assert_eq!(optional_enum_attr(&resource, "type"), Some("DNS"));
+        let schema = acm_schema();
+        let resource = make_test_resource(vec![("validation_method", "DNS")]);
+        assert_eq!(
+            optional_enum_attr(&resource, &schema, "validation_method"),
+            Some("DNS")
+        );
     }
 
     #[test]
     fn test_optional_enum_attr_enum_identifier() {
+        let schema = acm_schema();
         let resource = make_resource_with_value(
-            "type",
+            "validation_method",
             Value::Concrete(ConcreteValue::enum_identifier("dns")),
         );
-        assert_eq!(optional_enum_attr(&resource, "type"), Some("dns"));
+        assert_eq!(
+            optional_enum_attr(&resource, &schema, "validation_method"),
+            Some("DNS")
+        );
     }
 
     #[test]
     fn test_optional_enum_attr_canonical_enum() {
-        let resource = make_resource_with_value("type", canonical_validation_method_value());
-        assert_eq!(optional_enum_attr(&resource, "type"), Some("DNS"));
+        let schema = acm_schema();
+        let resource =
+            make_resource_with_value("validation_method", canonical_validation_method_value());
+        assert_eq!(
+            optional_enum_attr(&resource, &schema, "validation_method"),
+            Some("DNS")
+        );
     }
 
     #[test]
     fn test_optional_enum_attr_missing_is_none() {
+        let schema = acm_schema();
         let resource = make_test_resource(vec![]);
-        assert_eq!(optional_enum_attr(&resource, "type"), None);
+        assert_eq!(
+            optional_enum_attr(&resource, &schema, "validation_method"),
+            None
+        );
     }
 
     #[test]
     fn test_optional_enum_attr_non_enum_shape_is_none() {
-        let resource = make_resource_with_value("type", Value::Concrete(ConcreteValue::Bool(true)));
-        assert_eq!(optional_enum_attr(&resource, "type"), None);
+        let schema = acm_schema();
+        let resource = make_resource_with_value(
+            "validation_method",
+            Value::Concrete(ConcreteValue::Bool(true)),
+        );
+        assert_eq!(
+            optional_enum_attr(&resource, &schema, "validation_method"),
+            None
+        );
     }
 
     #[test]
@@ -748,6 +847,7 @@ mod tests {
 
     #[test]
     fn test_optional_enum_struct_field_string() {
+        let schema = acm_schema();
         let resource = make_resource_with_struct_field(
             "certificate_transparency_logging_preference",
             Value::Concrete(ConcreteValue::String("ENABLED".to_string())),
@@ -755,6 +855,7 @@ mod tests {
         assert_eq!(
             optional_enum_struct_field(
                 &resource,
+                &schema,
                 "options",
                 "certificate_transparency_logging_preference"
             ),
@@ -764,6 +865,7 @@ mod tests {
 
     #[test]
     fn test_optional_enum_struct_field_enum_identifier() {
+        let schema = acm_schema();
         let resource = make_resource_with_struct_field(
             "certificate_transparency_logging_preference",
             Value::Concrete(ConcreteValue::enum_identifier("enabled")),
@@ -771,22 +873,29 @@ mod tests {
         assert_eq!(
             optional_enum_struct_field(
                 &resource,
+                &schema,
                 "options",
                 "certificate_transparency_logging_preference"
             ),
-            Some("enabled")
+            Some("ENABLED")
         );
     }
 
     #[test]
     fn test_optional_enum_struct_field_canonical_enum() {
+        let schema = acm_schema();
         let resource = make_resource_with_struct_field(
-            "validation_method",
-            canonical_validation_method_value(),
+            "certificate_transparency_logging_preference",
+            canonical_certificate_transparency_value(),
         );
         assert_eq!(
-            optional_enum_struct_field(&resource, "options", "validation_method"),
-            Some("DNS")
+            optional_enum_struct_field(
+                &resource,
+                &schema,
+                "options",
+                "certificate_transparency_logging_preference"
+            ),
+            Some("ENABLED")
         );
     }
 
@@ -854,9 +963,10 @@ mod tests {
 
     #[test]
     fn test_struct_field_helpers_missing_outer_struct_are_none() {
+        let schema = acm_schema();
         let resource = make_test_resource(vec![]);
         assert_eq!(
-            optional_enum_struct_field(&resource, "options", "dns_support"),
+            optional_enum_struct_field(&resource, &schema, "options", "dns_support"),
             None
         );
         assert_eq!(
@@ -879,12 +989,13 @@ mod tests {
 
     #[test]
     fn test_struct_field_helpers_non_map_outer_struct_are_none() {
+        let schema = acm_schema();
         let resource = make_resource_with_value(
             "options",
             Value::Concrete(ConcreteValue::String("not-a-map".to_string())),
         );
         assert_eq!(
-            optional_enum_struct_field(&resource, "options", "dns_support"),
+            optional_enum_struct_field(&resource, &schema, "options", "dns_support"),
             None
         );
         assert_eq!(
@@ -907,12 +1018,13 @@ mod tests {
 
     #[test]
     fn test_struct_field_helpers_missing_field_are_none() {
+        let schema = acm_schema();
         let resource = make_resource_with_value(
             "options",
             Value::Concrete(ConcreteValue::Map(IndexMap::new())),
         );
         assert_eq!(
-            optional_enum_struct_field(&resource, "options", "dns_support"),
+            optional_enum_struct_field(&resource, &schema, "options", "dns_support"),
             None
         );
         assert_eq!(
@@ -935,6 +1047,7 @@ mod tests {
 
     #[test]
     fn test_struct_field_helpers_wrong_shape_are_none() {
+        let schema = acm_schema();
         let enum_resource = make_resource_with_struct_field(
             "dns_support",
             Value::Concrete(ConcreteValue::Bool(true)),
@@ -964,7 +1077,7 @@ mod tests {
             )])),
         );
         assert_eq!(
-            optional_enum_struct_field(&enum_resource, "options", "dns_support"),
+            optional_enum_struct_field(&enum_resource, &schema, "options", "dns_support"),
             None
         );
         assert_eq!(

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -30,6 +30,7 @@ use aws_sdk_route53::Client as Route53Client;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sqs::Client as SqsClient;
 use aws_sdk_sts::Client as StsClient;
+use carina_core::schema::{ResourceSchema, SchemaKind, SchemaRegistry};
 
 /// AWS Provider
 pub struct AwsProvider {
@@ -43,6 +44,7 @@ pub struct AwsProvider {
     route53_client: Route53Client,
     acm_client: AcmClient,
     sqs_client: SqsClient,
+    schema_registry: SchemaRegistry,
     region: String,
     /// Provider-level allow-list of AWS account IDs. Empty means "no
     /// allow-list configured" (the check is skipped). Enforced once
@@ -94,6 +96,19 @@ impl AwsProvider {
         )
     }
 
+    fn schema_registry() -> SchemaRegistry {
+        let mut registry = SchemaRegistry::new();
+        for schema in crate::schemas::all_schemas() {
+            registry.insert("aws", schema);
+        }
+        registry
+    }
+
+    pub(crate) fn resource_schema(&self, resource_type: &str) -> Option<&ResourceSchema> {
+        self.schema_registry
+            .get("aws", resource_type, SchemaKind::Resource)
+    }
+
     /// Construct an `AwsProvider` from caller-supplied SDK clients.
     ///
     /// `new_with_account_guard` is the production entry point — it
@@ -139,6 +154,7 @@ impl AwsProvider {
             route53_client,
             acm_client,
             sqs_client,
+            schema_registry: Self::schema_registry(),
             region,
             allowed_account_ids,
             forbidden_account_ids,

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -12,31 +12,42 @@ use crate::helpers::apply_patch_to_state;
 
 impl AwsProvider {
     pub async fn create_resource(&self, resource: &Resource) -> ProviderResult<CreateOutcome> {
+        let schema = self
+            .resource_schema(resource.id.resource_type.as_str())
+            .ok_or_else(|| {
+                ProviderError::internal(format!(
+                    "Unknown resource schema: {}",
+                    resource.id.resource_type
+                ))
+                .for_resource(resource.id.clone())
+            })?;
         let state = match resource.id.resource_type.as_str() {
             "s3.Bucket" => self.create_s3_bucket(resource).await,
             "s3.BucketPolicy" => self.create_s3_bucket_policy(resource).await,
             "s3.BucketPublicAccessBlock" => {
                 self.create_s3_bucket_public_access_block(resource).await
             }
-            "s3.BucketVersioning" => self.create_s3_bucket_versioning(resource).await,
+            "s3.BucketVersioning" => self.create_s3_bucket_versioning(resource, schema).await,
             "s3.BucketServerSideEncryptionConfiguration" => {
-                self.create_s3_bucket_server_side_encryption_configuration(resource)
+                self.create_s3_bucket_server_side_encryption_configuration(resource, schema)
                     .await
             }
-            "s3.BucketAcl" => self.create_s3_bucket_acl(resource).await,
+            "s3.BucketAcl" => self.create_s3_bucket_acl(resource, schema).await,
             "s3.BucketOwnershipControls" => {
-                self.create_s3_bucket_ownership_controls(resource).await
+                self.create_s3_bucket_ownership_controls(resource, schema)
+                    .await
             }
             "s3.BucketReplicationConfiguration" => {
-                self.create_s3_bucket_replication_configuration(resource)
+                self.create_s3_bucket_replication_configuration(resource, schema)
                     .await
             }
             "s3.BucketLifecycleConfiguration" => {
-                self.create_s3_bucket_lifecycle_configuration(resource)
+                self.create_s3_bucket_lifecycle_configuration(resource, schema)
                     .await
             }
             "s3.BucketWebsiteConfiguration" => {
-                self.create_s3_bucket_website_configuration(resource).await
+                self.create_s3_bucket_website_configuration(resource, schema)
+                    .await
             }
             "s3.BucketCorsConfiguration" => {
                 self.create_s3_bucket_cors_configuration(resource).await
@@ -45,40 +56,50 @@ impl AwsProvider {
                 self.create_s3_bucket_notification_configuration(resource)
                     .await
             }
-            "s3.BucketLogging" => self.create_s3_bucket_logging(resource).await,
-            "ec2.Eip" => self.create_ec2_eip(resource).await,
-            "ec2.Vpc" => self.create_ec2_vpc(resource).await,
-            "ec2.Subnet" => self.create_ec2_subnet(resource).await,
+            "s3.BucketLogging" => self.create_s3_bucket_logging(resource, schema).await,
+            "ec2.Eip" => self.create_ec2_eip(resource, schema).await,
+            "ec2.Vpc" => self.create_ec2_vpc(resource, schema).await,
+            "ec2.Subnet" => self.create_ec2_subnet(resource, schema).await,
             "ec2.InternetGateway" => self.create_ec2_internet_gateway(resource).await,
-            "ec2.NatGateway" => self.create_ec2_nat_gateway(resource).await,
+            "ec2.NatGateway" => self.create_ec2_nat_gateway(resource, schema).await,
             "ec2.RouteTable" => self.create_ec2_route_table(resource).await,
             "ec2.Route" => self.create_ec2_route(resource).await,
             "ec2.SecurityGroup" => self.create_ec2_security_group(resource).await,
-            "ec2.SecurityGroupIngress" => self.create_ec2_security_group_ingress(resource).await,
-            "ec2.SecurityGroupEgress" => self.create_ec2_security_group_egress(resource).await,
+            "ec2.SecurityGroupIngress" => {
+                self.create_ec2_security_group_ingress(resource, schema)
+                    .await
+            }
+            "ec2.SecurityGroupEgress" => {
+                self.create_ec2_security_group_egress(resource, schema)
+                    .await
+            }
             "ec2.SubnetRouteTableAssociation" => {
                 self.create_ec2_subnet_route_table_association(resource)
                     .await
             }
-            "ec2.FlowLog" => self.create_ec2_flow_log(resource).await,
-            "ec2.VpcEndpoint" => self.create_ec2_vpc_endpoint(resource).await,
+            "ec2.FlowLog" => self.create_ec2_flow_log(resource, schema).await,
+            "ec2.VpcEndpoint" => self.create_ec2_vpc_endpoint(resource, schema).await,
             "ec2.VpcGatewayAttachment" => self.create_ec2_vpc_gateway_attachment(resource).await,
-            "ec2.VpnGateway" => self.create_ec2_vpn_gateway(resource).await,
-            "ec2.TransitGateway" => self.create_ec2_transit_gateway(resource).await,
+            "ec2.VpnGateway" => self.create_ec2_vpn_gateway(resource, schema).await,
+            "ec2.TransitGateway" => self.create_ec2_transit_gateway(resource, schema).await,
             "ec2.TransitGatewayAttachment" => {
-                self.create_ec2_transit_gateway_attachment(resource).await
+                self.create_ec2_transit_gateway_attachment(resource, schema)
+                    .await
             }
             "ec2.VpcPeeringConnection" => self.create_ec2_vpc_peering_connection(resource).await,
             "ec2.EgressOnlyInternetGateway" => {
                 self.create_ec2_egress_only_internet_gateway(resource).await
             }
-            "organizations.Account" => self.create_organizations_account(resource).await,
-            "organizations.Organization" => self.create_organizations_organization(resource).await,
+            "organizations.Account" => self.create_organizations_account(resource, schema).await,
+            "organizations.Organization" => {
+                self.create_organizations_organization(resource, schema)
+                    .await
+            }
             "iam.Role" => self.create_iam_role(resource).await,
-            "logs.LogGroup" => self.create_logs_log_group(resource).await,
-            "route53.RecordSet" => self.create_route53_record_set(resource).await,
-            "acm.Certificate" => self.create_acm_certificate(resource).await,
-            "sqs.Queue" => self.create_sqs_queue(resource).await,
+            "logs.LogGroup" => self.create_logs_log_group(resource, schema).await,
+            "route53.RecordSet" => self.create_route53_record_set(resource, schema).await,
+            "acm.Certificate" => self.create_acm_certificate(resource, schema).await,
+            "sqs.Queue" => self.create_sqs_queue(resource, schema).await,
             _ => Err(ProviderError::internal(format!(
                 "Unknown resource type: {}",
                 resource.id.resource_type
@@ -263,6 +284,15 @@ impl Provider for AwsProvider {
         // for partial-update API paths once those are wired in.
         let to = apply_patch_to_state(&request.from, &request.patch);
         Box::pin(async move {
+            let schema = self
+                .resource_schema(id.resource_type.as_str())
+                .ok_or_else(|| {
+                    ProviderError::internal(format!(
+                        "Unknown resource schema: {}",
+                        id.resource_type
+                    ))
+                    .for_resource(id.clone())
+                })?;
             let state = match id.resource_type.as_str() {
                 "s3.Bucket" => self.update_s3_bucket(id, &identifier, &from, to).await,
                 "s3.BucketPolicy" => {
@@ -274,7 +304,7 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "s3.BucketVersioning" => {
-                    self.update_s3_bucket_versioning(id, &identifier, &from, to)
+                    self.update_s3_bucket_versioning(id, &identifier, &from, to, schema)
                         .await
                 }
                 "s3.BucketServerSideEncryptionConfiguration" => {
@@ -283,24 +313,40 @@ impl Provider for AwsProvider {
                         &identifier,
                         &from,
                         to,
+                        schema,
                     )
                     .await
                 }
-                "s3.BucketAcl" => self.update_s3_bucket_acl(id, &identifier, &from, to).await,
+                "s3.BucketAcl" => {
+                    self.update_s3_bucket_acl(id, &identifier, &from, to, schema)
+                        .await
+                }
                 "s3.BucketOwnershipControls" => {
-                    self.update_s3_bucket_ownership_controls(id, &identifier, &from, to)
+                    self.update_s3_bucket_ownership_controls(id, &identifier, &from, to, schema)
                         .await
                 }
                 "s3.BucketReplicationConfiguration" => {
-                    self.update_s3_bucket_replication_configuration(id, &identifier, &from, to)
-                        .await
+                    self.update_s3_bucket_replication_configuration(
+                        id,
+                        &identifier,
+                        &from,
+                        to,
+                        schema,
+                    )
+                    .await
                 }
                 "s3.BucketLifecycleConfiguration" => {
-                    self.update_s3_bucket_lifecycle_configuration(id, &identifier, &from, to)
-                        .await
+                    self.update_s3_bucket_lifecycle_configuration(
+                        id,
+                        &identifier,
+                        &from,
+                        to,
+                        schema,
+                    )
+                    .await
                 }
                 "s3.BucketWebsiteConfiguration" => {
-                    self.update_s3_bucket_website_configuration(id, &identifier, &from, to)
+                    self.update_s3_bucket_website_configuration(id, &identifier, &from, to, schema)
                         .await
                 }
                 "s3.BucketCorsConfiguration" => {
@@ -312,18 +358,27 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "s3.BucketLogging" => {
-                    self.update_s3_bucket_logging(id, &identifier, &from, to)
+                    self.update_s3_bucket_logging(id, &identifier, &from, to, schema)
                         .await
                 }
-                "ec2.Eip" => self.update_ec2_eip(id, &identifier, &from, to).await,
-                "ec2.Vpc" => self.update_ec2_vpc(id, &identifier, &from, to).await,
-                "ec2.Subnet" => self.update_ec2_subnet(id, &identifier, &from, to).await,
+                "ec2.Eip" => {
+                    self.update_ec2_eip(id, &identifier, &from, to, schema)
+                        .await
+                }
+                "ec2.Vpc" => {
+                    self.update_ec2_vpc(id, &identifier, &from, to, schema)
+                        .await
+                }
+                "ec2.Subnet" => {
+                    self.update_ec2_subnet(id, &identifier, &from, to, schema)
+                        .await
+                }
                 "ec2.InternetGateway" => {
                     self.update_ec2_internet_gateway(id, &identifier, &from, to)
                         .await
                 }
                 "ec2.NatGateway" => {
-                    self.update_ec2_nat_gateway(id, &identifier, &from, to)
+                    self.update_ec2_nat_gateway(id, &identifier, &from, to, schema)
                         .await
                 }
                 "ec2.RouteTable" => {
@@ -336,20 +391,23 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "ec2.SecurityGroupIngress" => {
-                    self.update_ec2_security_group_ingress(id, &identifier, to)
+                    self.update_ec2_security_group_ingress(id, &identifier, to, schema)
                         .await
                 }
                 "ec2.SecurityGroupEgress" => {
-                    self.update_ec2_security_group_egress(id, &identifier, to)
+                    self.update_ec2_security_group_egress(id, &identifier, to, schema)
                         .await
                 }
                 "ec2.SubnetRouteTableAssociation" => {
                     self.update_ec2_subnet_route_table_association(id, &identifier, to)
                         .await
                 }
-                "ec2.FlowLog" => self.update_ec2_flow_log(id, &identifier, &from, to).await,
+                "ec2.FlowLog" => {
+                    self.update_ec2_flow_log(id, &identifier, &from, to, schema)
+                        .await
+                }
                 "ec2.VpcEndpoint" => {
-                    self.update_ec2_vpc_endpoint(id, &identifier, &from, to)
+                    self.update_ec2_vpc_endpoint(id, &identifier, &from, to, schema)
                         .await
                 }
                 "ec2.VpcGatewayAttachment" => {
@@ -357,15 +415,15 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "ec2.VpnGateway" => {
-                    self.update_ec2_vpn_gateway(id, &identifier, &from, to)
+                    self.update_ec2_vpn_gateway(id, &identifier, &from, to, schema)
                         .await
                 }
                 "ec2.TransitGateway" => {
-                    self.update_ec2_transit_gateway(id, &identifier, &from, to)
+                    self.update_ec2_transit_gateway(id, &identifier, &from, to, schema)
                         .await
                 }
                 "ec2.TransitGatewayAttachment" => {
-                    self.update_ec2_transit_gateway_attachment(id, &identifier, &from, to)
+                    self.update_ec2_transit_gateway_attachment(id, &identifier, &from, to, schema)
                         .await
                 }
                 "ec2.VpcPeeringConnection" => {
@@ -377,7 +435,7 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "organizations.Account" => {
-                    self.update_organizations_account(id, &identifier, &from, to)
+                    self.update_organizations_account(id, &identifier, &from, to, schema)
                         .await
                 }
                 "organizations.Organization" => {
@@ -386,13 +444,22 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "iam.Role" => self.update_iam_role(id, &identifier, &from, to).await,
-                "logs.LogGroup" => self.update_logs_log_group(id, &identifier, &from, to).await,
-                "route53.RecordSet" => self.update_route53_record_set(id, &identifier, to).await,
-                "acm.Certificate" => {
-                    self.update_acm_certificate(id, &identifier, &from, to)
+                "logs.LogGroup" => {
+                    self.update_logs_log_group(id, &identifier, &from, to, schema)
                         .await
                 }
-                "sqs.Queue" => self.update_sqs_queue(id, &identifier, &from, to).await,
+                "route53.RecordSet" => {
+                    self.update_route53_record_set(id, &identifier, to, schema)
+                        .await
+                }
+                "acm.Certificate" => {
+                    self.update_acm_certificate(id, &identifier, &from, to, schema)
+                        .await
+                }
+                "sqs.Queue" => {
+                    self.update_sqs_queue(id, &identifier, &from, to, schema)
+                        .await
+                }
                 _ => Err(ProviderError::internal(format!(
                     "Unknown resource type: {}",
                     id.resource_type

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -17,6 +17,7 @@ use indexmap::IndexMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -96,9 +97,11 @@ fn parse_validation_method(input: &str) -> Option<ValidationMethod> {
 
 fn build_update_certificate_options(
     resource: &Resource,
+    schema: &ResourceSchema,
 ) -> Option<aws_sdk_acm::types::CertificateOptions> {
     let pref = optional_enum_struct_field(
         resource,
+        schema,
         "options",
         "certificate_transparency_logging_preference",
     )?;
@@ -111,6 +114,7 @@ fn build_update_certificate_options(
 
 fn build_create_certificate_options(
     resource: &Resource,
+    schema: &ResourceSchema,
 ) -> Option<aws_sdk_acm::types::CertificateOptions> {
     use aws_sdk_acm::types::{CertificateExport, CertificateTransparencyLoggingPreference};
 
@@ -119,6 +123,7 @@ fn build_create_certificate_options(
 
     if let Some(pref) = optional_enum_struct_field(
         resource,
+        schema,
         "options",
         "certificate_transparency_logging_preference",
     ) {
@@ -127,7 +132,7 @@ fn build_create_certificate_options(
         );
         has_options = true;
     }
-    if let Some(export) = optional_enum_struct_field(resource, "options", "export") {
+    if let Some(export) = optional_enum_struct_field(resource, schema, "options", "export") {
         options = options.export(CertificateExport::from(export));
         has_options = true;
     }
@@ -298,7 +303,9 @@ impl AwsProvider {
     pub(crate) async fn create_acm_certificate(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let id = resource.id.clone();
         let domain_name = require_string_attr(resource, "domain_name")?;
 
@@ -307,8 +314,8 @@ impl AwsProvider {
             .request_certificate()
             .domain_name(domain_name);
 
-        if let Some(method) =
-            optional_enum_attr(resource, "validation_method").and_then(parse_validation_method)
+        if let Some(method) = optional_enum_attr(resource, schema, "validation_method")
+            .and_then(parse_validation_method)
         {
             req = req.validation_method(method);
         }
@@ -319,12 +326,12 @@ impl AwsProvider {
         for san in sans {
             req = req.subject_alternative_names(san);
         }
-        if let Some(key_algorithm) = optional_enum_attr(resource, "key_algorithm") {
+        if let Some(key_algorithm) = optional_enum_attr(resource, schema, "key_algorithm") {
             // Pass the AWS canonical form through verbatim — schema
             // narrowing has already validated it.
             req = req.key_algorithm(key_algorithm.into());
         }
-        if let Some(options) = build_create_certificate_options(resource) {
+        if let Some(options) = build_create_certificate_options(resource, schema) {
             req = req.options(options);
         }
         // RequestCertificate accepts tags inline, avoiding a follow-up
@@ -367,8 +374,8 @@ impl AwsProvider {
                 .for_resource(id.clone())
         })?;
 
-        let validation_method =
-            optional_enum_attr(resource, "validation_method").and_then(parse_validation_method);
+        let validation_method = optional_enum_attr(resource, schema, "validation_method")
+            .and_then(parse_validation_method);
 
         // DNS validation populates DomainValidationOptions[].ResourceRecord
         // asynchronously after RequestCertificate. Wait so the post-create
@@ -491,8 +498,10 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        if let Some(options) = build_update_certificate_options(&to) {
+        let _ = schema;
+        if let Some(options) = build_update_certificate_options(&to, schema) {
             self.acm_client
                 .update_certificate_options()
                 .certificate_arn(identifier)
@@ -665,6 +674,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn acm_schema() -> ResourceSchema {
+        crate::schemas::generated::acm::certificate::acm_certificate_config().schema
+    }
     use aws_sdk_acm::types::{
         CertificateDetail, CertificateExport, CertificateOptions,
         CertificateTransparencyLoggingPreference, DomainValidation, RecordType, ResourceRecord,
@@ -813,7 +826,8 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(options)),
         );
 
-        let request_options = build_create_certificate_options(&resource).expect("options");
+        let request_options =
+            build_create_certificate_options(&resource, &acm_schema()).expect("options");
         assert_eq!(request_options.export(), Some(&CertificateExport::Enabled));
     }
 
@@ -834,7 +848,8 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(options)),
         );
 
-        let request_options = build_create_certificate_options(&resource).expect("options");
+        let request_options =
+            build_create_certificate_options(&resource, &acm_schema()).expect("options");
         assert_eq!(
             request_options.certificate_transparency_logging_preference(),
             Some(&CertificateTransparencyLoggingPreference::Disabled)
@@ -855,7 +870,8 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(options)),
         );
 
-        let request_options = build_update_certificate_options(&resource).expect("options");
+        let request_options =
+            build_update_certificate_options(&resource, &acm_schema()).expect("options");
         assert_eq!(
             request_options.certificate_transparency_logging_preference(),
             Some(&CertificateTransparencyLoggingPreference::Disabled)
@@ -1152,7 +1168,8 @@ mod tests {
         // silently returned None.
         let mut resource = Resource::with_provider("aws", "acm.Certificate", "test-cert", None);
         resource.set_attr("validation_method".to_string(), canonical);
-        let parsed = crate::helpers::optional_enum_attr(&resource, "validation_method")
+        let schema = acm_schema();
+        let parsed = crate::helpers::optional_enum_attr(&resource, &schema, "validation_method")
             .and_then(parse_validation_method);
         assert_eq!(
             parsed,
@@ -1178,7 +1195,8 @@ mod tests {
             "validation_method".to_string(),
             Value::Concrete(ConcreteValue::enum_identifier("dns")),
         );
-        let parsed = crate::helpers::optional_enum_attr(&resource, "validation_method")
+        let schema = acm_schema();
+        let parsed = crate::helpers::optional_enum_attr(&resource, &schema, "validation_method")
             .and_then(parse_validation_method);
         assert_eq!(
             parsed,
@@ -1202,7 +1220,8 @@ mod tests {
             "validation_method".to_string(),
             Value::Concrete(ConcreteValue::String("DNS".to_string())),
         );
-        let parsed = crate::helpers::optional_enum_attr(&resource, "validation_method")
+        let schema = acm_schema();
+        let parsed = crate::helpers::optional_enum_attr(&resource, &schema, "validation_method")
             .and_then(parse_validation_method);
         assert_eq!(parsed, Some(ValidationMethod::Dns));
     }

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{Resource, ResourceId, State};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -59,10 +60,15 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Elastic IP
-    pub(crate) async fn create_ec2_eip(&self, resource: &Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_eip(
+        &self,
+        resource: &Resource,
+        schema: &ResourceSchema,
+    ) -> ProviderResult<State> {
+        let _ = schema;
         let mut req = self.ec2_client.allocate_address();
 
-        if let Some(domain) = optional_enum_attr(resource, "domain") {
+        if let Some(domain) = optional_enum_attr(resource, schema, "domain") {
             use aws_sdk_ec2::types::DomainType;
             req = req.domain(DomainType::from(domain));
         } else {
@@ -100,7 +106,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -74,7 +75,12 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Flow Log
-    pub(crate) async fn create_ec2_flow_log(&self, resource: &Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_flow_log(
+        &self,
+        resource: &Resource,
+        schema: &ResourceSchema,
+    ) -> ProviderResult<State> {
+        let _ = schema;
         let resource_ids_val: Vec<String> = match resource.get_attr("resource_ids") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
@@ -95,7 +101,7 @@ impl AwsProvider {
             .for_resource(resource.id.clone()));
         }
 
-        let resource_type_val = require_enum_attr(resource, "resource_type")?;
+        let resource_type_val = require_enum_attr(resource, schema, "resource_type")?;
 
         let mut req = self
             .ec2_client
@@ -105,12 +111,12 @@ impl AwsProvider {
                 resource_type_val.as_str(),
             ));
 
-        if let Some(traffic_type) = optional_enum_attr(resource, "traffic_type") {
+        if let Some(traffic_type) = optional_enum_attr(resource, schema, "traffic_type") {
             use aws_sdk_ec2::types::TrafficType;
             req = req.traffic_type(TrafficType::from(traffic_type));
         }
 
-        if let Some(log_dest_type) = optional_enum_attr(resource, "log_destination_type") {
+        if let Some(log_dest_type) = optional_enum_attr(resource, schema, "log_destination_type") {
             use aws_sdk_ec2::types::LogDestinationType;
             req = req.log_destination_type(LogDestinationType::from(log_dest_type));
         }
@@ -233,7 +239,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use aws_sdk_ec2::types::NatGatewayState;
 
@@ -76,7 +77,9 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_nat_gateway(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let subnet_id = require_string_attr(resource, "subnet_id")?;
 
         let mut req = self.ec2_client.create_nat_gateway().subnet_id(&subnet_id);
@@ -87,7 +90,7 @@ impl AwsProvider {
             req = req.allocation_id(alloc_id);
         }
 
-        if let Some(conn_type) = optional_enum_attr(resource, "connectivity_type") {
+        if let Some(conn_type) = optional_enum_attr(resource, schema, "connectivity_type") {
             use aws_sdk_ec2::types::ConnectivityType;
             req = req.connectivity_type(ConnectivityType::from(conn_type));
         }
@@ -130,7 +133,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/services/ec2/security_group_egress.rs
@@ -1,5 +1,6 @@
 use carina_core::provider::ProviderResult;
 use carina_core::resource::{Resource, ResourceId, State};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 
@@ -18,8 +19,11 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_security_group_egress(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.create_ec2_security_group_rule(resource, false).await
+        let _ = schema;
+        self.create_ec2_security_group_rule(resource, schema, false)
+            .await
     }
 
     /// Update an EC2 Security Group Egress Rule
@@ -28,8 +32,10 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.update_ec2_security_group_rule(id, identifier, to, false)
+        let _ = schema;
+        self.update_ec2_security_group_rule(id, identifier, to, schema, false)
             .await
     }
 

--- a/carina-provider-aws/src/services/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/services/ec2/security_group_ingress.rs
@@ -1,5 +1,6 @@
 use carina_core::provider::ProviderResult;
 use carina_core::resource::{Resource, ResourceId, State};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 
@@ -18,8 +19,11 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_security_group_ingress(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.create_ec2_security_group_rule(resource, true).await
+        let _ = schema;
+        self.create_ec2_security_group_rule(resource, schema, true)
+            .await
     }
 
     /// Update an EC2 Security Group Ingress Rule
@@ -28,8 +32,10 @@ impl AwsProvider {
         id: ResourceId,
         identifier: &str,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.update_ec2_security_group_rule(id, identifier, to, true)
+        let _ = schema;
+        self.update_ec2_security_group_rule(id, identifier, to, schema, true)
             .await
     }
 

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::resource::{Resource, ResourceId, State};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{
-    optional_bool_attr, optional_bool_struct_field, optional_enum_struct_field, require_string_attr,
+    optional_bool_attr, optional_bool_struct_field, optional_enum_attr, optional_enum_struct_field,
+    require_string_attr,
 };
 use aws_sdk_ec2::types::{AttributeBooleanValue, HostnameType};
 
@@ -70,7 +72,12 @@ impl AwsProvider {
     }
 
     /// Create an EC2 Subnet
-    pub(crate) async fn create_ec2_subnet(&self, resource: &Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_subnet(
+        &self,
+        resource: &Resource,
+        schema: &ResourceSchema,
+    ) -> ProviderResult<State> {
+        let _ = schema;
         let cidr_block = require_string_attr(resource, "cidr_block")?;
         let vpc_id = require_string_attr(resource, "vpc_id")?;
 
@@ -80,9 +87,7 @@ impl AwsProvider {
             .vpc_id(&vpc_id)
             .cidr_block(&cidr_block);
 
-        if let Some(Value::Concrete(ConcreteValue::String(az))) =
-            resource.get_attr("availability_zone")
-        {
+        if let Some(az) = optional_enum_attr(resource, schema, "availability_zone") {
             req = req.availability_zone(az);
         }
 
@@ -102,7 +107,7 @@ impl AwsProvider {
             .await?;
 
         // Apply subnet attributes that require ModifySubnetAttribute
-        self.modify_subnet_attributes(&resource.id, subnet_id, resource)
+        self.modify_subnet_attributes(&resource.id, subnet_id, resource, schema)
             .await?;
 
         // Read back using subnet ID (reliable identifier)
@@ -116,10 +121,13 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         // Apply subnet attributes that require ModifySubnetAttribute
         let attrs = to.resolved_attributes();
-        self.modify_subnet_attributes(&id, identifier, &to).await?;
+        self.modify_subnet_attributes(&id, identifier, &to, schema)
+            .await?;
 
         // Update tags
         self.apply_ec2_tags(&id, identifier, &attrs, Some(&from.attributes))
@@ -135,6 +143,7 @@ impl AwsProvider {
         id: &ResourceId,
         subnet_id: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<()> {
         if let Some(enabled) = optional_bool_attr(resource, "map_public_ip_on_launch") {
             self.ec2_client
@@ -193,6 +202,7 @@ impl AwsProvider {
         // Each private_dns_name_options_on_launch field must be a separate API call.
         if let Some(ht) = optional_enum_struct_field(
             resource,
+            schema,
             "private_dns_name_options_on_launch",
             "hostname_type",
         ) {

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -12,6 +13,7 @@ use crate::helpers::{
 
 fn build_create_transit_gateway_options(
     resource: &Resource,
+    schema: &ResourceSchema,
 ) -> Option<aws_sdk_ec2::types::TransitGatewayRequestOptions> {
     use aws_sdk_ec2::types::{
         AutoAcceptSharedAttachmentsValue, DefaultRouteTableAssociationValue,
@@ -26,37 +28,49 @@ fn build_create_transit_gateway_options(
         options = options.amazon_side_asn(asn);
         has_options = true;
     }
-    if let Some(v) =
-        optional_enum_struct_field(resource, "options", "auto_accept_shared_attachments")
-    {
+    if let Some(v) = optional_enum_struct_field(
+        resource,
+        schema,
+        "options",
+        "auto_accept_shared_attachments",
+    ) {
         options = options.auto_accept_shared_attachments(AutoAcceptSharedAttachmentsValue::from(v));
         has_options = true;
     }
-    if let Some(v) =
-        optional_enum_struct_field(resource, "options", "default_route_table_association")
-    {
+    if let Some(v) = optional_enum_struct_field(
+        resource,
+        schema,
+        "options",
+        "default_route_table_association",
+    ) {
         options =
             options.default_route_table_association(DefaultRouteTableAssociationValue::from(v));
         has_options = true;
     }
-    if let Some(v) =
-        optional_enum_struct_field(resource, "options", "default_route_table_propagation")
-    {
+    if let Some(v) = optional_enum_struct_field(
+        resource,
+        schema,
+        "options",
+        "default_route_table_propagation",
+    ) {
         options =
             options.default_route_table_propagation(DefaultRouteTablePropagationValue::from(v));
         has_options = true;
     }
-    if let Some(v) = optional_enum_struct_field(resource, "options", "dns_support") {
+    if let Some(v) = optional_enum_struct_field(resource, schema, "options", "dns_support") {
         options = options.dns_support(DnsSupportValue::from(v));
         has_options = true;
     }
-    if let Some(v) = optional_enum_struct_field(resource, "options", "multicast_support") {
+    if let Some(v) = optional_enum_struct_field(resource, schema, "options", "multicast_support") {
         options = options.multicast_support(MulticastSupportValue::from(v));
         has_options = true;
     }
-    if let Some(v) =
-        optional_enum_struct_field(resource, "options", "security_group_referencing_support")
-    {
+    if let Some(v) = optional_enum_struct_field(
+        resource,
+        schema,
+        "options",
+        "security_group_referencing_support",
+    ) {
         options = options
             .security_group_referencing_support(SecurityGroupReferencingSupportValue::from(v));
         has_options = true;
@@ -68,7 +82,7 @@ fn build_create_transit_gateway_options(
         options = options.set_transit_gateway_cidr_blocks(Some(blocks));
         has_options = true;
     }
-    if let Some(v) = optional_enum_struct_field(resource, "options", "vpn_ecmp_support") {
+    if let Some(v) = optional_enum_struct_field(resource, schema, "options", "vpn_ecmp_support") {
         options = options.vpn_ecmp_support(VpnEcmpSupportValue::from(v));
         has_options = true;
     }
@@ -133,7 +147,9 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_transit_gateway(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let mut req = self.ec2_client.create_transit_gateway();
 
         if let Some(Value::Concrete(ConcreteValue::String(desc))) = resource.get_attr("description")
@@ -141,7 +157,7 @@ impl AwsProvider {
             req = req.description(desc);
         }
 
-        if let Some(options) = build_create_transit_gateway_options(resource) {
+        if let Some(options) = build_create_transit_gateway_options(resource, schema) {
             req = req.options(options);
         }
 
@@ -185,7 +201,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,
@@ -321,6 +339,10 @@ mod tests {
     };
     use indexmap::IndexMap;
 
+    fn schema() -> ResourceSchema {
+        crate::schemas::generated::ec2::transit_gateway::ec2_transit_gateway_config().schema
+    }
+
     fn resource_with_options(options: IndexMap<String, Value>) -> Resource {
         let mut resource = Resource::with_provider("aws", "ec2.TransitGateway", "test", None);
         resource.set_attr(
@@ -330,11 +352,14 @@ mod tests {
         resource
     }
 
-    fn canonical_enable_disable(api_value: &str) -> Value {
+    fn canonical_dns_support(api_value: &str) -> Value {
         use carina_core::schema::{AttributeType, Schema, enum_identity};
 
         let attr_type = AttributeType::enum_(
-            enum_identity("EnableDisable", Some("aws.ec2.TransitGateway")),
+            enum_identity(
+                "DnsSupport",
+                Some("aws.ec2.TransitGateway.TransitGatewayRequestOptions"),
+            ),
             Some(vec!["enable".to_string(), "disable".to_string()]),
             vec![
                 ("enable".to_string(), "enable".to_string()),
@@ -353,8 +378,8 @@ mod tests {
 
     #[test]
     fn create_reads_nested_options_dns_support_canonical_enum() {
-        let resource = one_enum_option("dns_support", canonical_enable_disable("disable"));
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let resource = one_enum_option("dns_support", canonical_dns_support("disable"));
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(options.dns_support(), Some(&DnsSupportValue::Disable));
     }
 
@@ -364,7 +389,7 @@ mod tests {
             "vpn_ecmp_support",
             Value::Concrete(ConcreteValue::String("enable".to_string())),
         );
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(
             options.vpn_ecmp_support(),
             Some(&VpnEcmpSupportValue::Enable)
@@ -377,7 +402,7 @@ mod tests {
             "multicast_support",
             Value::Concrete(ConcreteValue::String("enable".to_string())),
         );
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(
             options.multicast_support(),
             Some(&MulticastSupportValue::Enable)
@@ -390,7 +415,7 @@ mod tests {
             "security_group_referencing_support",
             Value::Concrete(ConcreteValue::String("enable".to_string())),
         );
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(
             options.security_group_referencing_support(),
             Some(&SecurityGroupReferencingSupportValue::Enable)
@@ -403,7 +428,7 @@ mod tests {
             "auto_accept_shared_attachments",
             Value::Concrete(ConcreteValue::String("enable".to_string())),
         );
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(
             options.auto_accept_shared_attachments(),
             Some(&AutoAcceptSharedAttachmentsValue::Enable)
@@ -416,7 +441,7 @@ mod tests {
             "default_route_table_association",
             Value::Concrete(ConcreteValue::String("disable".to_string())),
         );
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(
             options.default_route_table_association(),
             Some(&DefaultRouteTableAssociationValue::Disable)
@@ -429,7 +454,7 @@ mod tests {
             "default_route_table_propagation",
             Value::Concrete(ConcreteValue::String("disable".to_string())),
         );
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(
             options.default_route_table_propagation(),
             Some(&DefaultRouteTablePropagationValue::Disable)
@@ -446,7 +471,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(options.amazon_side_asn(), Some(64512));
     }
 
@@ -462,7 +487,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let options = build_create_transit_gateway_options(&resource).expect("options");
+        let options = build_create_transit_gateway_options(&resource, &schema()).expect("options");
         assert_eq!(options.transit_gateway_cidr_blocks(), ["10.0.0.0/24"]);
     }
 
@@ -478,7 +503,7 @@ mod tests {
         );
 
         assert!(
-            build_create_transit_gateway_options(&resource).is_none(),
+            build_create_transit_gateway_options(&resource, &schema()).is_none(),
             "an empty CIDR list must not cause the SDK request to carry options"
         );
     }
@@ -529,6 +554,6 @@ mod tests {
             "dns_support".to_string(),
             Value::Concrete(ConcreteValue::String("disable".to_string())),
         );
-        assert!(build_create_transit_gateway_options(&resource).is_none());
+        assert!(build_create_transit_gateway_options(&resource, &schema()).is_none());
     }
 }

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -12,6 +13,7 @@ use crate::helpers::{
 
 fn build_create_transit_gateway_attachment_options(
     resource: &Resource,
+    schema: &ResourceSchema,
 ) -> Option<aws_sdk_ec2::types::CreateTransitGatewayVpcAttachmentRequestOptions> {
     use aws_sdk_ec2::types::{
         ApplianceModeSupportValue, DnsSupportValue, Ipv6SupportValue,
@@ -22,21 +24,26 @@ fn build_create_transit_gateway_attachment_options(
         aws_sdk_ec2::types::CreateTransitGatewayVpcAttachmentRequestOptions::builder();
     let mut has_options = false;
 
-    if let Some(v) = optional_enum_struct_field(resource, "options", "appliance_mode_support") {
+    if let Some(v) =
+        optional_enum_struct_field(resource, schema, "options", "appliance_mode_support")
+    {
         options = options.appliance_mode_support(ApplianceModeSupportValue::from(v));
         has_options = true;
     }
-    if let Some(v) = optional_enum_struct_field(resource, "options", "dns_support") {
+    if let Some(v) = optional_enum_struct_field(resource, schema, "options", "dns_support") {
         options = options.dns_support(DnsSupportValue::from(v));
         has_options = true;
     }
-    if let Some(v) = optional_enum_struct_field(resource, "options", "ipv6_support") {
+    if let Some(v) = optional_enum_struct_field(resource, schema, "options", "ipv6_support") {
         options = options.ipv6_support(Ipv6SupportValue::from(v));
         has_options = true;
     }
-    if let Some(v) =
-        optional_enum_struct_field(resource, "options", "security_group_referencing_support")
-    {
+    if let Some(v) = optional_enum_struct_field(
+        resource,
+        schema,
+        "options",
+        "security_group_referencing_support",
+    ) {
         options = options
             .security_group_referencing_support(SecurityGroupReferencingSupportValue::from(v));
         has_options = true;
@@ -102,7 +109,9 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_transit_gateway_attachment(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let transit_gateway_id = require_string_attr(resource, "transit_gateway_id")?;
         let vpc_id = require_string_attr(resource, "vpc_id")?;
 
@@ -136,7 +145,7 @@ impl AwsProvider {
             req = req.subnet_ids(subnet_id);
         }
 
-        if let Some(options) = build_create_transit_gateway_attachment_options(resource) {
+        if let Some(options) = build_create_transit_gateway_attachment_options(resource, schema) {
             req = req.options(options);
         }
 
@@ -181,7 +190,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,
@@ -319,6 +330,10 @@ mod tests {
     };
     use indexmap::IndexMap;
 
+    fn schema() -> ResourceSchema {
+        crate::schemas::generated::ec2::transit_gateway_attachment::ec2_transit_gateway_attachment_config().schema
+    }
+
     fn resource_with_options(options: IndexMap<String, Value>) -> Resource {
         let mut resource =
             Resource::with_provider("aws", "ec2.TransitGatewayAttachment", "test", None);
@@ -343,7 +358,8 @@ mod tests {
     #[test]
     fn create_reads_nested_options_appliance_mode_support() {
         let resource = one_enum_option("appliance_mode_support", "enable");
-        let options = build_create_transit_gateway_attachment_options(&resource).expect("options");
+        let options =
+            build_create_transit_gateway_attachment_options(&resource, &schema()).expect("options");
         assert_eq!(
             options.appliance_mode_support(),
             Some(&ApplianceModeSupportValue::Enable)
@@ -353,21 +369,24 @@ mod tests {
     #[test]
     fn create_reads_nested_options_dns_support() {
         let resource = one_enum_option("dns_support", "disable");
-        let options = build_create_transit_gateway_attachment_options(&resource).expect("options");
+        let options =
+            build_create_transit_gateway_attachment_options(&resource, &schema()).expect("options");
         assert_eq!(options.dns_support(), Some(&DnsSupportValue::Disable));
     }
 
     #[test]
     fn create_reads_nested_options_ipv6_support() {
         let resource = one_enum_option("ipv6_support", "enable");
-        let options = build_create_transit_gateway_attachment_options(&resource).expect("options");
+        let options =
+            build_create_transit_gateway_attachment_options(&resource, &schema()).expect("options");
         assert_eq!(options.ipv6_support(), Some(&Ipv6SupportValue::Enable));
     }
 
     #[test]
     fn create_reads_nested_options_security_group_referencing_support() {
         let resource = one_enum_option("security_group_referencing_support", "enable");
-        let options = build_create_transit_gateway_attachment_options(&resource).expect("options");
+        let options =
+            build_create_transit_gateway_attachment_options(&resource, &schema()).expect("options");
         assert_eq!(
             options.security_group_referencing_support(),
             Some(&SecurityGroupReferencingSupportValue::Enable)
@@ -423,6 +442,6 @@ mod tests {
             "dns_support".to_string(),
             Value::Concrete(ConcreteValue::String("disable".to_string())),
         );
-        assert!(build_create_transit_gateway_attachment_options(&resource).is_none());
+        assert!(build_create_transit_gateway_attachment_options(&resource, &schema()).is_none());
     }
 }

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -91,14 +92,19 @@ impl AwsProvider {
     }
 
     /// Create an EC2 VPC
-    pub(crate) async fn create_ec2_vpc(&self, resource: &Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_ec2_vpc(
+        &self,
+        resource: &Resource,
+        schema: &ResourceSchema,
+    ) -> ProviderResult<State> {
+        let _ = schema;
         let cidr_block = require_string_attr(resource, "cidr_block")?;
 
         // Create VPC with optional instance_tenancy
         let mut create_vpc_builder = self.ec2_client.create_vpc().cidr_block(&cidr_block);
 
         // Handle instance_tenancy if specified
-        if let Some(tenancy) = optional_enum_attr(resource, "instance_tenancy") {
+        if let Some(tenancy) = optional_enum_attr(resource, schema, "instance_tenancy") {
             let tenancy_enum = match tenancy {
                 "dedicated" => aws_sdk_ec2::types::Tenancy::Dedicated,
                 "host" => aws_sdk_ec2::types::Tenancy::Host,
@@ -174,7 +180,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         // identifier is the VPC ID (e.g., vpc-12345678)
         let vpc_id = identifier.to_string();
 

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -66,7 +67,9 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_vpc_endpoint(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let vpc_id = require_string_attr(resource, "vpc_id")?;
         let service_name = require_string_attr(resource, "service_name")?;
 
@@ -76,7 +79,7 @@ impl AwsProvider {
             .vpc_id(&vpc_id)
             .service_name(&service_name);
 
-        if let Some(ep_type) = optional_enum_attr(resource, "vpc_endpoint_type") {
+        if let Some(ep_type) = optional_enum_attr(resource, schema, "vpc_endpoint_type") {
             use aws_sdk_ec2::types::VpcEndpointType;
             req = req.vpc_endpoint_type(VpcEndpointType::from(ep_type));
         }
@@ -171,7 +174,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let mut req = self
             .ec2_client
             .modify_vpc_endpoint()

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -70,8 +71,10 @@ impl AwsProvider {
     pub(crate) async fn create_ec2_vpn_gateway(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let gw_type = require_enum_attr(resource, "type")?;
+        let _ = schema;
+        let gw_type = require_enum_attr(resource, schema, "type")?;
 
         let mut req = self
             .ec2_client
@@ -111,7 +114,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::ProviderResult;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -112,7 +113,12 @@ impl AwsProvider {
     }
 
     /// Create a CloudWatch Logs Log Group
-    pub(crate) async fn create_logs_log_group(&self, resource: &Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_logs_log_group(
+        &self,
+        resource: &Resource,
+        schema: &ResourceSchema,
+    ) -> ProviderResult<State> {
+        let _ = schema;
         let log_group_name = require_string_attr(resource, "log_group_name")?;
 
         let mut req = self
@@ -126,7 +132,7 @@ impl AwsProvider {
             req = req.kms_key_id(kms_key);
         }
 
-        if let Some(class) = optional_enum_attr(resource, "log_group_class") {
+        if let Some(class) = optional_enum_attr(resource, schema, "log_group_class") {
             use aws_sdk_cloudwatchlogs::types::LogGroupClass;
             req = req.log_group_class(LogGroupClass::from(class));
         }
@@ -177,7 +183,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         // Update retention
         match to.get_attr("retention_in_days") {
             Some(Value::Concrete(ConcreteValue::Int(days))) => {

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -163,7 +164,9 @@ impl AwsProvider {
     pub(crate) async fn create_organizations_account(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let name = require_string_attr(resource, "account_name")?;
         let email = require_string_attr(resource, "email")?;
 
@@ -173,7 +176,9 @@ impl AwsProvider {
             .account_name(&name)
             .email(&email);
 
-        if let Some(iam_billing) = optional_enum_attr(resource, "iam_user_access_to_billing") {
+        if let Some(iam_billing) =
+            optional_enum_attr(resource, schema, "iam_user_access_to_billing")
+        {
             let val = aws_sdk_organizations::types::IamUserAccessToBilling::from(iam_billing);
             req = req.iam_user_access_to_billing(val);
         }
@@ -332,7 +337,9 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         // Handle parent_id change via MoveAccount
         let desired_parent = to.get_attr("parent_id").and_then(|v| match v {
             Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -108,10 +109,12 @@ impl AwsProvider {
     pub(crate) async fn create_organizations_organization(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let mut req = self.organizations_client.create_organization();
 
-        if let Some(feature_set) = optional_enum_attr(resource, "feature_set") {
+        if let Some(feature_set) = optional_enum_attr(resource, schema, "feature_set") {
             let fs = aws_sdk_organizations::types::OrganizationFeatureSet::from(feature_set);
             req = req.feature_set(fs);
         }

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -12,6 +12,7 @@ use aws_sdk_route53::types::{
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -151,9 +152,12 @@ fn build_alias_target_from_map(
 }
 
 /// Build an AWS SDK ResourceRecordSet from carina resource attributes.
-fn build_record_set(resource: &Resource) -> ProviderResult<ResourceRecordSet> {
+fn build_record_set(
+    resource: &Resource,
+    schema: &ResourceSchema,
+) -> ProviderResult<ResourceRecordSet> {
     let name = require_string_attr(resource, "name")?;
-    let record_type = require_enum_attr(resource, "type")?;
+    let record_type = require_enum_attr(resource, schema, "type")?;
 
     let mut builder = ResourceRecordSet::builder()
         .name(normalize_dns_name(&name))
@@ -357,12 +361,14 @@ impl AwsProvider {
     pub(crate) async fn create_route53_record_set(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let hosted_zone_id = require_string_attr(resource, "hosted_zone_id")?;
         let name = require_string_attr(resource, "name")?;
-        let record_type = require_enum_attr(resource, "type")?;
+        let record_type = require_enum_attr(resource, schema, "type")?;
 
-        let record_set = build_record_set(resource)?;
+        let record_set = build_record_set(resource, schema)?;
         change_record_set(
             &self.route53_client,
             &hosted_zone_id,
@@ -382,12 +388,14 @@ impl AwsProvider {
         id: ResourceId,
         _identifier: &str,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let hosted_zone_id = require_string_attr(&to, "hosted_zone_id")?;
         let name = require_string_attr(&to, "name")?;
-        let record_type = require_enum_attr(&to, "type")?;
+        let record_type = require_enum_attr(&to, schema, "type")?;
 
-        let record_set = build_record_set(&to)?;
+        let record_set = build_record_set(&to, schema)?;
         change_record_set(
             &self.route53_client,
             &hosted_zone_id,
@@ -549,7 +557,7 @@ mod tests {
         use carina_core::schema::{AttributeType, Schema, enum_identity};
 
         let attr_type = AttributeType::enum_(
-            enum_identity("RrType", Some("aws.route53.RecordSet")),
+            enum_identity("Type", Some("aws.route53.RecordSet")),
             Some(vec!["A".to_string(), "AAAA".to_string()]),
             vec![
                 ("A".to_string(), "a".to_string()),
@@ -564,7 +572,10 @@ mod tests {
 
         let mut r = record_set("registry.example.com");
         r.set_attr("type".to_string(), canonical);
-        let record_set = build_record_set(&r).expect("canonical enum type should build");
+        let resource_schema =
+            crate::schemas::generated::route53::record_set::route53_record_set_config().schema;
+        let record_set =
+            build_record_set(&r, &resource_schema).expect("canonical enum type should build");
 
         assert_eq!(record_set.r#type().as_str(), "AAAA");
     }

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use aws_sdk_s3::types::{BucketCannedAcl, Grant, Permission, Type as GranteeType};
 use carina_core::provider::ProviderResult;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -142,9 +143,14 @@ impl AwsProvider {
         }
     }
 
-    pub(crate) async fn create_s3_bucket_acl(&self, resource: &Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_s3_bucket_acl(
+        &self,
+        resource: &Resource,
+        schema: &ResourceSchema,
+    ) -> ProviderResult<State> {
+        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
-        self.put_s3_bucket_acl(&resource.id, &bucket, resource)
+        self.put_s3_bucket_acl(&resource.id, &bucket, resource, schema)
             .await
     }
 
@@ -154,8 +160,10 @@ impl AwsProvider {
         identifier: &str,
         _from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.put_s3_bucket_acl(&id, identifier, &to).await
+        let _ = schema;
+        self.put_s3_bucket_acl(&id, identifier, &to, schema).await
     }
 
     async fn put_s3_bucket_acl(
@@ -163,8 +171,9 @@ impl AwsProvider {
         id: &ResourceId,
         bucket: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let acl_str = require_enum_attr(resource, "acl")?;
+        let acl_str = require_enum_attr(resource, schema, "acl")?;
 
         self.s3_client
             .put_bucket_acl()

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -6,11 +6,15 @@ use aws_sdk_s3::types::{
 };
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{
+    RetryPolicy, optional_enum_value_at_schema_path, require_string_attr, retry_aws_operation,
+    sdk_error_message,
+};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -67,9 +71,11 @@ impl AwsProvider {
     pub(crate) async fn create_s3_bucket_server_side_encryption_configuration(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
-        self.put_s3_bucket_encryption(&resource.id, &bucket, resource)
+        self.put_s3_bucket_encryption(&resource.id, &bucket, resource, schema)
             .await
     }
 
@@ -79,8 +85,11 @@ impl AwsProvider {
         identifier: &str,
         _from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.put_s3_bucket_encryption(&id, identifier, &to).await
+        let _ = schema;
+        self.put_s3_bucket_encryption(&id, identifier, &to, schema)
+            .await
     }
 
     async fn put_s3_bucket_encryption(
@@ -88,6 +97,7 @@ impl AwsProvider {
         id: &ResourceId,
         bucket: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
         let rules = match resource.get_attr("rules") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items,
@@ -101,7 +111,7 @@ impl AwsProvider {
 
         let sdk_rules: Vec<ServerSideEncryptionRule> = rules
             .iter()
-            .map(|v| build_rule(id, v))
+            .map(|v| build_rule(id, schema, v))
             .collect::<ProviderResult<Vec<_>>>()?;
 
         let config = ServerSideEncryptionConfiguration::builder()
@@ -172,7 +182,11 @@ impl AwsProvider {
     }
 }
 
-fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ServerSideEncryptionRule> {
+fn build_rule(
+    id: &ResourceId,
+    schema: &ResourceSchema,
+    rule_value: &Value,
+) -> ProviderResult<ServerSideEncryptionRule> {
     let Value::Concrete(ConcreteValue::Map(rule_map)) = rule_value else {
         return Err(
             ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
@@ -182,8 +196,8 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ServerSideE
     let mut builder = ServerSideEncryptionRule::builder();
 
     if let Some(by_default) = rule_map.get("apply_server_side_encryption_by_default") {
-        builder =
-            builder.apply_server_side_encryption_by_default(build_by_default(id, by_default)?);
+        builder = builder
+            .apply_server_side_encryption_by_default(build_by_default(id, schema, by_default)?);
     }
     if let Some(Value::Concrete(ConcreteValue::Bool(b))) = rule_map.get("bucket_key_enabled") {
         builder = builder.bucket_key_enabled(*b);
@@ -194,6 +208,7 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ServerSideE
 
 fn build_by_default(
     id: &ResourceId,
+    schema: &ResourceSchema,
     value: &Value,
 ) -> ProviderResult<ServerSideEncryptionByDefault> {
     let Value::Concrete(ConcreteValue::Map(map)) = value else {
@@ -202,8 +217,15 @@ fn build_by_default(
         )
         .for_resource(id.clone()));
     };
-    let algorithm_str = match map.get("sse_algorithm") {
-        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+    let algorithm_str = match map.get("sse_algorithm").and_then(|v| {
+        optional_enum_value_at_schema_path(
+            schema,
+            "rules",
+            &["apply_server_side_encryption_by_default", "sse_algorithm"],
+            v,
+        )
+    }) {
+        Some(s) => s,
         _ => {
             return Err(
                 ProviderError::invalid_input("sse_algorithm is required").for_resource(id.clone())

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -8,11 +8,15 @@ use aws_sdk_s3::types::{
 };
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{
+    RetryPolicy, optional_enum_value_at_schema_path, require_string_attr, retry_aws_operation,
+    sdk_error_message,
+};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -67,9 +71,11 @@ impl AwsProvider {
     pub(crate) async fn create_s3_bucket_lifecycle_configuration(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
-        self.put_s3_bucket_lifecycle(&resource.id, &bucket, resource)
+        self.put_s3_bucket_lifecycle(&resource.id, &bucket, resource, schema)
             .await
     }
 
@@ -79,8 +85,11 @@ impl AwsProvider {
         identifier: &str,
         _from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.put_s3_bucket_lifecycle(&id, identifier, &to).await
+        let _ = schema;
+        self.put_s3_bucket_lifecycle(&id, identifier, &to, schema)
+            .await
     }
 
     async fn put_s3_bucket_lifecycle(
@@ -88,6 +97,7 @@ impl AwsProvider {
         id: &ResourceId,
         bucket: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
         let rules = match resource.get_attr("rules") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items,
@@ -101,7 +111,7 @@ impl AwsProvider {
 
         let sdk_rules: Vec<LifecycleRule> = rules
             .iter()
-            .map(|v| build_rule(id, v))
+            .map(|v| build_rule(id, schema, v))
             .collect::<ProviderResult<Vec<_>>>()?;
 
         let config = BucketLifecycleConfiguration::builder()
@@ -173,15 +183,22 @@ impl AwsProvider {
     }
 }
 
-fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRule> {
+fn build_rule(
+    id: &ResourceId,
+    schema: &ResourceSchema,
+    rule_value: &Value,
+) -> ProviderResult<LifecycleRule> {
     let Value::Concrete(ConcreteValue::Map(map)) = rule_value else {
         return Err(
             ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
         );
     };
 
-    let status_str = match map.get("status") {
-        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+    let status_str = match map
+        .get("status")
+        .and_then(|v| optional_enum_value_at_schema_path(schema, "rules", &["status"], v))
+    {
+        Some(s) => s,
         _ => {
             return Err(
                 ProviderError::invalid_input("rule.status is required").for_resource(id.clone())
@@ -208,7 +225,7 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRu
     if let Some(Value::Concrete(ConcreteValue::List(items))) = map.get("transitions") {
         let transitions: Vec<Transition> = items
             .iter()
-            .map(|v| build_transition(id, v))
+            .map(|v| build_transition(id, schema, v))
             .collect::<ProviderResult<Vec<_>>>()?;
         builder = builder.set_transitions(Some(transitions));
     }
@@ -220,7 +237,7 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<LifecycleRu
     {
         let transitions: Vec<NoncurrentVersionTransition> = items
             .iter()
-            .map(|v| build_ncv_transition(id, v))
+            .map(|v| build_ncv_transition(id, schema, v))
             .collect::<ProviderResult<Vec<_>>>()?;
         builder = builder.set_noncurrent_version_transitions(Some(transitions));
     }
@@ -331,14 +348,20 @@ fn build_expiration(id: &ResourceId, value: &Value) -> ProviderResult<LifecycleE
     Ok(builder.build())
 }
 
-fn build_transition(id: &ResourceId, value: &Value) -> ProviderResult<Transition> {
+fn build_transition(
+    id: &ResourceId,
+    schema: &ResourceSchema,
+    value: &Value,
+) -> ProviderResult<Transition> {
     let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("transition must be a map").for_resource(id.clone())
         );
     };
-    let storage_class_str = match map.get("storage_class") {
-        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+    let storage_class_str = match map.get("storage_class").and_then(|v| {
+        optional_enum_value_at_schema_path(schema, "rules", &["transitions", "storage_class"], v)
+    }) {
+        Some(s) => s,
         _ => {
             return Err(
                 ProviderError::invalid_input("transition.storage_class is required")
@@ -376,6 +399,7 @@ fn build_ncv_expiration(
 
 fn build_ncv_transition(
     id: &ResourceId,
+    schema: &ResourceSchema,
     value: &Value,
 ) -> ProviderResult<NoncurrentVersionTransition> {
     let Value::Concrete(ConcreteValue::Map(map)) = value else {
@@ -384,8 +408,15 @@ fn build_ncv_transition(
                 .for_resource(id.clone()),
         );
     };
-    let storage_class_str = match map.get("storage_class") {
-        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+    let storage_class_str = match map.get("storage_class").and_then(|v| {
+        optional_enum_value_at_schema_path(
+            schema,
+            "rules",
+            &["noncurrent_version_transitions", "storage_class"],
+            v,
+        )
+    }) {
+        Some(s) => s,
         _ => {
             return Err(ProviderError::invalid_input(
                 "noncurrent_version_transition.storage_class is required",
@@ -660,6 +691,10 @@ mod tests {
         ResourceId::new("s3.bucket_lifecycle_configuration", "test")
     }
 
+    fn schema() -> ResourceSchema {
+        crate::schemas::generated::s3::bucket_lifecycle_configuration::s3_bucket_lifecycle_configuration_config().schema
+    }
+
     fn str_val(s: &str) -> Value {
         Value::Concrete(ConcreteValue::String(s.to_string()))
     }
@@ -685,7 +720,7 @@ mod tests {
                 map_val(vec![("days", Value::Concrete(ConcreteValue::Int(365)))]),
             ),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         assert!(
             rule.filter().is_some(),
             "a lifecycle rule must always carry a Filter element"
@@ -698,7 +733,7 @@ mod tests {
             ("status", str_val("Enabled")),
             ("filter", map_val(vec![("prefix", str_val("logs/"))])),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         let filter = rule.filter().expect("filter set");
         assert_eq!(filter.prefix(), Some("logs/"));
     }
@@ -715,7 +750,7 @@ mod tests {
                 )]),
             ),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         let tag = rule.filter().and_then(|f| f.tag()).expect("tag set");
         assert_eq!(tag.key(), "env");
         assert_eq!(tag.value(), "dev");
@@ -746,7 +781,7 @@ mod tests {
                 )]),
             ),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         let and = rule.filter().and_then(|f| f.and()).expect("and set");
         assert_eq!(and.prefix(), Some("data/"));
         assert_eq!(and.object_size_greater_than(), Some(1024));
@@ -765,6 +800,7 @@ mod tests {
     fn prefix_filter_round_trips() {
         let built = build_rule(
             &rid(),
+            &schema(),
             &map_val(vec![
                 ("status", str_val("Enabled")),
                 ("filter", map_val(vec![("prefix", str_val("logs/"))])),

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -6,11 +6,15 @@ use aws_sdk_s3::types::{
 };
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{
+    RetryPolicy, optional_enum_value_at_schema_path, require_string_attr, retry_aws_operation,
+    sdk_error_message,
+};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -70,9 +74,11 @@ impl AwsProvider {
     pub(crate) async fn create_s3_bucket_logging(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
-        self.put_s3_bucket_logging(&resource.id, &bucket, resource)
+        self.put_s3_bucket_logging(&resource.id, &bucket, resource, schema)
             .await
     }
 
@@ -82,8 +88,11 @@ impl AwsProvider {
         identifier: &str,
         _from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.put_s3_bucket_logging(&id, identifier, &to).await
+        let _ = schema;
+        self.put_s3_bucket_logging(&id, identifier, &to, schema)
+            .await
     }
 
     async fn put_s3_bucket_logging(
@@ -91,6 +100,7 @@ impl AwsProvider {
         id: &ResourceId,
         bucket: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
         let target_bucket = require_string_attr(resource, "target_bucket")?;
         let target_prefix = match resource.get_attr("target_prefix") {
@@ -109,7 +119,7 @@ impl AwsProvider {
             .target_prefix(target_prefix);
 
         if let Some(v) = resource.get_attr("target_object_key_format") {
-            le_builder = le_builder.target_object_key_format(build_key_format(id, v)?);
+            le_builder = le_builder.target_object_key_format(build_key_format(id, schema, v)?);
         }
 
         let le = le_builder.build().map_err(|e| {
@@ -164,7 +174,11 @@ impl AwsProvider {
     }
 }
 
-fn build_key_format(id: &ResourceId, value: &Value) -> ProviderResult<TargetObjectKeyFormat> {
+fn build_key_format(
+    id: &ResourceId,
+    schema: &ResourceSchema,
+    value: &Value,
+) -> ProviderResult<TargetObjectKeyFormat> {
     let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("target_object_key_format must be a map")
@@ -178,8 +192,15 @@ fn build_key_format(id: &ResourceId, value: &Value) -> ProviderResult<TargetObje
     }
     if let Some(Value::Concrete(ConcreteValue::Map(pp))) = map.get("partitioned_prefix") {
         let mut pb = PartitionedPrefix::builder();
-        if let Some(Value::Concrete(ConcreteValue::String(s))) = pp.get("partition_date_source") {
-            pb = pb.partition_date_source(PartitionDateSource::from(s.as_str()));
+        if let Some(source) = pp.get("partition_date_source").and_then(|v| {
+            optional_enum_value_at_schema_path(
+                schema,
+                "target_object_key_format",
+                &["partitioned_prefix", "partition_date_source"],
+                v,
+            )
+        }) {
+            pb = pb.partition_date_source(PartitionDateSource::from(source.as_str()));
         }
         builder = builder.partitioned_prefix(pb.build());
     }

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use aws_sdk_s3::types::{ObjectOwnership, OwnershipControls, OwnershipControlsRule};
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -66,9 +67,11 @@ impl AwsProvider {
     pub(crate) async fn create_s3_bucket_ownership_controls(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
-        self.put_s3_bucket_ownership_controls(&resource.id, &bucket, resource)
+        self.put_s3_bucket_ownership_controls(&resource.id, &bucket, resource, schema)
             .await
     }
 
@@ -78,8 +81,10 @@ impl AwsProvider {
         identifier: &str,
         _from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.put_s3_bucket_ownership_controls(&id, identifier, &to)
+        let _ = schema;
+        self.put_s3_bucket_ownership_controls(&id, identifier, &to, schema)
             .await
     }
 
@@ -88,8 +93,9 @@ impl AwsProvider {
         id: &ResourceId,
         bucket: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let ownership_str = require_enum_attr(resource, "object_ownership")?;
+        let ownership_str = require_enum_attr(resource, schema, "object_ownership")?;
 
         let rule = OwnershipControlsRule::builder()
             .object_ownership(ObjectOwnership::from(ownership_str.as_str()))

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -7,11 +7,15 @@ use aws_sdk_s3::types::{
 };
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{
+    RetryPolicy, optional_enum_value_at_schema_path, require_string_attr, retry_aws_operation,
+    sdk_error_message,
+};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -72,9 +76,11 @@ impl AwsProvider {
     pub(crate) async fn create_s3_bucket_replication_configuration(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
-        self.put_s3_bucket_replication(&resource.id, &bucket, resource)
+        self.put_s3_bucket_replication(&resource.id, &bucket, resource, schema)
             .await
     }
 
@@ -84,8 +90,11 @@ impl AwsProvider {
         identifier: &str,
         _from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.put_s3_bucket_replication(&id, identifier, &to).await
+        let _ = schema;
+        self.put_s3_bucket_replication(&id, identifier, &to, schema)
+            .await
     }
 
     async fn put_s3_bucket_replication(
@@ -93,6 +102,7 @@ impl AwsProvider {
         id: &ResourceId,
         bucket: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
         let role = require_string_attr(resource, "role")?;
         let rules = match resource.get_attr("rules") {
@@ -107,7 +117,7 @@ impl AwsProvider {
 
         let sdk_rules: Vec<ReplicationRule> = rules
             .iter()
-            .map(|v| build_rule(id, v))
+            .map(|v| build_rule(id, schema, v))
             .collect::<ProviderResult<Vec<_>>>()?;
 
         let config = ReplicationConfiguration::builder()
@@ -177,15 +187,22 @@ impl AwsProvider {
     }
 }
 
-fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<ReplicationRule> {
+fn build_rule(
+    id: &ResourceId,
+    schema: &ResourceSchema,
+    rule_value: &Value,
+) -> ProviderResult<ReplicationRule> {
     let Value::Concrete(ConcreteValue::Map(map)) = rule_value else {
         return Err(
             ProviderError::invalid_input("each rule must be a map").for_resource(id.clone())
         );
     };
 
-    let status_str = match map.get("status") {
-        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+    let status_str = match map
+        .get("status")
+        .and_then(|v| optional_enum_value_at_schema_path(schema, "rules", &["status"], v))
+    {
+        Some(s) => s,
         _ => {
             return Err(
                 ProviderError::invalid_input("rule.status is required").for_resource(id.clone())
@@ -193,7 +210,7 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<Replication
         }
     };
     let destination = match map.get("destination") {
-        Some(v) => build_destination(id, v)?,
+        Some(v) => build_destination(id, schema, v)?,
         None => {
             return Err(ProviderError::invalid_input("rule.destination is required")
                 .for_resource(id.clone()));
@@ -212,9 +229,17 @@ fn build_rule(id: &ResourceId, rule_value: &Value) -> ProviderResult<Replication
     // Default to `Disabled` when the DSL omits it.
     let delete_marker_status = match map.get("delete_marker_replication") {
         Some(Value::Concrete(ConcreteValue::Map(dm))) => match dm.get("status") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => {
-                DeleteMarkerReplicationStatus::from(s.as_str())
-            }
+            Some(v) => optional_enum_value_at_schema_path(
+                schema,
+                "rules",
+                &["delete_marker_replication", "status"],
+                v,
+            )
+            .map(|s| DeleteMarkerReplicationStatus::from(s.as_str()))
+            .ok_or_else(|| {
+                ProviderError::invalid_input("delete_marker_replication.status is required")
+                    .for_resource(id.clone())
+            })?,
             _ => {
                 return Err(ProviderError::invalid_input(
                     "delete_marker_replication.status is required",
@@ -320,7 +345,11 @@ fn build_filter(id: &ResourceId, value: &Value) -> ProviderResult<ReplicationRul
     Ok(builder.build())
 }
 
-fn build_destination(id: &ResourceId, value: &Value) -> ProviderResult<Destination> {
+fn build_destination(
+    id: &ResourceId,
+    schema: &ResourceSchema,
+    value: &Value,
+) -> ProviderResult<Destination> {
     let Value::Concrete(ConcreteValue::Map(map)) = value else {
         return Err(
             ProviderError::invalid_input("destination must be a map").for_resource(id.clone())
@@ -339,8 +368,10 @@ fn build_destination(id: &ResourceId, value: &Value) -> ProviderResult<Destinati
     if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("account") {
         builder = builder.account(s);
     }
-    if let Some(Value::Concrete(ConcreteValue::String(s))) = map.get("storage_class") {
-        builder = builder.storage_class(StorageClass::from(s.as_str()));
+    if let Some(storage_class) = map.get("storage_class").and_then(|v| {
+        optional_enum_value_at_schema_path(schema, "rules", &["destination", "storage_class"], v)
+    }) {
+        builder = builder.storage_class(StorageClass::from(storage_class.as_str()));
     }
     builder.build().map_err(|e| {
         ProviderError::api_error(sdk_error_message("Failed to build Destination", &e))
@@ -499,6 +530,10 @@ mod tests {
         ResourceId::new("s3.bucket_replication_configuration", "test")
     }
 
+    fn schema() -> ResourceSchema {
+        crate::schemas::generated::s3::bucket_replication_configuration::s3_bucket_replication_configuration_config().schema
+    }
+
     fn str_val(s: &str) -> Value {
         Value::Concrete(ConcreteValue::String(s.to_string()))
     }
@@ -525,7 +560,7 @@ mod tests {
             ("status", str_val("Enabled")),
             ("destination", dest()),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         assert!(
             rule.filter().is_some(),
             "a replication rule must always carry a Filter element"
@@ -540,7 +575,7 @@ mod tests {
             ("status", str_val("Enabled")),
             ("destination", dest()),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         let status = rule
             .delete_marker_replication()
             .and_then(|d| d.status())
@@ -558,7 +593,7 @@ mod tests {
                 map_val(vec![("status", str_val("Enabled"))]),
             ),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         let status = rule
             .delete_marker_replication()
             .and_then(|d| d.status())
@@ -573,7 +608,7 @@ mod tests {
             ("destination", dest()),
             ("filter", map_val(vec![("prefix", str_val("docs/"))])),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         assert_eq!(rule.filter().and_then(|f| f.prefix()), Some("docs/"));
     }
 
@@ -599,7 +634,7 @@ mod tests {
                 )]),
             ),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         let and = rule.filter().and_then(|f| f.and()).expect("and set");
         assert_eq!(and.prefix(), Some("data/"));
         assert_eq!(and.tags().len(), 1);
@@ -618,6 +653,7 @@ mod tests {
         // omits it. Only Enabled should round-trip.
         let built = build_rule(
             &rid(),
+            &schema(),
             &map_val(vec![
                 ("status", str_val("Enabled")),
                 ("destination", dest()),
@@ -644,7 +680,7 @@ mod tests {
             ("status", str_val("Enabled")),
             ("destination", dest()),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         assert_eq!(
             rule.priority(),
             Some(0),
@@ -659,7 +695,7 @@ mod tests {
             ("destination", dest()),
             ("priority", Value::Concrete(ConcreteValue::Int(5))),
         ]);
-        let rule = build_rule(&rid(), &rule_value).expect("build_rule should succeed");
+        let rule = build_rule(&rid(), &schema(), &rule_value).expect("build_rule should succeed");
         assert_eq!(rule.priority(), Some(5));
     }
 
@@ -669,6 +705,7 @@ mod tests {
         // on read would diff against a DSL config that omits `priority`.
         let built = build_rule(
             &rid(),
+            &schema(),
             &map_val(vec![
                 ("status", str_val("Enabled")),
                 ("destination", dest()),
@@ -689,6 +726,7 @@ mod tests {
     fn nonzero_priority_round_trips() {
         let built = build_rule(
             &rid(),
+            &schema(),
             &map_val(vec![
                 ("status", str_val("Enabled")),
                 ("destination", dest()),

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -9,6 +9,7 @@ use crate::services::s3::bucket::is_s3_not_configured_error;
 use aws_sdk_s3::types::{BucketVersioningStatus, MfaDelete, VersioningConfiguration};
 use carina_core::provider::ProviderResult;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 impl AwsProvider {
     /// Read an S3 BucketVersioning.
@@ -71,9 +72,11 @@ impl AwsProvider {
     pub(crate) async fn create_s3_bucket_versioning(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
-        self.put_s3_bucket_versioning(&resource.id, &bucket, resource)
+        self.put_s3_bucket_versioning(&resource.id, &bucket, resource, schema)
             .await
     }
 
@@ -83,8 +86,11 @@ impl AwsProvider {
         identifier: &str,
         _from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.put_s3_bucket_versioning(&id, identifier, &to).await
+        let _ = schema;
+        self.put_s3_bucket_versioning(&id, identifier, &to, schema)
+            .await
     }
 
     async fn put_s3_bucket_versioning(
@@ -92,12 +98,13 @@ impl AwsProvider {
         id: &ResourceId,
         bucket: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let status_str = require_enum_attr(resource, "status")?;
+        let status_str = require_enum_attr(resource, schema, "status")?;
         let status = BucketVersioningStatus::from(status_str.as_str());
 
         let mut config_builder = VersioningConfiguration::builder().status(status);
-        if let Some(s) = optional_enum_attr(resource, "mfa_delete") {
+        if let Some(s) = optional_enum_attr(resource, schema, "mfa_delete") {
             config_builder = config_builder.mfa_delete(MfaDelete::from(s));
         }
 

--- a/carina-provider-aws/src/services/s3/bucket_website.rs
+++ b/carina-provider-aws/src/services/s3/bucket_website.rs
@@ -5,11 +5,15 @@ use aws_sdk_s3::types::{
 };
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 use indexmap::IndexMap;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
-use crate::helpers::{RetryPolicy, require_string_attr, retry_aws_operation, sdk_error_message};
+use crate::helpers::{
+    RetryPolicy, optional_enum_struct_field, require_string_attr, retry_aws_operation,
+    sdk_error_message,
+};
 use crate::services::s3::bucket::is_s3_not_configured_error;
 
 impl AwsProvider {
@@ -96,9 +100,11 @@ impl AwsProvider {
     pub(crate) async fn create_s3_bucket_website_configuration(
         &self,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
-        self.put_s3_bucket_website(&resource.id, &bucket, resource)
+        self.put_s3_bucket_website(&resource.id, &bucket, resource, schema)
             .await
     }
 
@@ -108,8 +114,11 @@ impl AwsProvider {
         identifier: &str,
         _from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        self.put_s3_bucket_website(&id, identifier, &to).await
+        let _ = schema;
+        self.put_s3_bucket_website(&id, identifier, &to, schema)
+            .await
     }
 
     async fn put_s3_bucket_website(
@@ -117,6 +126,7 @@ impl AwsProvider {
         id: &ResourceId,
         bucket: &str,
         resource: &Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
         let mut config_builder = WebsiteConfiguration::builder();
 
@@ -175,8 +185,10 @@ impl AwsProvider {
                 }
             };
             let mut rb = RedirectAllRequestsTo::builder().host_name(host_name);
-            if let Some(Value::Concrete(ConcreteValue::String(p))) = map.get("protocol") {
-                rb = rb.protocol(Protocol::from(p.as_str()));
+            if let Some(protocol) =
+                optional_enum_struct_field(resource, schema, "redirect_all_requests_to", "protocol")
+            {
+                rb = rb.protocol(Protocol::from(protocol));
             }
             config_builder = config_builder.redirect_all_requests_to(rb.build().map_err(|e| {
                 ProviderError::api_error(sdk_error_message(

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::ResourceSchema;
 
 use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
@@ -469,7 +470,12 @@ impl AwsProvider {
     }
 
     /// Create an SQS Queue and return its post-create state.
-    pub(crate) async fn create_sqs_queue(&self, resource: &Resource) -> ProviderResult<State> {
+    pub(crate) async fn create_sqs_queue(
+        &self,
+        resource: &Resource,
+        schema: &ResourceSchema,
+    ) -> ProviderResult<State> {
+        let _ = schema;
         let queue_name = require_string_attr(resource, "queue_name")?;
 
         // Pack every writable attribute the user actually set.
@@ -515,7 +521,10 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
+        schema: &ResourceSchema,
     ) -> ProviderResult<State> {
+        let _ = schema;
+        let _ = schema;
         // Build a partial map of attributes whose value changed.
         // Create-only attributes (FifoQueue / FifoThroughputLimit /
         // DeduplicationScope) are dropped — schema marks them


### PR DESCRIPTION
## Summary

This is the AWS provider side of carina-rs/carina#3555 — the helper-signature migration **and** the full service sweep, merged into one PR per the design doc's "typed reshape in-PR, no compat wrapper" stance. Today's acceptance run (2026-06-16, see carina#3555 evidence comment) caught the carina-provider-aws#440 class regressing for the third time across 11+ new resources; documentation convention has provably not held, so the seam moves into the type system.

What this PR does:

1. Bumps the carina rev pin to `9c91c5f8` (carina main after PR1 #3585 + PR1.5 #3586). Both `Resource::get_enum_attr` and `Resource::get_enum_struct_field` now exist on `&Resource`.
2. Stores a `SchemaRegistry` on `AwsProvider`. `AwsProvider::resource_schema(resource_type)` is the lookup. `provider.rs::create_resource` / `read_resource` / `update_resource` / `delete_resource` thread both `&Resource` and `&ResourceSchema` into every service method.
3. The four enum helpers in `helpers.rs` now require `&ResourceSchema` and forward to the typed core accessors. **No compat overload.** Service code that forgets the schema will not compile.
4. Adds `optional_enum_value_at_schema_path` for the list-element nested enum reads (S3 `rules[*].status`, `rules[*].transitions[*].storage_class`, etc.) that the two core accessors do not cover directly. Per the design doc, a third helper is preferable to duplicating projection logic.
5. Sweeps the full set of pre-existing helper call sites (≈ 54 across 17 service files, matching the design doc's PR3 audit).
6. Replaces the raw `Value::Concrete(ConcreteValue::String(_))` enum reads at every site the 2026-06-16 audit flagged:
   - `ec2_security_group_rules.rs` — `ip_protocol` (top-level)
   - `services/ec2/subnet.rs` — `availability_zone` (top-level)
   - `services/s3/bucket_lifecycle.rs` — `rules[*].status`, `rules[*].transitions[*].storage_class`, `rules[*].noncurrent_version_transitions[*].storage_class`
   - `services/s3/bucket_encryption.rs` — `rules[*].apply_server_side_encryption_by_default.sse_algorithm`
   - `services/s3/bucket_logging.rs` — `target_object_key_format.partitioned_prefix.partition_date_source`
   - `services/s3/bucket_replication.rs` — `rules[*].status`, `rules[*].delete_marker_replication.status`, `rules[*].destination.storage_class`
   - `services/s3/bucket_website.rs` — `redirect_all_requests_to.protocol`

`carina-aws-types/Cargo.toml` is also bumped to the same carina rev so the workspace does not end up with two `carina_core` versions through the shared types crate.

## Why one PR rather than helper-then-sweep

CLAUDE.md's "Root-cause fixes only — and make the broken state unrepresentable" + "Do the typed reshape in-PR. Do not measure radius and do not defer it." rules are explicit: shipping the helper change as PR2 and the sweep as PR3 would leave the buggy raw-match sites untouched in main between the two PRs, which is the bandaid this work is trying to remove. The compile breakage is the whole point of this change — splitting it would defeat the type-safety reshape.

## Known follow-up (intentional small debt, not in this PR)

Codex emitted `let _ = schema;` at the top of a number of helper-internal/private methods to suppress the unused-binding warning before later code uses `schema`. Most of those bindings *are* used later, so the suppression is dead code; a small follow-up cleanup PR will sweep them. The choice to ship this PR with that noise is deliberate — getting the type-safety reshape on main and re-running acceptance tests is higher priority than scrubbing the cosmetic noise.

## Test plan

- [x] `cargo update -p carina-core -p carina-plugin-sdk -p carina-provider-protocol` — clean lockfile bump.
- [x] `cargo check` — passes.
- [x] `cargo test` — passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes.
- [x] `cargo build --target wasm32-wasip2 -p carina-provider-aws --release` — passes.
- [ ] Re-run the acceptance suite (`./acceptance-tests/run-tests.sh full`) after merge to confirm the 23/47 → expected-large-improvement on the 11+ sites this PR touches. Will land in a follow-up acceptance run.

Refs carina-rs/carina#3555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
