### PR TITLE
chore(provider-aws): drop dead let _ = schema; lines, rename unused params to _schema (#3555)

### DIFF
--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -305,7 +305,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let id = resource.id.clone();
         let domain_name = require_string_attr(resource, "domain_name")?;
 
@@ -500,7 +499,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         if let Some(options) = build_update_certificate_options(&to, schema) {
             self.acm_client
                 .update_certificate_options()

--- a/carina-provider-aws/src/services/ec2/eip.rs
+++ b/carina-provider-aws/src/services/ec2/eip.rs
@@ -65,7 +65,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let mut req = self.ec2_client.allocate_address();
 
         if let Some(domain) = optional_enum_attr(resource, schema, "domain") {
@@ -106,9 +105,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/ec2/flow_log.rs
+++ b/carina-provider-aws/src/services/ec2/flow_log.rs
@@ -80,7 +80,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let resource_ids_val: Vec<String> = match resource.get_attr("resource_ids") {
             Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
@@ -239,9 +238,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/ec2/nat_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/nat_gateway.rs
@@ -79,7 +79,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let subnet_id = require_string_attr(resource, "subnet_id")?;
 
         let mut req = self.ec2_client.create_nat_gateway().subnet_id(&subnet_id);
@@ -133,9 +132,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/services/ec2/security_group_egress.rs
@@ -21,7 +21,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.create_ec2_security_group_rule(resource, schema, false)
             .await
     }
@@ -34,7 +33,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.update_ec2_security_group_rule(id, identifier, to, schema, false)
             .await
     }

--- a/carina-provider-aws/src/services/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/services/ec2/security_group_ingress.rs
@@ -21,7 +21,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.create_ec2_security_group_rule(resource, schema, true)
             .await
     }
@@ -34,7 +33,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.update_ec2_security_group_rule(id, identifier, to, schema, true)
             .await
     }

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -77,7 +77,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let cidr_block = require_string_attr(resource, "cidr_block")?;
         let vpc_id = require_string_attr(resource, "vpc_id")?;
 
@@ -123,7 +122,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         // Apply subnet attributes that require ModifySubnetAttribute
         let attrs = to.resolved_attributes();
         self.modify_subnet_attributes(&id, identifier, &to, schema)

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -149,7 +149,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let mut req = self.ec2_client.create_transit_gateway();
 
         if let Some(Value::Concrete(ConcreteValue::String(desc))) = resource.get_attr("description")
@@ -201,9 +200,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -111,7 +111,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let transit_gateway_id = require_string_attr(resource, "transit_gateway_id")?;
         let vpc_id = require_string_attr(resource, "vpc_id")?;
 
@@ -190,9 +189,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -97,7 +97,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let cidr_block = require_string_attr(resource, "cidr_block")?;
 
         // Create VPC with optional instance_tenancy
@@ -180,9 +179,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         // identifier is the VPC ID (e.g., vpc-12345678)
         let vpc_id = identifier.to_string();
 

--- a/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_endpoint.rs
@@ -69,7 +69,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let vpc_id = require_string_attr(resource, "vpc_id")?;
         let service_name = require_string_attr(resource, "service_name")?;
 
@@ -174,9 +173,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let mut req = self
             .ec2_client
             .modify_vpc_endpoint()

--- a/carina-provider-aws/src/services/ec2/vpn_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/vpn_gateway.rs
@@ -73,7 +73,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let gw_type = require_enum_attr(resource, schema, "type")?;
 
         let mut req = self
