### PR TITLE
test(acceptance): add fixtures for acm.Certificate, route53.RecordSet, iam.Roles

### DIFF
--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -1,0 +1,16 @@
+# Acceptance Tests
+
+## Known coverage gaps
+
+The following resource types intentionally do not have runnable acceptance
+fixtures:
+
+- `aws.organizations.Organization`: skipped because the shared
+  `carina-test-00X` pool accounts are already members of an AWS Organization,
+  and `CreateOrganization` requires the caller account not to belong to one.
+- `aws.organizations.Account`: skipped because account closure has AWS cooldowns
+  and quotas, and closed accounts remain visible in the organization for 90 days,
+  making repeated acceptance runs unsuitable for the shared pool.
+- `aws.identitystore.User`: skipped because it requires an IAM Identity Center
+  identity store, which exists in the organization management account rather
+  than the pool accounts used by these tests.

--- a/acceptance-tests/acm_certificate/basic.crn
+++ b/acceptance-tests/acm_certificate/basic.crn
@@ -1,0 +1,20 @@
+# ACM Certificate - DNS validation pending test
+#
+# Tests: aws.acm.Certificate create/read/destroy with DNS validation.
+# The reserved example.com name is never validated, so the certificate
+# remains PENDING_VALIDATION while deferred status and validation records
+# are read back for plan-verify.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+aws.acm.Certificate {
+  domain_name       = 'acceptance-test.carina-rs.example.com'
+  validation_method = aws.acm.Certificate.ValidationMethod.dns
+  key_algorithm     = aws.acm.Certificate.KeyAlgorithm.rsa_2048
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/iam_roles/basic.crn
+++ b/acceptance-tests/iam_roles/basic.crn
@@ -1,0 +1,59 @@
+# IAM Roles - data source test
+#
+# Tests: aws.iam.Role creation followed by read aws.iam.Roles.
+# A second role consumes roles.names[0] so the data-source output is
+# referenced by the graph and must be resolved during apply/plan.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let target_role_name = 'carina-acc-test-iam-roles-target'
+
+let target_role = aws.iam.Role {
+  role_name = target_role_name
+
+  assume_role_policy_document = {
+    version = aws.iam.PolicyDocument.Version.2012_10_17
+    statement {
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
+
+      principal = {
+        service = 'lambda.amazonaws.com'
+      }
+
+      action = 'sts:AssumeRole'
+    }
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let roles = read aws.iam.Roles {
+  path_prefix = '/'
+  name_regex  = "^${target_role.role_name}$"
+}
+
+aws.iam.Role {
+  role_name   = 'carina-acc-test-iam-roles-consumer'
+  description = roles.names[0]
+
+  assume_role_policy_document = {
+    version = aws.iam.PolicyDocument.Version.2012_10_17
+    statement {
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
+
+      principal = {
+        service = 'lambda.amazonaws.com'
+      }
+
+      action = 'sts:AssumeRole'
+    }
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/route53_record_set/basic.crn
+++ b/acceptance-tests/route53_record_set/basic.crn
@@ -1,0 +1,36 @@
+# Route53 RecordSet - cross-provider hosted zone test
+#
+# Tests: aws.route53.RecordSet creation in an awscc.route53.HostedZone.
+# The aws provider owns the record set; awscc supplies the hosted zone
+# resource that is not available in the aws provider.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+let zone = awscc.route53.HostedZone {
+  name = 'carina-acc-test-route53-record-set.example.com.'
+
+  hosted_zone_config = {
+    comment = 'Carina acceptance test zone'
+  }
+
+  hosted_zone_tags = [
+    {
+      key   = 'Environment'
+      value = 'acceptance-test'
+    },
+  ]
+}
+
+aws.route53.RecordSet {
+  hosted_zone_id   = zone.id
+  name             = 'www.carina-acc-test-route53-record-set.example.com'
+  type             = aws.route53.RecordSet.Type.a
+  ttl              = 60
+  resource_records = ['192.0.2.10']
+}

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -399,7 +399,45 @@ deep_cleanup_account() {
         with_account_creds "$account" aws logs delete-log-group --log-group-name "$lg" 2>/dev/null || true
     done
 
-    # 5. Delete transit gateways
+    # 5. Delete orphaned Route53 hosted zones from record set tests
+    local route53_zone_name="carina-acc-test-route53-record-set.example.com."
+    local route53_record_name="www.carina-acc-test-route53-record-set.example.com."
+    local hosted_zones
+    hosted_zones=$(with_account_creds "$account" aws route53 list-hosted-zones-by-name \
+        --dns-name "$route53_zone_name" \
+        --query "HostedZones[?Name=='$route53_zone_name'].Id" --output text 2>/dev/null)
+    for zone_id in $hosted_zones; do
+        if [ -z "$zone_id" ] || [ "$zone_id" = "None" ]; then
+            continue
+        fi
+        found=$((found + 1))
+        echo "  Cleaning Route53 hosted zone $zone_id..."
+        with_account_creds "$account" aws route53 change-resource-record-sets \
+            --hosted-zone-id "$zone_id" \
+            --change-batch '{"Changes":[{"Action":"DELETE","ResourceRecordSet":{"Name":"'"$route53_record_name"'","Type":"A","TTL":60,"ResourceRecords":[{"Value":"192.0.2.10"}]}}]}' \
+            2>/dev/null || true
+        with_account_creds "$account" aws route53 delete-hosted-zone --id "$zone_id" 2>/dev/null || true
+    done
+
+    # 6. Delete orphaned ACM certificates from certificate tests
+    local acm_cert_domain="acceptance-test.carina-rs.example.com"
+    local certs
+    certs=$(with_account_creds "$account" aws acm list-certificates \
+        --region ap-northeast-1 \
+        --certificate-statuses PENDING_VALIDATION ISSUED INACTIVE EXPIRED VALIDATION_TIMED_OUT REVOKED FAILED \
+        --query "CertificateSummaryList[?DomainName=='$acm_cert_domain'].CertificateArn" --output text 2>/dev/null)
+    for cert_arn in $certs; do
+        if [ -z "$cert_arn" ] || [ "$cert_arn" = "None" ]; then
+            continue
+        fi
+        found=$((found + 1))
+        echo "  Cleaning ACM certificate $cert_arn..."
+        with_account_creds "$account" aws acm delete-certificate \
+            --region ap-northeast-1 \
+            --certificate-arn "$cert_arn" 2>/dev/null || true
+    done
+
+    # 7. Delete transit gateways
     local tgws
     tgws=$(with_account_creds "$account" aws ec2 describe-transit-gateways \
         --filters "Name=state,Values=available,pending" \
@@ -420,7 +458,7 @@ deep_cleanup_account() {
         with_account_creds "$account" aws ec2 delete-transit-gateway --transit-gateway-id "$tgw_id" 2>/dev/null || true
     done
 
-    # 6. Release Elastic IPs not associated with anything
+    # 8. Release Elastic IPs not associated with anything
     local eips
     eips=$(with_account_creds "$account" aws ec2 describe-addresses \
         --query 'Addresses[?AssociationId==null].AllocationId' --output text 2>/dev/null)
@@ -448,7 +486,7 @@ fi
 echo ""
 
 # CARINA_BIN can be set externally (e.g., when running from the monorepo).
-if [ -z "$CARINA_BIN" ]; then
+if [ -z "${CARINA_BIN:-}" ]; then
     # Prefer release build (WASM JIT is much faster with release)
     if [ -f "$SIBLING_BASE/carina/target/release/carina" ]; then
         CARINA_BIN="$SIBLING_BASE/carina/target/release/carina"


### PR DESCRIPTION
Closes #469

## What

Acceptance test fixtures for the three implementable coverage gaps from #469, plus documentation of the intentionally skipped resources.

### New fixtures (all pass `run-tests.sh validate`)

- **acm_certificate/basic.crn** — DNS-validated certificate that intentionally stays `PENDING_VALIDATION` (reserved example.com subdomain never validates). Exercises create → plan-verify → destroy including the deferred `Status` / `DomainValidationOptions` read-back, without waiting for issuance.
- **route53_record_set/basic.crn** — cross-provider fixture: `awscc.route53.HostedZone` supplies the zone (the aws provider has no HostedZone resource), `aws.route53.RecordSet` creates an A record in it. `run-tests.sh` already injects `source`/`version` into both `provider aws {` and `provider awscc {` blocks. The issue offered "pre-created zone" vs "cross-provider fixture"; cross-provider was chosen because it is self-contained (no manual account preparation) and works in any pool account.
- **iam_roles/basic.crn** — data-source test: creates a role, reads it back via `read aws.iam.Roles` with a `name_regex`, and references the result from a second role so the read participates in the dependency graph.

### Documented skips (acceptance-tests/README.md)

`organizations.Organization` (pool accounts are already org members), `organizations.Account` (closure cooldowns + 90-day lingering), `identitystore.User` (Identity Center lives in the management account).

### Runner changes

- deep-cleanup: new sections for orphaned Route53 hosted zones and ACM certificates from these fixtures
- fix: `CARINA_BIN` unset handling under `set -u`

## Verification

```
./acceptance-tests/run-tests.sh validate acm_certificate route53_record_set iam_roles
acm_certificate/basic.crn       OK
iam_roles/basic.crn             OK
route53_record_set/basic.crn    OK
Results: 3 passed, 0 failed (total: 3)
```

Real-AWS full-cycle runs (apply → plan-verify → destroy) follow after merge; failures found there will be filed as issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)