### PR TITLE
refactor: rename id.name to id.identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=c74fa7640cc008e9a958ef1a6edc02e3b9506149#c74fa7640cc008e9a958ef1a6edc02e3b9506149"
+source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=c74fa7640cc008e9a958ef1a6edc02e3b9506149#c74fa7640cc008e9a958ef1a6edc02e3b9506149"
+source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=c74fa7640cc008e9a958ef1a6edc02e3b9506149#c74fa7640cc008e9a958ef1a6edc02e3b9506149"
+source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
 dependencies = [
  "serde",
  "serde_json",
@@ -2305,7 +2305,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "c74fa7640cc008e9a958ef1a6edc02e3b9506149" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "c74fa7640cc008e9a958ef1a6edc02e3b9506149" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "c74fa7640cc008e9a958ef1a6edc02e3b9506149" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "c74fa7640cc008e9a958ef1a6edc02e3b9506149" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-aws/src/convert.rs
+++ b/carina-provider-aws/src/convert.rs
@@ -34,7 +34,7 @@ pub fn core_to_proto_resource_id(id: &CoreResourceId) -> ProtoResourceId {
     ProtoResourceId {
         provider: id.provider.clone(),
         resource_type: id.resource_type.clone(),
-        name: id.name.to_string(),
+        identity: id.identity_or_empty().to_string(),
     }
 }
 
@@ -42,7 +42,7 @@ pub fn proto_to_core_resource_id(id: &ProtoResourceId) -> CoreResourceId {
     // `ProtoResourceId` predates carina#3038's `provider_instance` field;
     // the WIT wire format does not carry it. Pass `None` so the
     // reconstructed `CoreResourceId` routes through the default provider.
-    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name, None)
+    CoreResourceId::with_provider_name_compat(&id.provider, &id.resource_type, &id.identity, None)
 }
 
 // -- Value --
@@ -229,7 +229,7 @@ pub fn core_to_proto_directives(l: &CoreDirectives) -> ProtoDirectives {
 
 pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
     let mut resource =
-        CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name, None);
+        CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.identity, None);
     resource.attributes = r
         .attributes
         .iter()
@@ -251,7 +251,7 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
 /// data-source read request maps to this typed projection (carina#3181).
 pub fn proto_to_core_data_source(r: &ProtoResource) -> CoreDataSource {
     let mut data_source =
-        CoreDataSource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name, None);
+        CoreDataSource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.identity, None);
     data_source.attributes = r
         .attributes
         .iter()
@@ -476,7 +476,7 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
         description: s.description.clone(),
         validator: None,
         kind: proto_to_core_schema_kind(s.kind),
-        name_attribute: s.name_attribute.clone(),
+        unique_name_attribute: s.unique_name_attribute.clone(),
         operation_config: s.operation_config.as_ref().map(|c| CoreOperationConfig {
             delete_timeout_secs: c.delete_timeout_secs,
             delete_max_retries: c.delete_max_retries,
@@ -650,7 +650,7 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
             .collect(),
         description: s.description.clone(),
         kind: core_to_proto_schema_kind(s.kind),
-        name_attribute: s.name_attribute.clone(),
+        unique_name_attribute: s.unique_name_attribute.clone(),
         operation_config: s.operation_config.as_ref().map(|c| ProtoOperationConfig {
             delete_timeout_secs: c.delete_timeout_secs,
             delete_max_retries: c.delete_max_retries,

--- a/carina-provider-aws/src/helpers.rs
+++ b/carina-provider-aws/src/helpers.rs
@@ -505,7 +505,10 @@ where
 /// `Directives` (directives are delete-only and are not consulted on
 /// update paths in this provider).
 pub fn apply_patch_to_state(from: &State, patch: &UpdatePatch) -> Resource {
-    let mut resource = Resource::new(from.id.resource_type.clone(), from.id.name.to_string());
+    let mut resource = Resource::new(
+        from.id.resource_type.clone(),
+        from.id.identity_or_empty().to_string(),
+    );
     resource.id = from.id.clone();
     resource.attributes = from
         .attributes
@@ -638,7 +641,7 @@ mod tests {
         use std::collections::HashMap;
 
         // from-state has two attrs; patch adds one, replaces one, removes one.
-        let id = ResourceId::with_provider("aws", "ec2.Vpc", "test", None);
+        let id = ResourceId::with_provider_identity("aws", "ec2.Vpc", "test", None);
         let mut from_attrs: HashMap<String, Value> = HashMap::new();
         from_attrs.insert(
             "cidr_block".into(),

--- a/carina-provider-aws/src/services/acm/certificate.rs
+++ b/carina-provider-aws/src/services/acm/certificate.rs
@@ -684,7 +684,7 @@ mod tests {
     use std::time::Duration;
 
     fn id() -> ResourceId {
-        ResourceId::with_provider("aws", "acm.Certificate", "test-cert", None)
+        ResourceId::with_provider_identity("aws", "acm.Certificate", "test-cert", None)
     }
 
     fn dv_without_rr(domain: &str) -> DomainValidation {

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -77,7 +77,7 @@ impl AwsProvider {
         // group_name is required for CreateSecurityGroup API
         let group_name = match resource.get_attr("group_name") {
             Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
-            _ => resource.id.name.to_string(),
+            _ => resource.id.identity_or_empty().to_string(),
         };
 
         // Create Security Group

--- a/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
+++ b/carina-provider-aws/src/services/s3/bucket_lifecycle.rs
@@ -686,7 +686,7 @@ mod tests {
     use super::*;
 
     fn rid() -> ResourceId {
-        ResourceId::new("s3.bucket_lifecycle_configuration", "test")
+        ResourceId::with_identity("s3.bucket_lifecycle_configuration", "test")
     }
 
     fn schema() -> ResourceSchema {

--- a/carina-provider-aws/src/services/s3/bucket_replication.rs
+++ b/carina-provider-aws/src/services/s3/bucket_replication.rs
@@ -525,7 +525,7 @@ mod tests {
     use super::*;
 
     fn rid() -> ResourceId {
-        ResourceId::new("s3.bucket_replication_configuration", "test")
+        ResourceId::with_identity("s3.bucket_replication_configuration", "test")
     }
 
     fn schema() -> ResourceSchema {

--- a/carina-provider-aws/tests/sts_caller_identity_winterbaume.rs
+++ b/carina-provider-aws/tests/sts_caller_identity_winterbaume.rs
@@ -70,7 +70,7 @@ async fn required_permissions_returns_empty_vec() {
         SqsClient::new(&sdk_config),
     );
 
-    let id = ResourceId::with_provider("aws", "s3.Bucket", "example", None);
+    let id = ResourceId::with_provider_identity("aws", "s3.Bucket", "example", None);
 
     assert_eq!(
         provider.required_permissions(&id, PlanOp::Create),


### PR DESCRIPTION
## Summary

- Rename `id.name` → `id.identity` across all protocol/WIT ResourceId references
- Bump carina rev to eaf06412 (protocol ResourceId.identity)
- Update carina-plugin-wit submodule

Counterpart to carina-rs/carina#3638 and carina-rs/carina#3644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)