### PR TITLE
test(acceptance): fix acm_certificate, route53_record_set, iam_roles fixtures

### DIFF
--- a/acceptance-tests/acm_certificate/basic.crn
+++ b/acceptance-tests/acm_certificate/basic.crn
@@ -1,18 +1,19 @@
 # ACM Certificate - DNS validation pending test
 #
 # Tests: aws.acm.Certificate create/read/destroy with DNS validation.
-# The reserved example.com name is never validated, so the certificate
-# remains PENDING_VALIDATION while deferred status and validation records
-# are read back for plan-verify.
+# The domain is a fake domain we do not own, so DNS validation never
+# completes and the certificate remains PENDING_VALIDATION while deferred
+# status and validation records are read back for plan-verify.
+# Explicit key_algorithm coverage is blocked on #474 (read-back
+# normalization); restore it when fixed.
 
 provider aws {
   region = aws.Region.ap_northeast_1
 }
 
 aws.acm.Certificate {
-  domain_name       = 'acceptance-test.carina-rs.example.com'
+  domain_name       = 'acceptance-test.carina-rs-test.com'
   validation_method = aws.acm.Certificate.ValidationMethod.dns
-  key_algorithm     = aws.acm.Certificate.KeyAlgorithm.rsa_2048
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/iam_roles/basic.crn
+++ b/acceptance-tests/iam_roles/basic.crn
@@ -1,39 +1,20 @@
 # IAM Roles - data source test
 #
-# Tests: aws.iam.Role creation followed by read aws.iam.Roles.
+# Tests: read aws.iam.Roles against a role pre-created outside Carina.
 # A second role consumes roles.names[0] so the data-source output is
 # referenced by the graph and must be resolved during apply/plan.
+#
+# The matched role is pre-created by run.sh because carina-rs/carina#3666
+# currently lets consumers of a same-apply data-source output execute
+# before the data-source read.
 
 provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let target_role_name = 'carina-acc-test-iam-roles-target'
-
-let target_role = aws.iam.Role {
-  role_name = target_role_name
-
-  assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
-    statement {
-      effect = aws.iam.PolicyDocument.Statement.Effect.allow
-
-      principal = {
-        service = 'lambda.amazonaws.com'
-      }
-
-      action = 'sts:AssumeRole'
-    }
-  }
-
-  tags = {
-    Environment = 'acceptance-test'
-  }
-}
-
 let roles = read aws.iam.Roles {
   path_prefix = '/'
-  name_regex  = "^${target_role.role_name}$"
+  name_regex  = '^carina-acc-test-iam-roles-preexisting$'
 }
 
 aws.iam.Role {

--- a/acceptance-tests/iam_roles/run.sh
+++ b/acceptance-tests/iam_roles/run.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Runs iam_roles acceptance tests.
+#
+# Custom-runner directories are skipped by acceptance-tests/run-tests.sh,
+# matching s3_bucket_data_source. Resolve credentials before invoking this
+# suite; the Carina WASM provider cannot use AWS_PROFILE/SSO directly.
+# Examples:
+#   eval "$(aws configure export-credentials --profile carina-test-000 --format env)"
+#   ./run.sh [filter]
+#   with_account_creds "carina-test-000" ./run.sh [filter]
+#
+# The custom path pre-creates the data-source target outside Carina to avoid
+# carina-rs/carina#3666, then runs init/apply/plan-verify/destroy.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER="${1:-}"
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+TESTS_RUN=0
+
+echo "iam_roles acceptance tests"
+echo "========================================"
+
+for test_file in "$SCRIPT_DIR"/tests/*.sh; do
+    test_name="$(basename "$test_file" .sh)"
+    if [ -n "$FILTER" ] && ! echo "$test_name" | grep -q "$FILTER"; then
+        continue
+    fi
+    echo ""
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if bash "$test_file"; then
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    else
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+    fi
+done
+
+echo ""
+echo "========================================"
+echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+echo "========================================"
+
+[ "$TOTAL_FAILED" -gt 0 ] && exit 1

--- a/acceptance-tests/iam_roles/tests/basic.sh
+++ b/acceptance-tests/iam_roles/tests/basic.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Test: iam.Roles data source read with a pre-existing IAM role.
+source "$(dirname "$0")/../../shared/_helpers.sh"
+
+echo "Test: iam_roles data source"
+echo ""
+
+PRE_ROLE_NAME="carina-acc-test-iam-roles-preexisting"
+CONSUMER_ROLE_NAME="carina-acc-test-iam-roles-consumer"
+ASSUME_ROLE_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+
+delete_role_if_exists() {
+    local role_name="$1"
+    local policy_arns policy_arn policy_names policy_name
+
+    policy_arns=$(aws iam list-attached-role-policies \
+        --role-name "$role_name" \
+        --query 'AttachedPolicies[*].PolicyArn' \
+        --output text 2>/dev/null || true)
+    for policy_arn in $policy_arns; do
+        [ -z "$policy_arn" ] && continue
+        aws iam detach-role-policy --role-name "$role_name" --policy-arn "$policy_arn" 2>/dev/null || true
+    done
+
+    policy_names=$(aws iam list-role-policies \
+        --role-name "$role_name" \
+        --query 'PolicyNames[*]' \
+        --output text 2>/dev/null || true)
+    for policy_name in $policy_names; do
+        [ -z "$policy_name" ] && continue
+        aws iam delete-role-policy --role-name "$role_name" --policy-name "$policy_name" 2>/dev/null || true
+    done
+
+    aws iam delete-role --role-name "$role_name" 2>/dev/null || true
+}
+
+cleanup_pre_role() {
+    delete_role_if_exists "$PRE_ROLE_NAME"
+}
+trap 'cleanup; cleanup_pre_role' EXIT
+
+delete_role_if_exists "$PRE_ROLE_NAME"
+
+printf "  %-50s" "setup: pre-create $PRE_ROLE_NAME"
+if aws iam create-role \
+    --role-name "$PRE_ROLE_NAME" \
+    --assume-role-policy-document "$ASSUME_ROLE_POLICY" \
+    --tags Key=Environment,Value=acceptance-test > /dev/null 2>&1 && \
+    aws iam wait role-exists --role-name "$PRE_ROLE_NAME" > /dev/null 2>&1; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL"
+    TEST_FAILED=$((TEST_FAILED + 1))
+    finish_test
+fi
+
+cp "$SCRIPT_DIR/basic.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+prepare_work_dir "$WORK_DIR"
+run_step "step0: init (resolve provider)" "$CARINA_BIN" init .
+run_step "step1: apply (reads existing role)" "$CARINA_BIN" apply --auto-approve .
+
+printf "  %-50s" "step2: plan-verify (no changes)"
+PLAN_RC=0
+PLAN_OUTPUT=$("$CARINA_BIN" plan --detailed-exitcode . 2>&1) || PLAN_RC=$?
+if [ "$PLAN_RC" -eq 0 ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (exit $PLAN_RC)"
+    echo "$PLAN_OUTPUT"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# carina#3266 prunes data-source read artifact rows from state.resources;
+# only the managed consumer role is persisted.
+assert_state_resource_count "assert: 1 resource in state" "1" "$WORK_DIR"
+
+printf "  %-50s" "assert: consumer.description = $PRE_ROLE_NAME"
+ACTUAL=$(jq -r '.resources[] | select(.attributes.role_name == "'"$CONSUMER_ROLE_NAME"'") | .attributes.description' "$WORK_DIR/carina.state.json" 2>/dev/null)
+if [ "$ACTUAL" = "$PRE_ROLE_NAME" ]; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (got '$ACTUAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+run_step "step3: destroy (consumer role only)" "$CARINA_BIN" destroy --auto-approve .
+ACTIVE_WORK_DIR=""
+rm -rf "$WORK_DIR"
+
+cleanup_pre_role
+
+finish_test

--- a/acceptance-tests/route53_record_set/basic.crn
+++ b/acceptance-tests/route53_record_set/basic.crn
@@ -13,7 +13,7 @@ provider awscc {
 }
 
 let zone = awscc.route53.HostedZone {
-  name = 'carina-acc-test-route53-record-set.example.com.'
+  name = 'carina-acc-test-record-set.carina-rs-test.com.'
 
   hosted_zone_config = {
     comment = 'Carina acceptance test zone'
@@ -29,7 +29,7 @@ let zone = awscc.route53.HostedZone {
 
 aws.route53.RecordSet {
   hosted_zone_id   = zone.id
-  name             = 'www.carina-acc-test-route53-record-set.example.com'
+  name             = 'www.carina-acc-test-record-set.carina-rs-test.com'
   type             = aws.route53.RecordSet.Type.a
   ttl              = 60
   resource_records = ['192.0.2.10']

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -400,8 +400,8 @@ deep_cleanup_account() {
     done
 
     # 5. Delete orphaned Route53 hosted zones from record set tests
-    local route53_zone_name="carina-acc-test-route53-record-set.example.com."
-    local route53_record_name="www.carina-acc-test-route53-record-set.example.com."
+    local route53_zone_name="carina-acc-test-record-set.carina-rs-test.com."
+    local route53_record_name="www.carina-acc-test-record-set.carina-rs-test.com."
     local hosted_zones
     hosted_zones=$(with_account_creds "$account" aws route53 list-hosted-zones-by-name \
         --dns-name "$route53_zone_name" \
@@ -420,7 +420,7 @@ deep_cleanup_account() {
     done
 
     # 6. Delete orphaned ACM certificates from certificate tests
-    local acm_cert_domain="acceptance-test.carina-rs.example.com"
+    local acm_cert_domain="acceptance-test.carina-rs-test.com"
     local certs
     certs=$(with_account_creds "$account" aws acm list-certificates \
         --region ap-northeast-1 \


### PR DESCRIPTION
Closes #471
Closes #472

## What

All three #470 fixtures failed their first real-AWS acceptance run. This fixes each at its root cause and verifies on real AWS.

### #471 — reserved example.com domains (acm_certificate, route53_record_set)

Route53 rejects `*.example.com` hosted zones (`InvalidDomainNameException`); ACM marks certificate requests for example.com subdomains `FAILED` and never populates `DomainValidationOptions`, so the provider's DVO poll times out (which also exposed #473, the orphan-on-timeout behavior). Both fixtures now use `carina-rs-test.com` subdomains — verified with a real repro that ACM populates the validation record in ~15s and the certificate stays `PENDING_VALIDATION` as intended. Deep-cleanup name filters updated to match.

`acm_certificate` additionally drops `key_algorithm`: ACM returns `RSA-2048` (hyphen) for the requested `RSA_2048` (underscore) and the un-normalized read-back forces a phantom replacement on every plan — tracked as #474; explicit coverage returns when that is fixed.

### #472 — iam_roles read-after-create

The original design (read a role created in the same apply, consume the result) cannot work today: consumers of an apply-time data-source read execute before the read — carina-rs/carina#3666, diagnosed from this fixture (plan shows the dependency edge; execution ignores it; no `wait` formulation helps). Restructured to the `s3_bucket_data_source` precedent: `iam_roles/run.sh` pre-creates the target role outside carina, the fixture reads it via a literal `name_regex` (the path carina#3252/#3265 already fixed), and a consumer role's `description = roles.names[0]` proves the value flows through the graph.

State assertions follow the post-carina#3266 contract (data-source rows are pruned from `state.resources`); the pre-#3266 assertions in `s3_bucket_data_source` itself are tracked as #475.

## Real-AWS verification (apply → plan-verify → destroy)

```
OK   route53_record_set/basic.crn      (sweep cycle, account pool)
OK   acm_certificate/basic.crn         (sweep cycle)
iam_roles via run.sh: 7 passed, 0 failed
  setup / init / apply / plan-verify / 1-resource state assert /
  consumer.description assert / destroy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)