@@ -114,9 +113,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.apply_ec2_tags(
             &id,
             identifier,

--- a/carina-provider-aws/src/services/logs/log_group.rs
+++ b/carina-provider-aws/src/services/logs/log_group.rs
@@ -118,7 +118,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let log_group_name = require_string_attr(resource, "log_group_name")?;
 
         let mut req = self
@@ -183,9 +182,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         // Update retention
         match to.get_attr("retention_in_days") {
             Some(Value::Concrete(ConcreteValue::Int(days))) => {

--- a/carina-provider-aws/src/services/organizations/account.rs
+++ b/carina-provider-aws/src/services/organizations/account.rs
@@ -166,7 +166,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let name = require_string_attr(resource, "account_name")?;
         let email = require_string_attr(resource, "email")?;
 
@@ -337,9 +336,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         // Handle parent_id change via MoveAccount
         let desired_parent = to.get_attr("parent_id").and_then(|v| match v {
             Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),

--- a/carina-provider-aws/src/services/organizations/organization.rs
+++ b/carina-provider-aws/src/services/organizations/organization.rs
@@ -111,7 +111,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let mut req = self.organizations_client.create_organization();
 
         if let Some(feature_set) = optional_enum_attr(resource, schema, "feature_set") {

--- a/carina-provider-aws/src/services/route53/record_set.rs
+++ b/carina-provider-aws/src/services/route53/record_set.rs
@@ -363,7 +363,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let hosted_zone_id = require_string_attr(resource, "hosted_zone_id")?;
         let name = require_string_attr(resource, "name")?;
         let record_type = require_enum_attr(resource, schema, "type")?;
@@ -390,7 +389,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let hosted_zone_id = require_string_attr(&to, "hosted_zone_id")?;
         let name = require_string_attr(&to, "name")?;
         let record_type = require_enum_attr(&to, schema, "type")?;

--- a/carina-provider-aws/src/services/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/services/s3/bucket_acl.rs
@@ -148,7 +148,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
         self.put_s3_bucket_acl(&resource.id, &bucket, resource, schema)
             .await
@@ -162,7 +161,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.put_s3_bucket_acl(&id, identifier, &to, schema).await
     }
 

--- a/carina-provider-aws/src/services/s3/bucket_encryption.rs
+++ b/carina-provider-aws/src/services/s3/bucket_encryption.rs
@@ -73,7 +73,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
         self.put_s3_bucket_encryption(&resource.id, &bucket, resource, schema)
             .await
@@ -87,7 +86,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.put_s3_bucket_encryption(&id, identifier, &to, schema)
             .await
     }

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -73,7 +73,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
         self.put_s3_bucket_lifecycle(&resource.id, &bucket, resource, schema)
             .await
@@ -87,7 +86,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.put_s3_bucket_lifecycle(&id, identifier, &to, schema)
             .await
     }

--- a/carina-provider-aws/src/services/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/services/s3/bucket_logging.rs
@@ -76,7 +76,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
         self.put_s3_bucket_logging(&resource.id, &bucket, resource, schema)
             .await
@@ -90,7 +89,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.put_s3_bucket_logging(&id, identifier, &to, schema)
             .await
     }

--- a/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/services/s3/bucket_ownership_controls.rs
@@ -69,7 +69,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
         self.put_s3_bucket_ownership_controls(&resource.id, &bucket, resource, schema)
             .await
@@ -83,7 +82,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.put_s3_bucket_ownership_controls(&id, identifier, &to, schema)
             .await
     }

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -78,7 +78,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
         self.put_s3_bucket_replication(&resource.id, &bucket, resource, schema)
             .await
@@ -92,7 +91,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.put_s3_bucket_replication(&id, identifier, &to, schema)
             .await
     }

--- a/carina-provider-aws/src/services/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/services/s3/bucket_versioning.rs
@@ -74,7 +74,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
         self.put_s3_bucket_versioning(&resource.id, &bucket, resource, schema)
             .await
@@ -88,7 +87,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.put_s3_bucket_versioning(&id, identifier, &to, schema)
             .await
     }

--- a/carina-provider-aws/src/services/s3/bucket_website.rs
+++ b/carina-provider-aws/src/services/s3/bucket_website.rs
@@ -102,7 +102,6 @@ impl AwsProvider {
         resource: &Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let bucket = require_string_attr(resource, "bucket")?;
         self.put_s3_bucket_website(&resource.id, &bucket, resource, schema)
             .await
@@ -116,7 +115,6 @@ impl AwsProvider {
         to: Resource,
         schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         self.put_s3_bucket_website(&id, identifier, &to, schema)
             .await
     }

--- a/carina-provider-aws/src/services/sqs/queue.rs
+++ b/carina-provider-aws/src/services/sqs/queue.rs
@@ -473,9 +473,8 @@ impl AwsProvider {
     pub(crate) async fn create_sqs_queue(
         &self,
         resource: &Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
         let queue_name = require_string_attr(resource, "queue_name")?;
 
         // Pack every writable attribute the user actually set.
@@ -521,10 +520,8 @@ impl AwsProvider {
         identifier: &str,
         from: &State,
         to: Resource,
-        schema: &ResourceSchema,
+        _schema: &ResourceSchema,
     ) -> ProviderResult<State> {
-        let _ = schema;
-        let _ = schema;
         // Build a partial map of attributes whose value changed.
         // Create-only attributes (FifoQueue / FifoThroughputLimit /
         // DeduplicationScope) are dropped — schema marks them


### PR DESCRIPTION
## Summary

Pure cosmetic cleanup following PR #458 (the carina-rs/carina#3555 schema-threading sweep).

The earlier sweep added a `let _ = schema;` suppression at the top of every service method that received the new `&ResourceSchema` parameter. Most of those methods *do* use `schema` later in the body, so Rust's `unused_variables` lint would have been silent without the suppression — the suppressions are dead code.

This PR:

- Deletes every `let _ = schema;` line under `carina-provider-aws/src/` (50 lines across 25 files).
- For the 12 service methods where `schema` is genuinely unused (signature parity for `provider.rs`'s `(resource, schema)` dispatcher, but the method body does not consult the schema), renames the parameter to `_schema` so the unused-binding warning stays suppressed in Rust's idiomatic form. The parameter itself stays so the dispatcher does not need a per-resource_type signature carve-out.

No semantic changes. No `#[allow(...)]` attributes. The audit did not surface any latent "schema *should* have been used" site.

## Test plan

- [x] `cargo check` — passes.
- [x] `cargo test` — passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes.
- [x] `cargo fmt --check` — passes.
- [x] `cargo build --target wasm32-wasip2 -p carina-provider-aws --release` — passes.

Refs carina-rs/carina#3555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
