### PR TITLE
fix(acceptance): resolve git-common-dir against PROJECT_ROOT, not caller cwd

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -71,9 +71,14 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # `cd && pwd` canonicalizes both relative (`.git` from the main
 # checkout) and absolute (full path from a worktree) forms into the
 # same absolute path.
-GIT_COMMON_DIR="$(cd "$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir)" && pwd)"
-REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
-SIBLING_BASE="$(dirname "$REPO_ROOT")"
+resolve_sibling_base() {
+    local git_common_dir
+    local repo_root
+
+    git_common_dir="$(cd "$PROJECT_ROOT" && cd "$(git rev-parse --git-common-dir)" && pwd)"
+    repo_root="$(dirname "$git_common_dir")"
+    dirname "$repo_root"
+}
 
 # ── Parse options ─────────────────────────────────────────────────────
 ACCOUNT_START=""
@@ -487,6 +492,8 @@ echo ""
 
 # CARINA_BIN can be set externally (e.g., when running from the monorepo).
 if [ -z "${CARINA_BIN:-}" ]; then
+    SIBLING_BASE="$(resolve_sibling_base)"
+
     # Prefer release build (WASM JIT is much faster with release)
     if [ -f "$SIBLING_BASE/carina/target/release/carina" ]; then
         CARINA_BIN="$SIBLING_BASE/carina/target/release/carina"
@@ -507,7 +514,7 @@ fi
 
 # ── Provider source injection ────────────────────────────────────────
 _TEST_AWS_WASM="${_TEST_AWS_WASM:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
-_TEST_AWSCC_WASM="${_TEST_AWSCC_WASM:-$SIBLING_BASE/carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
+_TEST_AWSCC_WASM="${_TEST_AWSCC_WASM:-}"
 
 # Read provider version from workspace Cargo.toml to avoid hardcoding
 PROVIDER_VERSION=$(grep '^version = ' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
@@ -524,6 +531,12 @@ for bin_var in _TEST_AWS_WASM _TEST_AWSCC_WASM; do
     fi
 done
 
+ensure_awscc_wasm() {
+    if [ -z "${_TEST_AWSCC_WASM:-}" ]; then
+        _TEST_AWSCC_WASM="${SIBLING_BASE:-$(resolve_sibling_base)}/carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm"
+    fi
+}
+
 # inject_provider_source: Create a temp copy of a .crn file with source/version
 # injected into provider blocks. Prints the temp file path.
 # Args: original_crn_file
@@ -531,6 +544,10 @@ inject_provider_source() {
     local original="$1"
     local tmp_file
     tmp_file=$(mktemp).crn
+
+    if grep -q '^provider awscc {' "$original" 2>/dev/null; then
+        ensure_awscc_wasm
+    fi
 
     sed \
         -e '/^provider aws {/a\

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -19,10 +19,14 @@ PROJECT_ROOT="$(cd "$HELPERS_DIR/../.." && pwd)"
 # (carina-rs/carina-provider-aws#360). Resolve the carina-rs sibling
 # base via the canonical .git directory so worktree and main checkouts
 # both produce the same path.
-GIT_COMMON_DIR="$(cd "$(git -C "$PROJECT_ROOT" rev-parse --git-common-dir)" && pwd)"
-SIBLING_BASE="$(dirname "$(dirname "$GIT_COMMON_DIR")")"
+resolve_sibling_base() {
+    local git_common_dir
+    git_common_dir="$(cd "$PROJECT_ROOT" && cd "$(git rev-parse --git-common-dir)" && pwd)"
+    dirname "$(dirname "$git_common_dir")"
+}
 
-if [ -z "$CARINA_BIN" ]; then
+if [ -z "${CARINA_BIN:-}" ]; then
+    SIBLING_BASE="$(resolve_sibling_base)"
     if [ -f "$SIBLING_BASE/carina/target/debug/carina" ]; then
         CARINA_BIN="$SIBLING_BASE/carina/target/debug/carina"
     elif command -v carina &>/dev/null; then
@@ -37,8 +41,14 @@ fi
 # Use WASM provider binaries (carina CLI only supports WASM providers)
 # Build with: cargo build -p carina-provider-aws --target wasm32-wasip2 --release
 _TEST_AWS_WASM="${_TEST_AWS_WASM:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
-_TEST_AWSCC_WASM="${_TEST_AWSCC_WASM:-$SIBLING_BASE/carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
+_TEST_AWSCC_WASM="${_TEST_AWSCC_WASM:-}"
 PROVIDER_VERSION=$(grep '^version = ' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+ensure_awscc_wasm() {
+    if [ -z "${_TEST_AWSCC_WASM:-}" ]; then
+        _TEST_AWSCC_WASM="${SIBLING_BASE:-$(resolve_sibling_base)}/carina-provider-awscc/target/wasm32-wasip2/release/carina-provider-awscc.wasm"
+    fi
+}
 
 # inject_provider_source: Create a temp directory containing a .crn file with
 # source/version injected into provider blocks. Prints the temp directory path.
@@ -48,6 +58,10 @@ inject_provider_source() {
     local original="$1"
     local tmp_dir
     tmp_dir=$(mktemp -d)
+
+    if grep -q '^provider awscc {' "$original" 2>/dev/null; then
+        ensure_awscc_wasm
+    fi
 
     sed \
         -e '/^provider aws {/a\
@@ -66,6 +80,10 @@ inject_provider_source() {
 # Args: directory
 inject_provider_source_dir() {
     local dir="$1"
+    if grep -R -q '^provider awscc {' "$dir" 2>/dev/null; then
+        ensure_awscc_wasm
+    fi
+
     find "$dir" -name '*.crn' -print0 | while IFS= read -r -d '' crn_file; do
         if grep -q '^\s*source\s*=' "$crn_file" 2>/dev/null; then
             continue


### PR DESCRIPTION
## Summary

`git rev-parse --git-common-dir` prints a repo-root-relative path (typically `.git`), but `shared/_helpers.sh` and `run-tests.sh` cd'd into it from the caller's cwd. Invoked from anywhere but the repo root the scripts died under `set -e` with `cd: .git: No such file or directory` — even when `CARINA_BIN` was explicitly set — and from inside a *different* git repo they silently resolved `SIBLING_BASE` against the wrong repository.

## Changes

- `resolve_sibling_base()` resolves the relative git output against `$PROJECT_ROOT` (worktree checkouts still canonicalize to the main repo, preserving the #360 fix).
- `SIBLING_BASE` is derived only inside the `CARINA_BIN` fallback branch, so an explicitly-set `CARINA_BIN` never depends on git resolution.
- The awscc WASM default path (the other `SIBLING_BASE` consumer) resolves lazily, only when a `.crn` actually declares `provider awscc`.

## Verification

- Suites source cleanly from a foreign cwd with `CARINA_BIN` set (previously crashed at line 22).
- With `CARINA_BIN` unset and the caller inside another git repo, `SIBLING_BASE` resolves from this repo's `.git`, not the caller's.
- From a `git worktree` checkout, resolution still lands on the main checkout's parent (the #360 scenario).

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vca7585CbZTp7xYdAMu3YN