### PR TITLE
feat(codegen): classify ec2.TransitGatewayAttachment as Coexisting (awscc parity)

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -25,8 +25,19 @@ enum UniqueNameReplacementClass {
     Coexisting,
 }
 
-const UNIQUE_NAME_REPLACEMENT_CLASSES: &[(&str, UniqueNameReplacementClass)] =
-    &[("ec2.Vpc", UniqueNameReplacementClass::Coexisting)];
+const UNIQUE_NAME_REPLACEMENT_CLASSES: &[(&str, UniqueNameReplacementClass)] = &[
+    ("ec2.Vpc", UniqueNameReplacementClass::Coexisting),
+    // TransitGatewayAttachment replacements are driven by create-only
+    // transit_gateway_id/vpc_id changes. Any reachable replacement targets a
+    // different (transit gateway, VPC) pair than the original; AWS allows a VPC
+    // to attach to multiple transit gateways simultaneously, so the new
+    // attachment can coexist during create_before_destroy. Cascade-driven
+    // replacements also change the pair because the upstream TGW/VPC id changes.
+    (
+        "ec2.TransitGatewayAttachment",
+        UniqueNameReplacementClass::Coexisting,
+    ),
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum UniqueNameEmission {
@@ -5105,7 +5116,13 @@ mod tests {
 
         assert_eq!(
             UNIQUE_NAME_REPLACEMENT_CLASSES,
-            &[("ec2.Vpc", UniqueNameReplacementClass::Coexisting)]
+            &[
+                ("ec2.Vpc", UniqueNameReplacementClass::Coexisting),
+                (
+                    "ec2.TransitGatewayAttachment",
+                    UniqueNameReplacementClass::Coexisting
+                ),
+            ]
         );
 
         let attr_attrs = vec![test_attr(
@@ -5141,6 +5158,18 @@ mod tests {
         assert_eq!(coexisting_emission, UniqueNameEmission::Coexisting);
         assert_eq!(
             emitted(coexisting_emission),
+            "\x20       .with_coexisting_replacement()\n"
+        );
+
+        let tgw_attachment_emission = derive_unique_name_emission(
+            "ec2.TransitGatewayAttachment",
+            "TransitGatewayAttachmentId",
+            &[],
+            false,
+        );
+        assert_eq!(tgw_attachment_emission, UniqueNameEmission::Coexisting);
+        assert_eq!(
+            emitted(tgw_attachment_emission),
             "\x20       .with_coexisting_replacement()\n"
         );
 

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -25,6 +25,7 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsSchemaConfig {
         has_tags: true,
         schema: ResourceSchema::new("ec2.TransitGatewayAttachment")
         .with_description("Describes a VPC attachment.")
+        .with_coexisting_replacement()
         .attribute(
             AttributeSchema::new("options", AttributeType::struct_(
                     "CreateTransitGatewayVpcAttachmentRequestOptions".to_string(),


### PR DESCRIPTION
Part of carina-rs/carina#3667. Mirrors carina-provider-awscc#388 so the two providers' Coexisting classification tables stay identical.

A transit gateway attachment replace is only reachable when `transit_gateway_id` or `vpc_id` changes — the replacement always targets a different (TGW, VPC) pair, and AWS allows a VPC to attach to multiple TGWs simultaneously, so the CBD replacement always coexists with the original.

Generated diff: `ec2/transit_gateway_attachment.rs` gains `.with_coexisting_replacement()`, nothing else; docs no drift. Emission unit test extended. Semantic proven on real AWS by the awscc CBD suite (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)