### PR TITLE
test(acceptance): pin current contracts in CBD ec2_vpc and s3 data source tests

### DIFF
--- a/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
@@ -1,13 +1,17 @@
-# EC2 VPC - create_before_destroy test (step 1: initial)
+# EC2 VPC - create_before_destroy negative test (step 1: initial)
 #
-# VPC has no name_attribute, so create_before_destroy replacement should
-# proceed without temporary name generation.
+# Seeds a stable, let-bound VPC for the step-2 replacement attempt. Anonymous
+# resource identities include create-only attributes, so changing cidr_block
+# would route the diff to independent Create+Delete instead of replacement and
+# never exercise the MissingNameAttributeError path. ec2.Vpc has no
+# unique_name_attribute, so the current core contract rejects CBD replacement
+# at plan time. Name-free CBD semantics are tracked in carina-rs/carina#3667.
 
 provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.Vpc {
+let cbd_vpc = aws.ec2.Vpc {
   cidr_block           = '10.200.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -1,13 +1,18 @@
-# EC2 VPC - create_before_destroy test (step 2: replace)
+# EC2 VPC - create_before_destroy negative test (step 2: replace)
 #
-# Changes cidr_block (create-only) with create_before_destroy lifecycle.
-# VPC has no name_attribute, so no temporary name is generated.
+# Changes cidr_block (create-only) with create_before_destroy lifecycle while
+# keeping the same let binding as step 1. Anonymous resource identities include
+# create-only attributes, so changing cidr_block would route the diff to
+# independent Create+Delete instead of replacement and never exercise the
+# MissingNameAttributeError path. This must fail at plan time because ec2.Vpc
+# has no unique_name_attribute; core needs one to generate a temporary name.
+# Name-free CBD semantics are tracked in carina-rs/carina#3667.
 
 provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-aws.ec2.Vpc {
+let cbd_vpc = aws.ec2.Vpc {
   cidr_block           = '10.201.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/create_before_destroy/run.sh
+++ b/acceptance-tests/create_before_destroy/run.sh
@@ -5,9 +5,13 @@
 #   env AWS_PROFILE="<profile>" ./run.sh [filter]
 #
 # Tests:
-#   ec2_vpc - Replacement without temporary name (no name_attribute)
+#   ec2_vpc - Replacement rejected when no unique_name_attribute exists
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc")
+#
+# This ec2_vpc case pins core's current MissingNameAttributeError contract.
+# Name-free CBD semantics are tracked in carina-rs/carina#3667; positive CBD
+# replacement coverage lives in the iam_role steps of this suite.
 #
 # AWS authentication:
 #   Set AWS_PROFILE to one of the carina-test-00X profiles. The script
@@ -87,6 +91,39 @@ run_step() {
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
         return 1
     fi
+}
+
+run_expected_error() {
+    local work_dir="$1"
+    local description="$2"
+    local command="$3"
+    local expected_fragment="$4"
+    local extra_args="${5:-}"
+
+    printf "  %-55s " "$description"
+
+    local output
+    if output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" $command $extra_args . 2>&1); then
+        echo "FAIL"
+        echo "  ERROR: command unexpectedly succeeded; expected error containing:"
+        echo "    $expected_fragment"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        return 1
+    fi
+
+    if grep -Fq "$expected_fragment" <<< "$output"; then
+        echo "OK"
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+        return 0
+    fi
+
+    echo "FAIL"
+    echo "  ERROR: expected error containing:"
+    echo "    $expected_fragment"
+    echo "  Actual output:"
+    echo "  $output"
+    TOTAL_FAILED=$((TOTAL_FAILED + 1))
+    return 1
 }
 
 # Extract all resource identifiers from carina.state.json as a sorted newline-separated string.
@@ -223,6 +260,7 @@ run_test() {
     local step1="$2"
     local step2="$3"
     local desc="$4"
+    local expected_step2_error="${5:-}"
 
     # Apply filter
     if [ -n "$FILTER" ] && [[ "$test_name" != *"$FILTER"* ]]; then
@@ -271,6 +309,33 @@ run_test() {
     # Swap in step2 config (providers are the same, lock already present)
     swap_crn "$step2" "$work_dir"
 
+    if [ -n "$expected_step2_error" ]; then
+        if ! run_expected_error "$work_dir" "step2: plan replace fails as expected" "plan" "$expected_step2_error"; then
+            destroy_work_dir "$work_dir"
+            rm -rf "$work_dir"
+            ACTIVE_WORK_DIR=""
+            return 1
+        fi
+
+        # Restore the applied config so destroy uses the same resource identity
+        # that created the initial VPC.
+        swap_crn "$step1" "$work_dir"
+
+        if ! destroy_work_dir "$work_dir"; then
+            echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+            echo "    $work_dir"
+            TOTAL_FAILED=$((TOTAL_FAILED + 1))
+            ACTIVE_WORK_DIR=""
+            echo ""
+            return 1
+        fi
+
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 0
+    fi
+
     # Step 2: Apply modified config (triggers create_before_destroy replacement)
     if ! run_step "$work_dir" "step2: apply replace (create_before_destroy)" "apply" "--auto-approve"; then
         destroy_work_dir "$work_dir"
@@ -318,12 +383,13 @@ echo "create_before_destroy multi-step acceptance tests (AWS)"
 echo "════════════════════════════════════════"
 echo ""
 
-# Test 1: EC2 VPC - replacement WITHOUT temporary name
-# No name_attribute, cidr_block is create-only
+# Test 1: EC2 VPC - CBD rejects schemas without unique_name_attribute
+# ec2.Vpc has no unique_name_attribute; cidr_block is create-only.
 run_test "ec2_vpc" \
     "$SCRIPT_DIR/ec2_vpc_step1.crn" \
     "$SCRIPT_DIR/ec2_vpc_step2.crn" \
-    "Test 1: EC2 VPC (no name_attribute, no temporary name)"
+    "Test 1: EC2 VPC (missing unique_name_attribute error)" \
+    "has no unique_name_attribute"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"

--- a/acceptance-tests/s3_bucket_data_source/basic.crn
+++ b/acceptance-tests/s3_bucket_data_source/basic.crn
@@ -3,6 +3,7 @@
 # Exercises:
 # - aws.s3.Bucket as Managed (Carina creates and destroys it)
 # - aws.s3.Bucket as DataSource (Carina reads a pre-existing bucket)
+# - data-source outputs consumed by the Managed bucket through tags
 #
 # The pre-existing bucket is created/destroyed by run.sh outside Carina.
 # Bucket names are templated via envsubst before apply because S3 bucket
@@ -12,10 +13,20 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let new_bucket = aws.s3.Bucket {
-  bucket = '${NEW_BUCKET}'
-}
-
 let existing = read aws.s3.Bucket {
   bucket = '${PRE_BUCKET}'
+}
+
+aws.s3.Bucket {
+  bucket = '${NEW_BUCKET}'
+
+  tags = {
+    Environment          = 'acceptance-test'
+    ExistingBucket       = existing.bucket
+    ExistingArn          = existing.arn
+    ExistingRegion       = existing.region
+    ExistingDomain       = existing.bucket_domain_name
+    ExistingRegionalName = existing.bucket_regional_domain_name
+    ExistingHostedZoneId = existing.hosted_zone_id
+  }
 }

--- a/acceptance-tests/s3_bucket_data_source/tests/basic.sh
+++ b/acceptance-tests/s3_bucket_data_source/tests/basic.sh
@@ -46,86 +46,43 @@ run_step "step0: init (resolve provider)" "$CARINA_BIN" init .
 
 run_step "step1: apply (creates new + reads existing)" "$CARINA_BIN" apply --auto-approve .
 
-# State should hold both resources: new_bucket (Managed) + existing (DataSource).
-assert_state_resource_count "assert: 2 resources in state" "2" "$WORK_DIR"
+# carina#3266 prunes data-source read artifact rows from state.resources;
+# only the managed bucket is persisted. Data-source values are proven
+# end-to-end by tags on the managed bucket that consume existing.* outputs.
+assert_state_resource_count "assert: 1 resource in state" "1" "$WORK_DIR"
 
-# Locate the data source entry by binding name and verify the computed
-# attributes (arn, region, bucket_domain_name, bucket_regional_domain_name,
-# hosted_zone_id) match what the lookup table promises.
-DS_PATH=".resources[] | select(.binding == \"existing\")"
+MANAGED_PATH=".resources[] | select(.attributes.bucket == \"$NEW_BUCKET\")"
 
-printf "  %-50s" "assert: existing.bucket = $PRE_BUCKET"
-ACTUAL=$(jq -r "$DS_PATH | .attributes.bucket" "$WORK_DIR/carina.state.json" 2>/dev/null)
-if [ "$ACTUAL" = "$PRE_BUCKET" ]; then
-    echo "OK"
-    TEST_PASSED=$((TEST_PASSED + 1))
-else
-    echo "FAIL (got '$ACTUAL')"
-    TEST_FAILED=$((TEST_FAILED + 1))
-fi
-
-printf "  %-50s" "assert: existing.region = $REGION"
-ACTUAL=$(jq -r "$DS_PATH | .attributes.region" "$WORK_DIR/carina.state.json" 2>/dev/null)
-if [ "$ACTUAL" = "$REGION" ]; then
-    echo "OK"
-    TEST_PASSED=$((TEST_PASSED + 1))
-else
-    echo "FAIL (got '$ACTUAL')"
-    TEST_FAILED=$((TEST_FAILED + 1))
-fi
-
-printf "  %-50s" "assert: existing.arn formatted"
-ACTUAL=$(jq -r "$DS_PATH | .attributes.arn" "$WORK_DIR/carina.state.json" 2>/dev/null)
-if [ "$ACTUAL" = "arn:aws:s3:::$PRE_BUCKET" ]; then
-    echo "OK"
-    TEST_PASSED=$((TEST_PASSED + 1))
-else
-    echo "FAIL (got '$ACTUAL')"
-    TEST_FAILED=$((TEST_FAILED + 1))
-fi
-
-printf "  %-50s" "assert: existing.bucket_domain_name"
-ACTUAL=$(jq -r "$DS_PATH | .attributes.bucket_domain_name" "$WORK_DIR/carina.state.json" 2>/dev/null)
-if [ "$ACTUAL" = "$PRE_BUCKET.s3.amazonaws.com" ]; then
-    echo "OK"
-    TEST_PASSED=$((TEST_PASSED + 1))
-else
-    echo "FAIL (got '$ACTUAL')"
-    TEST_FAILED=$((TEST_FAILED + 1))
-fi
-
-printf "  %-50s" "assert: existing.bucket_regional_domain_name"
-ACTUAL=$(jq -r "$DS_PATH | .attributes.bucket_regional_domain_name" "$WORK_DIR/carina.state.json" 2>/dev/null)
-if [ "$ACTUAL" = "$PRE_BUCKET.s3.$REGION.amazonaws.com" ]; then
-    echo "OK"
-    TEST_PASSED=$((TEST_PASSED + 1))
-else
-    echo "FAIL (got '$ACTUAL')"
-    TEST_FAILED=$((TEST_FAILED + 1))
-fi
-
+assert_state_value "assert: new_bucket present in state" \
+    "$MANAGED_PATH | .attributes.bucket" \
+    "$NEW_BUCKET" \
+    "$WORK_DIR"
+assert_state_value "assert: tag ExistingBucket = existing.bucket" \
+    "$MANAGED_PATH | .attributes.tags.ExistingBucket" \
+    "$PRE_BUCKET" \
+    "$WORK_DIR"
+assert_state_value "assert: tag ExistingRegion = existing.region" \
+    "$MANAGED_PATH | .attributes.tags.ExistingRegion" \
+    "$REGION" \
+    "$WORK_DIR"
+assert_state_value "assert: tag ExistingArn = existing.arn" \
+    "$MANAGED_PATH | .attributes.tags.ExistingArn" \
+    "arn:aws:s3:::$PRE_BUCKET" \
+    "$WORK_DIR"
+assert_state_value "assert: tag ExistingDomain = existing.bucket_domain_name" \
+    "$MANAGED_PATH | .attributes.tags.ExistingDomain" \
+    "$PRE_BUCKET.s3.amazonaws.com" \
+    "$WORK_DIR"
+assert_state_value "assert: tag ExistingRegionalName = existing.bucket_regional_domain_name" \
+    "$MANAGED_PATH | .attributes.tags.ExistingRegionalName" \
+    "$PRE_BUCKET.s3.$REGION.amazonaws.com" \
+    "$WORK_DIR"
 # Hosted zone for ap-northeast-1 per
 # https://docs.aws.amazon.com/general/latest/gr/s3.html
-printf "  %-50s" "assert: existing.hosted_zone_id (ap-northeast-1)"
-ACTUAL=$(jq -r "$DS_PATH | .attributes.hosted_zone_id" "$WORK_DIR/carina.state.json" 2>/dev/null)
-if [ "$ACTUAL" = "Z2M4EHUR26P7ZW" ]; then
-    echo "OK"
-    TEST_PASSED=$((TEST_PASSED + 1))
-else
-    echo "FAIL (got '$ACTUAL')"
-    TEST_FAILED=$((TEST_FAILED + 1))
-fi
-
-# Verify the Managed-side bucket is also recorded.
-printf "  %-50s" "assert: new_bucket present in state"
-ACTUAL=$(jq -r ".resources[] | select(.binding == \"new_bucket\") | .attributes.bucket" "$WORK_DIR/carina.state.json" 2>/dev/null)
-if [ "$ACTUAL" = "$NEW_BUCKET" ]; then
-    echo "OK"
-    TEST_PASSED=$((TEST_PASSED + 1))
-else
-    echo "FAIL (got '$ACTUAL')"
-    TEST_FAILED=$((TEST_FAILED + 1))
-fi
+assert_state_value "assert: tag ExistingHostedZoneId = existing.hosted_zone_id" \
+    "$MANAGED_PATH | .attributes.tags.ExistingHostedZoneId" \
+    "Z2M4EHUR26P7ZW" \
+    "$WORK_DIR"
 
 run_step "step2: destroy (only the Managed bucket)" "$CARINA_BIN" destroy --auto-approve .
 ACTIVE_WORK_DIR=""


### PR DESCRIPTION
Closes #468
Closes #475

## What

Both stale run.sh suites asserted contracts superseded by core changes. Rewritten to pin current behavior; verified on real AWS.

### #468 — create_before_destroy ec2_vpc

Since carina#3625 Phase 4 (cb2aae62), CBD on a schema without `unique_name_attribute` is a **typed plan-time error**; the old test asserted the pre-Phase-4 "proceed without temporary name" behavior. The test is now a negative test: step 2 passes only when `plan` fails with `has no unique_name_attribute` (new `run_expected_error` helper in run.sh).

Two findings surfaced while fixing this:

- **Anonymous identity bypasses the replace path**: an anonymous resource's identity incorporates create-only attributes, so changing `cidr_block` yields a *different* identity — the differ plans independent Create + Delete, never a replace, and the CBD error is unreachable. The VPC is now `let`-bound in both steps to keep identity stable (confirmed by real-AWS repro both ways).
- The error output carries a spurious `prevent_destroy set` line with no `prevent_destroy` in the config — filed as carina-rs/carina#3669.

Name-free CBD semantics (whether VPC-like resources should be CBD-replaceable without a temp name now that #466 removed the None-ambiguity) are a design follow-up: carina-rs/carina#3667. Positive CBD coverage remains in this suite's iam_role steps.

### #475 — s3_bucket_data_source

Since carina#3266 (e8126e62), data-source reads are pruned from `state.resources`. The test expected 2 state rows and read DS attributes out of the state file. It now expects 1 managed row and proves the data-source values **end-to-end**: the managed bucket's tags carry `existing.bucket` / `arn` / `region` / `bucket_domain_name` / `bucket_regional_domain_name` / `hosted_zone_id`, asserted from the managed row after apply, with a clean plan-verify (also exercising the #3252/#3265 refresh-read → consumer path).

## Real-AWS verification

```
create_before_destroy ec2_vpc: 3 passed, 0 failed
  step1: apply initial / step1: plan-verify / step2: plan replace fails as expected
s3_bucket_data_source: 12 passed, 0 failed
  incl. all six ExistingXxx tag assertions and destroy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)