### PR TITLE
chore: bump carina-core rev to 8ebc747a (carina#3664)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
+source = "git+https://github.com/carina-rs/carina?rev=8ebc747a#8ebc747a03fe677d62763920d7bc5ecc9984fb0d"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
+source = "git+https://github.com/carina-rs/carina?rev=8ebc747a#8ebc747a03fe677d62763920d7bc5ecc9984fb0d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
+source = "git+https://github.com/carina-rs/carina?rev=8ebc747a#8ebc747a03fe677d62763920d7bc5ecc9984fb0d"
 dependencies = [
  "serde",
  "serde_json",
@@ -1122,7 +1122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2040,7 +2040,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "8ebc747a" }
 heck = "0.5"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -19,10 +19,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "8ebc747a" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "8ebc747a" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "8ebc747a" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

Bump carina-core, carina-plugin-sdk, and carina-provider-protocol git dependencies
to pick up carina#3664 (`into_plan_input_map` consolidation). No code changes needed
in this repo — `carina-provider-aws` does not call `State::into_plan_input()` directly.

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes