### PR TITLE
fix(acceptance): make harness exit status reflect test results only

### DIFF
--- a/acceptance-tests/iam_roles/run.sh
+++ b/acceptance-tests/iam_roles/run.sh
@@ -42,4 +42,6 @@ echo "========================================"
 echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
 echo "========================================"
 
-[ "$TOTAL_FAILED" -gt 0 ] && exit 1
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -209,7 +209,7 @@ if [ "$COMMAND" != "validate" ]; then
     if ! acquire_all_account_locks; then
         exit 1
     fi
-    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done; release_account_locks' EXIT
+    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null || true; done; release_account_locks' EXIT
 fi
 
 # Validate command
@@ -633,7 +633,7 @@ if [ "$COMMAND" = "cleanup" ]; then
     echo ""
 
     WORK_DIR=$(mktemp -d)
-    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null || true; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts
     echo "Pre-authenticating AWS accounts..."
@@ -760,7 +760,7 @@ if [ "$COMMAND" = "full" ]; then
     trap cleanup_main INT TERM
 
     # Clean up temp dir and release locks on normal exit
-    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null || true; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts sequentially to avoid opening
     # multiple SSO browser tabs simultaneously
@@ -971,7 +971,7 @@ echo ""
 # (plan/apply/destroy) to prevent cross-contamination between tests (issue #839)
 if [ "$COMMAND" != "validate" ]; then
     WORK_DIR=$(mktemp -d)
-    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null || true; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 fi
 
 PASSED=0

--- a/acceptance-tests/s3_bucket_data_source/run.sh
+++ b/acceptance-tests/s3_bucket_data_source/run.sh
@@ -32,4 +32,6 @@ echo "════════════════════════�
 echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
 echo "════════════════════════════════════════"
 
-[ "$TOTAL_FAILED" -gt 0 ] && exit 1
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/acceptance-tests/sts_caller_identity/run.sh
+++ b/acceptance-tests/sts_caller_identity/run.sh
@@ -32,4 +32,6 @@ echo "════════════════════════�
 echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
 echo "════════════════════════════════════════"
 
-[ "$TOTAL_FAILED" -gt 0 ] && exit 1
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The acceptance harness exited 1 even when every test passed (observed: `full` printing "Total: 49 passed, 0 failed (of 49)" then exiting 1). Two mechanisms, both fixed:

1. **run-tests.sh EXIT traps**: `kill "$p"` runs on worker PIDs that have already exited; under `set -e` the failing kill aborts the trap and overrides the script's exit status with 1. All four trap sites now use `kill "$p" 2>/dev/null || true`.
2. **Sub-runner trailing `[ "$TOTAL_FAILED" -gt 0 ] && exit 1`** (iam_roles, sts_caller_identity, s3_bucket_data_source): when `TOTAL_FAILED=0` the test command itself returns 1 and becomes the script's exit status (observed: iam_roles printing "1 passed, 0 failed" then exiting 1). Replaced with an explicit `if` branch.

## Verification

- Simulation exits 0/1 for `TOTAL_FAILED=0/1` in all three sub-runners.
- `CARINA_BIN=/usr/bin/true ./acceptance-tests/run-tests.sh cleanup ec2_vpc/basic` exits 0 (was 1). The trap mechanism was pinned empirically in the identical awscc harness: instrumenting the `wait` loop showed no worker returns nonzero; patching only the kill flips RC 1→0.
- No instance of either pattern remains under acceptance-tests/.

Same fix landed in carina-provider-awscc (carina-rs/carina-provider-awscc#390).

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vca7585CbZTp7xYdAMu3YN