### PR TITLE
feat(codegen): derive unique_name_attribute from ResourceDef identifier

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -11,12 +11,14 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
-use carina_smithy::{ShapeKind, SmithyModel};
+use carina_smithy::{Shape, ShapeKind, SmithyModel};
 use clap::Parser;
 use heck::ToSnakeCase;
 
 use carina_aws_types::dsl_enum_value;
 use carina_codegen_aws::resource_defs::{self, ResourceDef};
+
+const PLAIN_STRING_TYPE_CODE: &str = "AttributeType::string()";
 
 #[derive(Parser, Debug)]
 #[command(name = "smithy-codegen")]
@@ -385,6 +387,9 @@ struct AttrInfo {
     is_create_only: bool,
     /// Whether the field is read-only
     is_read_only: bool,
+    /// Whether the underlying Smithy member target is a plain string shape.
+    /// This is captured before rendered type overrides are applied.
+    is_plain_string: bool,
     /// Whether the field contributes to anonymous resource identity hashing
     is_identity: bool,
     /// Whether the AWS API populates this field asynchronously after Create
@@ -395,6 +400,49 @@ struct AttrInfo {
     description: Option<String>,
     /// Enum info if this attribute is an enum
     enum_info: Option<EnumInfo>,
+}
+
+fn is_plain_smithy_string(model: &SmithyModel, target: &str) -> bool {
+    match model.get_shape(target) {
+        Some(Shape::String(shape)) => !shape.traits.contains_key("smithy.api#enum"),
+        None => target == "smithy.api#String",
+        _ => false,
+    }
+}
+
+fn derive_unique_name_attribute(
+    identifier: &str,
+    attrs: &[AttrInfo],
+    is_data_source: bool,
+) -> Option<String> {
+    if is_data_source || identifier.is_empty() {
+        return None;
+    }
+    if attrs.iter().any(|attr| attr.is_identity) {
+        // awscc emits unique_name_attribute only when primary_ids.len() == 1.
+        // In this Smithy codegen, identity_overrides mark extra identity
+        // components beyond ResourceDef::identifier, so the identifier alone is
+        // not the resource's unique name.
+        return None;
+    }
+    let identifier_snake = identifier.to_snake_case();
+
+    attrs
+        .iter()
+        .find(|attr| {
+            (attr.provider_name == identifier
+                || attr.provider_name.to_snake_case() == identifier_snake)
+                && !attr.is_read_only
+                && attr.is_plain_string
+                // create_before_destroy temporary-name generation only makes sense
+                // for user-chosen names. Resource IDs, ARNs, CIDRs, and other
+                // inferred/overridden string subtypes are references to existing
+                // server-generated values; suffixing them would produce invalid
+                // temporary inputs. This matches awscc's outcome for resources
+                // whose real primary identity is composite.
+                && attr.type_code == PLAIN_STRING_TYPE_CODE
+        })
+        .map(|attr| attr.snake_name.clone())
 }
 
 /// Integer range constraint (supports one-sided ranges)
@@ -983,6 +1031,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             name,
         );
 
+        let is_plain_string = is_plain_smithy_string(model, &member_ref.target);
         let is_identity = identity_overrides.contains(name.as_str());
         let is_deferred_populate = deferred_populate_overrides.contains(name.as_str());
 
@@ -993,6 +1042,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_required,
             is_create_only,
             is_read_only,
+            is_plain_string,
             is_identity,
             is_deferred_populate,
             description,
@@ -1016,7 +1066,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         } else if let Some(inferred) = infer_string_type(extra.name) {
             inferred
         } else {
-            "AttributeType::string()".to_string()
+            PLAIN_STRING_TYPE_CODE.to_string()
         };
         let is_read_only = read_only_overrides.contains(extra.name);
         let is_create_only = !is_read_only
@@ -1030,6 +1080,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_required,
             is_create_only,
             is_read_only,
+            is_plain_string: false,
             is_identity: identity_overrides.contains(extra.name),
             is_deferred_populate: deferred_populate_overrides.contains(extra.name),
             description: extra.description.map(|s| s.to_string()),
@@ -1060,6 +1111,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             name,
         );
 
