### PR TITLE
fix(iam): serialize ConcreteValue::StringList in policy JSON walker (carina#3575/3576/3577)

### DIFF
--- a/carina-provider-aws/src/services/iam/role.rs
+++ b/carina-provider-aws/src/services/iam/role.rs
@@ -530,6 +530,12 @@ fn dsl_value_to_iam_json(
                     .map(|it| dsl_value_to_iam_json(it, element_type, attr_name))
                     .collect(),
             ),
+            Value::Concrete(ConcreteValue::StringList(items)) => serde_json::Value::Array(
+                items
+                    .iter()
+                    .map(|s| serde_json::Value::String(s.clone()))
+                    .collect(),
+            ),
             // A scalar where the schema declares a list: emit the scalar
             // (AWS accepts a bare string for single-element Action etc.).
             _ => dsl_value_to_iam_json(value, element_type, attr_name),
@@ -634,6 +640,12 @@ fn scalar_to_json(value: &Value) -> serde_json::Value {
         Value::Concrete(ConcreteValue::List(items)) => {
             serde_json::Value::Array(items.iter().map(scalar_to_json).collect())
         }
+        Value::Concrete(ConcreteValue::StringList(items)) => serde_json::Value::Array(
+            items
+                .iter()
+                .map(|s| serde_json::Value::String(s.clone()))
+                .collect(),
+        ),
         Value::Concrete(ConcreteValue::Map(map)) => {
             let mut obj = serde_json::Map::new();
             for (k, v) in map {
@@ -1117,6 +1129,56 @@ mod tests {
         assert!(
             !resolved.contains("statment") && !resolved.contains("bogus_field"),
             "unmodeled keys must not reach AWS, got: {resolved}"
+        );
+    }
+
+    #[test]
+    fn resolve_iam_policy_attr_serializes_parsed_canonicalized_iam_role_policy() {
+        let src = r#"
+            aws.iam.Role {
+              role_name = 'carina-acceptance-test-role'
+              assume_role_policy_document = {
+                version = aws.iam.PolicyDocument.Version.2012_10_17
+                statement {
+                  effect = aws.iam.PolicyDocument.Statement.Effect.allow
+                  principal = {
+                    service = 'ec2.amazonaws.com'
+                  }
+                  action = 'sts:AssumeRole'
+                }
+              }
+              description = 'Carina acceptance test role'
+              path = '/'
+              max_session_duration = 7200
+              tags = { Environment = 'acceptance-test' }
+            }
+        "#;
+        let parsed =
+            carina_core::parser::parse(src, &carina_core::parser::ProviderContext::default())
+                .expect("parse fixture");
+        let mut resource = parsed.resources[0].clone();
+        let schema = crate::schemas::generated::iam::role::iam_role_config().schema;
+        let policy_attr = &schema
+            .attributes
+            .get("assume_role_policy_document")
+            .expect("policy attr")
+            .attr_type;
+        let policy = resource
+            .get_attr("assume_role_policy_document")
+            .expect("policy")
+            .clone();
+        let policy_schema = carina_core::schema::Schema::flat(policy_attr.clone());
+        resource.set_attr(
+            "assume_role_policy_document",
+            policy_schema.canonicalize(policy),
+        );
+
+        let resolved =
+            resolve_iam_policy_attr(&resource, "assume_role_policy_document").expect("map -> JSON");
+
+        assert_eq!(
+            resolved,
+            r#"{"Statement":[{"Action":["sts:AssumeRole"],"Effect":"Allow","Principal":{"Service":["ec2.amazonaws.com"]}}],"Version":"2012-10-17"}"#
         );
     }
 


### PR DESCRIPTION
## Summary

Fix the IAM/S3/SQS policy JSON syntax error that surfaced as `Syntax error at position (1,29)` / `MalformedPolicy` / `Invalid policy syntax` / `Invalid value for the parameter Policy` in the 2026-06-16 acceptance run (carina-rs/carina#3575, #3576, #3577).

Root cause: `dsl_value_to_iam_json` / `scalar_to_json` in `services/iam/role.rs` handled `Value::Concrete(ConcreteValue::List(_))` but had no arm for `ConcreteValue::StringList(_)`. After parser + generated-schema canonicalize, the leaves the DSL writes as scalars — `action = 'sts:AssumeRole'`, `service = 'ec2.amazonaws.com'` — arrive at the serializer as `StringList` because the schema declares those fields as `List<String>`. The missing arm fell through to the catch-all that produces `serde_json::Value::Null`. The serialized JSON looked like:

```json
{"Statement":[{"Action":null,"Effect":"Allow","Principal":{"Service":null}}],"Version":"2012-10-17"}
```

…which AWS rejects.

Why the unit tests stayed green while the apply path broke: the existing `resolve_iam_policy_attr_*` tests hand-built `Resource` attributes as `ConcreteValue::Map` / `ConcreteValue::List<Value>` directly, bypassing parser + canonicalize. The path that exercised the bug starts at parser and goes through `Schema::canonicalize(...)` — exactly the apply path the unit tests never drove. This is the `feedback_unit_test_path_is_not_apply_path` lesson manifesting again.

## What this PR does

1. Adds the `ConcreteValue::StringList` arm to `dsl_value_to_iam_json`'s `Shape::List { .. }` match, emitting a JSON array of strings.
2. Adds the same arm to `scalar_to_json`'s value match for completeness — the policy walker can land there for non-Shape-typed positions, and the silent-null behavior is the same family of bug.
3. Adds `resolve_iam_policy_attr_serializes_parsed_canonicalized_iam_role_policy` that parses real DSL, runs the policy attribute through the generated IAM Role schema's canonicalize, and asserts the *exact* expected JSON output.

## Test plan

- [x] `cargo check` — passes.
- [x] `cargo test` — passes (new regression test green).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes.
- [x] `cargo fmt --check` — passes.
- [x] `cargo build --target wasm32-wasip2 -p carina-provider-aws --release` — passes.
- [ ] Re-run aws acceptance for `iam_role` / `s3_bucket_policy` / `sqs_queue` / `s3_bucket_notification_configuration` / `s3_bucket_replication_configuration` after merge to confirm green. Will land in a follow-up acceptance run.

## Known follow-up (not in this PR)

`scalar_to_json` and `dsl_value_to_iam_json`'s catch-all arms still silently drop other `ConcreteValue` variants (e.g. `EnumIdentifier` outside the StringEnum branch, `Bool`, `Int`, `Float`, `Duration` — most of those are not legal in policy positions anyway, but they fall through to `Null`). The unit tests that hand-build `Map` values do not exercise this — same gap as the StringList one. A separate audit issue should track making the policy walker reject (or explicitly handle) every `Value` variant the canonicalize pipeline can produce.

awscc's `dsl_value_to_aws_with_defs` should be audited for the symmetric StringList gap.

Refs carina-rs/carina#3575, #3576, #3577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
