### PR TITLE
chore: bump carina rev to dc9e6cab, route StringList through ProtoValue::StringList (carina#3584)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
+source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
+source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
+source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1122,7 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2040,7 +2040,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2305,7 +2305,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -75,12 +75,9 @@ pub fn core_to_proto_value(v: &CoreValue) -> ProtoValue {
         CoreValue::Concrete(ConcreteValue::List(l)) => {
             ProtoValue::List(l.iter().map(core_to_proto_value).collect())
         }
-        CoreValue::Concrete(ConcreteValue::StringList(items)) => ProtoValue::List(
-            items
-                .iter()
-                .map(|s| ProtoValue::String(s.clone()))
-                .collect(),
-        ),
+        CoreValue::Concrete(ConcreteValue::StringList(items)) => {
+            ProtoValue::StringList(items.clone())
+        }
         CoreValue::Concrete(ConcreteValue::Map(m)) => ProtoValue::Map(
             m.iter()
                 .map(|(k, v)| (k.clone(), core_to_proto_value(v)))
@@ -123,6 +120,9 @@ pub fn proto_to_core_value(v: &ProtoValue) -> CoreValue {
         ProtoValue::List(l) => CoreValue::Concrete(ConcreteValue::List(
             l.iter().map(proto_to_core_value).collect(),
         )),
+        ProtoValue::StringList(items) => {
+            CoreValue::Concrete(ConcreteValue::StringList(items.clone()))
+        }
         ProtoValue::Map(m) => CoreValue::Concrete(ConcreteValue::Map(
             m.iter()
                 .map(|(k, v)| (k.clone(), proto_to_core_value(v)))


### PR DESCRIPTION
## Summary

Bump carina rev pin to `dc9e6cab` (carina main after carina-rs/carina#3587) and route `ConcreteValue::StringList` through `ProtoValue::StringList` rather than flattening to `ProtoValue::List`.

## Why

The new `StringList` variant on the WIT `value` union (in `carina-plugin-wit#27`, merged into carina main as #3587) preserves the type tag across the host↔guest boundary. The carina-core differ treats `StringList` and `List<String>` as distinct shapes, so for `Union<String, List<String>>` schema attributes (e.g. `iam_policy_document.statement[*].action`) the tag must survive the round-trip. The previous protocol conversion in `provider-aws/src/convert.rs` collapsed `StringList` to a `List<ProtoValue::String>` on the way out and lost the tag, defeating the carina#3584 fix.

## What this PR does

1. Bump `carina-provider-aws/Cargo.toml` and `carina-aws-types/Cargo.toml` carina rev pin to `dc9e6cab`.
2. Update the `carina-plugin-wit` submodule to `facd597`.
3. In `provider-aws/src/convert.rs`:
   - `core_to_proto_value`: `ConcreteValue::StringList(items)` → `ProtoValue::StringList(items.clone())`.
   - `proto_to_core_value`: `ProtoValue::StringList(items)` → `ConcreteValue::StringList(items.clone())`.

## Test plan

- [x] `cargo update -p carina-core -p carina-plugin-sdk -p carina-provider-protocol` — clean lockfile bump.
- [x] `cargo check` — passes.
- [x] `cargo test` — passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes.
- [x] `cargo build --target wasm32-wasip2 -p carina-provider-aws --release` — passes.

Refs carina-rs/carina#3584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