+        let is_plain_string = is_plain_smithy_string(model, &member_ref.target);
         attrs.push(AttrInfo {
             snake_name,
             provider_name: name.clone(),
@@ -1067,6 +1119,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_required: false,
             is_create_only: false,
             is_read_only: true,
+            is_plain_string,
             is_identity: false,
             is_deferred_populate: deferred_populate_overrides.contains(name.as_str()),
             description,
@@ -1220,6 +1273,15 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     // Mark data sources
     if is_data_source {
         code.push_str("\x20       .as_data_source()\n");
+    }
+
+    if let Some(unique_name_attribute) =
+        derive_unique_name_attribute(res.identifier, &attrs, is_data_source)
+    {
+        code.push_str(&format!(
+            "\x20       .with_unique_name_attribute(\"{}\")\n",
+            unique_name_attribute
+        ));
     }
 
     // Generate attributes
@@ -1508,7 +1570,7 @@ fn resolve_type(
                 return (inferred, None);
             }
 
-            ("AttributeType::string()".to_string(), None)
+            (PLAIN_STRING_TYPE_CODE.to_string(), None)
         }
         Some(ShapeKind::Boolean) => ("AttributeType::bool()".to_string(), None),
         Some(ShapeKind::Integer) | Some(ShapeKind::Long) => {
@@ -1561,7 +1623,7 @@ fn resolve_type(
                     .or_insert_with(|| enum_info.clone());
                 return ("/* enum */".to_string(), Some(enum_info));
             }
-            ("AttributeType::string()".to_string(), None)
+            (PLAIN_STRING_TYPE_CODE.to_string(), None)
         }
         Some(ShapeKind::IntEnum) => ("AttributeType::int()".to_string(), None),
         Some(ShapeKind::List) => {
@@ -1571,13 +1633,13 @@ fn resolve_type(
                 (format!("AttributeType::list({})", item_type), None)
             } else {
                 (
-                    "AttributeType::list(AttributeType::string())".to_string(),
+                    format!("AttributeType::list({PLAIN_STRING_TYPE_CODE})"),
                     None,
                 )
             }
         }
         Some(ShapeKind::Map) => (
-            "AttributeType::map(AttributeType::string())".to_string(),
+            format!("AttributeType::map({PLAIN_STRING_TYPE_CODE})"),
             None,
         ),
         Some(ShapeKind::Structure) => {
@@ -1597,14 +1659,14 @@ fn resolve_type(
                 let struct_code = generate_struct_type(ctx, shape_name, structure);
                 return (struct_code, None);
             }
-            ("AttributeType::string()".to_string(), None)
+            (PLAIN_STRING_TYPE_CODE.to_string(), None)
         }
         _ => {
             // Fallback: try name-based heuristics
             if let Some(inferred) = infer_string_type(field_name) {
                 (inferred, None)
             } else {
-                ("AttributeType::string()".to_string(), None)
+                (PLAIN_STRING_TYPE_CODE.to_string(), None)
             }
         }
     }
@@ -3855,7 +3917,7 @@ fn generate_data_source(
         } else if is_email_property(input.provider_name) {
             "types::email()".to_string()
         } else {
-            "AttributeType::string()".to_string()
+            PLAIN_STRING_TYPE_CODE.to_string()
         };
         ds_attrs.push(DsAttr {
             name: input.name.to_string(),
@@ -4248,7 +4310,7 @@ fn type_code_to_display(type_code: &str) -> String {
     }
 
     match type_code {
-        "AttributeType::string()" => "String".to_string(),
+        PLAIN_STRING_TYPE_CODE => "String".to_string(),
         "AttributeType::bool()" => "Bool".to_string(),
         "AttributeType::int()" => "Int".to_string(),
         "AttributeType::float()" => "Float".to_string(),
@@ -4865,6 +4927,122 @@ mod tests {
             type_code_to_display("super::iam_oidc_provider_arn()"),
             "IamOidcProviderArn"
         );
+    }
+
+    fn test_attr(
+        provider_name: &str,
+        snake_name: &str,
+        type_code: &str,
+        is_read_only: bool,
+        is_plain_string: bool,
+        is_identity: bool,
+        enum_info: Option<EnumInfo>,
+    ) -> AttrInfo {
+        AttrInfo {
+            snake_name: snake_name.to_string(),
+            provider_name: provider_name.to_string(),
+            type_code: type_code.to_string(),
+            is_required: false,
+            is_create_only: false,
+            is_read_only,
+            is_plain_string,
+            is_identity,
+            is_deferred_populate: false,
+            description: None,
+            enum_info,
+        }
+    }
+
+    #[test]
+    fn derive_unique_name_attribute_requires_writable_plain_string_identifier() {
+        let attrs = vec![test_attr(
+            "RoleName",
+            "role_name",
+            PLAIN_STRING_TYPE_CODE,
+            false,
+            true,
+            false,
+            None,
+        )];
+        assert_eq!(
+            derive_unique_name_attribute("RoleName", &attrs, false),
+            Some("role_name".to_string())
+        );
+
+        let attrs = vec![test_attr(
+            "logGroupName",
+            "log_group_name",
+            PLAIN_STRING_TYPE_CODE,
+            false,
+            true,
+            false,
+            None,
+        )];
+        assert_eq!(
+            derive_unique_name_attribute("LogGroupName", &attrs, false),
+            Some("log_group_name".to_string())
+        );
+
+        let attrs = vec![test_attr(
+            "VpcId",
+            "vpc_id",
+            PLAIN_STRING_TYPE_CODE,
+            true,
+            true,
+            false,
+            None,
+        )];
+        assert_eq!(derive_unique_name_attribute("VpcId", &attrs, false), None);
+
+        let attrs = vec![test_attr(
+            "VpcId",
+            "vpc_id",
+            "super::vpc_id()",
+            false,
+            true,
+            false,
+            None,
+        )];
+        assert_eq!(derive_unique_name_attribute("VpcId", &attrs, false), None);
+
+        let attrs = vec![test_attr(
+            "DocumentName",
+            "document_name",
+            PLAIN_STRING_TYPE_CODE,
+            false,
+            false,
+            false,
+            None,
+        )];
+        assert_eq!(
+            derive_unique_name_attribute("DocumentName", &attrs, false),
+            None
+        );
+
+        let attrs = vec![
+            test_attr(
+                "Name",
+                "name",
+                PLAIN_STRING_TYPE_CODE,
+                false,
+                true,
+                false,
+                None,
+            ),
+            test_attr("Type", "type", "/* enum */", false, false, true, None),
+        ];
+        assert_eq!(derive_unique_name_attribute("Name", &attrs, false), None);
+
+        let attrs = vec![test_attr(
+            "Bucket",
+            "bucket",
+            PLAIN_STRING_TYPE_CODE,
+            false,
+            true,
+            false,
+            None,
+        )];
+        assert_eq!(derive_unique_name_attribute("Bucket", &attrs, true), None);
     }
 
     #[test]

--- a/carina-provider-aws/src/schemas/generated/iam/role.rs
+++ b/carina-provider-aws/src/schemas/generated/iam/role.rs
@@ -21,6 +21,7 @@ pub fn iam_role_config() -> AwsSchemaConfig {
         has_tags: true,
         schema: ResourceSchema::new("iam.Role")
         .with_description("Contains information about an IAM role. This structure is returned as a response element in several API operations that interact with roles.")
+        .with_unique_name_attribute("role_name")
         .attribute(
             AttributeSchema::new("assume_role_policy_document", super::iam_policy_document())
                 .required()

--- a/carina-provider-aws/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-aws/src/schemas/generated/logs/log_group.rs
@@ -19,6 +19,7 @@ pub fn logs_log_group_config() -> AwsSchemaConfig {
         has_tags: true,
         schema: ResourceSchema::new("logs.LogGroup")
         .with_description("Represents a log group.")
+        .with_unique_name_attribute("log_group_name")
         .attribute(
             AttributeSchema::new("deletion_protection_enabled", AttributeType::bool())
                 .create_only()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -18,6 +18,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
         resource_type_name: "s3.Bucket",
         has_tags: true,
         schema: ResourceSchema::new("s3.Bucket")
+        .with_unique_name_attribute("bucket")
         .attribute(
             AttributeSchema::new("bucket", AttributeType::string())
                 .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_acl.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_acl.rs
@@ -21,6 +21,7 @@ pub fn s3_bucket_acl_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketAcl",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketAcl")
+            .with_unique_name_attribute("bucket")
             .attribute(
                 AttributeSchema::new(
                     "acl",

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_cors_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_cors_configuration.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_cors_configuration_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketCorsConfiguration",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketCorsConfiguration")
+            .with_unique_name_attribute("bucket")
             .attribute(
                 AttributeSchema::new("bucket", AttributeType::string())
                     .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_lifecycle_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_lifecycle_configuration.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_lifecycle_configuration_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketLifecycleConfiguration",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketLifecycleConfiguration")
+            .with_unique_name_attribute("bucket")
             .attribute(
                 AttributeSchema::new("bucket", AttributeType::string())
                     .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_logging.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_logging.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_logging_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketLogging",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketLogging")
+            .with_unique_name_attribute("bucket")
             .attribute(
                 AttributeSchema::new("bucket", AttributeType::string())
                     .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_notification_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_notification_configuration.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_notification_configuration_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketNotificationConfiguration",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketNotificationConfiguration")
+            .with_unique_name_attribute("bucket")
             .attribute(
                 AttributeSchema::new("bucket", AttributeType::string())
                     .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_ownership_controls.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_ownership_controls.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_ownership_controls_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketOwnershipControls",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketOwnershipControls")
+        .with_unique_name_attribute("bucket")
         .attribute(
             AttributeSchema::new("bucket", AttributeType::string())
                 .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_policy.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_policy.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_policy_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketPolicy",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketPolicy")
+        .with_unique_name_attribute("bucket")
         .attribute(
             AttributeSchema::new("bucket", AttributeType::string())
                 .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_public_access_block.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_public_access_block.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_public_access_block_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketPublicAccessBlock",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketPublicAccessBlock")
+        .with_unique_name_attribute("bucket")
         .attribute(
             AttributeSchema::new("bucket", AttributeType::string())
                 .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_replication_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_replication_configuration.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_replication_configuration_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketReplicationConfiguration",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketReplicationConfiguration")
+            .with_unique_name_attribute("bucket")
             .attribute(
                 AttributeSchema::new("bucket", AttributeType::string())
                     .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_server_side_encryption_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_server_side_encryption_configuration.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_server_side_encryption_configuration_config() -> AwsSchemaConfi
         resource_type_name: "s3.BucketServerSideEncryptionConfiguration",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketServerSideEncryptionConfiguration")
+        .with_unique_name_attribute("bucket")
         .attribute(
             AttributeSchema::new("bucket", AttributeType::string())
                 .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_versioning.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_versioning.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_versioning_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketVersioning",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketVersioning")
+        .with_unique_name_attribute("bucket")
         .attribute(
             AttributeSchema::new("bucket", AttributeType::string())
                 .required()

--- a/carina-provider-aws/src/schemas/generated/s3/bucket_website_configuration.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket_website_configuration.rs
@@ -14,6 +14,7 @@ pub fn s3_bucket_website_configuration_config() -> AwsSchemaConfig {
         resource_type_name: "s3.BucketWebsiteConfiguration",
         has_tags: false,
         schema: ResourceSchema::new("s3.BucketWebsiteConfiguration")
+        .with_unique_name_attribute("bucket")
         .attribute(
             AttributeSchema::new("bucket", AttributeType::string())
                 .required()

--- a/carina-provider-aws/src/schemas/mod.rs
+++ b/carina-provider-aws/src/schemas/mod.rs
@@ -218,6 +218,31 @@ mod tests {
     }
 
     #[test]
+    fn generated_resource_unique_name_attributes_follow_writable_identifiers() {
+        let iam_role = super::generated::iam::role::iam_role_config();
+        assert_eq!(
+            iam_role.schema.unique_name_attribute,
+            Some("role_name".to_string())
+        );
+
+        let ec2_vpc = super::generated::ec2::vpc::ec2_vpc_config();
+        assert_eq!(ec2_vpc.schema.unique_name_attribute, None);
+
+        let ec2_route = super::generated::ec2::route::ec2_route_config();
+        assert_eq!(ec2_route.schema.unique_name_attribute, None);
+
+        let ec2_vpc_gateway_attachment =
+            super::generated::ec2::vpc_gateway_attachment::ec2_vpc_gateway_attachment_config();
+        assert_eq!(
+            ec2_vpc_gateway_attachment.schema.unique_name_attribute,
+            None
+        );
+
+        let route53_record_set = super::generated::route53::record_set::route53_record_set_config();
+        assert_eq!(route53_record_set.schema.unique_name_attribute, None);
+    }
+
+    #[test]
     fn security_group_ip_protocol_values_are_canonical_and_aliases_reverse() {
         for resource_type in ["ec2.SecurityGroupIngress", "ec2.SecurityGroupEgress"] {
             let values = super::generated::get_enum_valid_values(resource_type, "ip_protocol")


### PR DESCRIPTION
Closes #466

## Problem

The Smithy codegen never emitted `unique_name_attribute` in generated resource schemas, so **every** provider-aws resource failed at plan time when a create-before-destroy replacement was needed:

```
Error: aws.iam.Role.flow_log_role: resource type 'aws.iam.Role' has no unique_name_attribute; create_before_destroy needs one to generate a temporary name
```

(Surfaced via carina-rs/carina#3662; the phantom-diff trigger there was fixed by carina-rs/carina#3660, but the schema gap remained for any legitimate replacement.)

## Fix (root-cause: a derivation rule, not per-resource overrides)

Port the awscc codegen's `primaryIdentifier` rule to the Smithy side. `derive_unique_name_attribute()` emits `.with_unique_name_attribute("<snake_name>")` for the attribute matching `ResourceDef::identifier` iff it is:

1. **Writable** (not read-only) — excludes server-generated identifiers (ec2.Vpc `VpcId`, sqs.Queue `QueueUrl`, acm.Certificate `CertificateArn`)
2. **A plain string at the Smithy shape level** — excludes enums
3. **Rendered as plain `AttributeType::string()` in the final schema** (shared `PLAIN_STRING_TYPE_CODE` const, also used at all render sites so the predicate cannot silently desynchronize) — excludes identifiers the codegen's own type inference retypes to resource-ID types (ec2.Route `route_table_id`, ec2.VpcGatewayAttachment `vpc_id`): those are references to server-generated values, and a temporary name suffixed onto a reference can never be valid
4. **Not part of a composite identity** (empty `identity_overrides`) — excludes route53.RecordSet, whose identity is (Name, Type, SetIdentifier); a suffixed DNS name would also fall outside the hosted zone. This is the exact Smithy-side counterpart of awscc's `primary_ids.len() == 1` condition
5. **Not a data source**

A new `ResourceDef` tomorrow gets correct behavior automatically — a writable string name identifier gains the attribute, a reference/server-generated/composite identifier is excluded, with no author action either way.

## Resources gaining unique_name_attribute (15)

`iam.Role` → `role_name`, `logs.LogGroup` → `log_group_name`, `s3.Bucket` and the 12 `s3.Bucket*` config resources → `bucket`.

Exact parity with the awscc provider's generated output for the shared resource types. Note: for the s3 config resources, `bucket` is a reference to the parent bucket rather than a self-name — this is the rule's intended outcome and matches awscc's shipped behavior (`s3.BucketPolicy` → `bucket`); their temporary-name path is unreachable today because `bucket` is their only create-only attribute (a replace always changes it, which skips temp-name generation).

## Tests

- `derive_unique_name_attribute_requires_writable_plain_string_identifier` (codegen unit test): positive cases incl. the camelCase↔PascalCase snake fallback (logs.LogGroup), and one negative case per gate — read-only, typed-ID `type_code`, non-plain Smithy shape with plain `type_code`, composite identity, data source
- `generated_resource_unique_name_attributes_follow_writable_identifiers` (generated-schema integration test): iam.Role `Some("role_name")`; ec2.Vpc / ec2.Route / ec2.VpcGatewayAttachment / route53.RecordSet `None`

## Verification

- `scripts/generate-schemas-smithy.sh`, `scripts/generate-provider.sh`, `scripts/generate-docs.sh`: all exit 0, no drift beyond the 15 intended `.with_unique_name_attribute` lines (the docs generator does not render this field)
- `cargo test`: all suites pass; `cargo clippy --workspace --all-targets -- -D warnings`: 0; `cargo fmt --check`: 0
- `check-carina-pin.sh`, `check-string-enum-aliases.sh`: 0
- Review: workflow-backed adversarial review (13 agents) + 5 self-review rounds; findings fixed in-branch (RecordSet composite-identity exclusion, shared type-code const, dead enum guard removal, is_plain_string gate test pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)