### PR TITLE
fix(acceptance): initialize work dirs via shared seam; repair init-less suites

### DIFF
--- a/acceptance-tests/in_place_update/run.sh
+++ b/acceptance-tests/in_place_update/run.sh
@@ -11,7 +11,6 @@
 #   ec2_subnet         - Toggle map_public_ip_on_launch (false -> true)
 #   ec2_route          - Change route target (IGW -> NAT Gateway)
 #   s3_bucket          - Toggle versioning (Enabled -> Suspended)
-#   s3_bucket_acl      - ACL/object_ownership transition
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
 #
@@ -66,10 +65,14 @@ signal_cleanup() {
         set +e
         echo ""
         echo "Interrupted. Cleaning up resources..."
-        cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
-        cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        swap_crn "$ACTIVE_STEP2" "$ACTIVE_WORK_DIR"
+        (cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1)
+        swap_crn "$ACTIVE_STEP1" "$ACTIVE_WORK_DIR"
+        (cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1)
+        swap_crn "$ACTIVE_STEP2" "$ACTIVE_WORK_DIR"
+        (cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1)
+        swap_crn "$ACTIVE_STEP1" "$ACTIVE_WORK_DIR"
+        (cd "$ACTIVE_WORK_DIR" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1)
         rm -rf "$ACTIVE_WORK_DIR"
         ACTIVE_WORK_DIR=""
     fi
@@ -82,13 +85,12 @@ run_step() {
     local work_dir="$1"
     local description="$2"
     local command="$3"
-    local crn_file="$4"
-    local extra_args="${5:-}"
+    local extra_args="${4:-}"
 
     printf "  %-55s " "$description"
 
     local output
-    if output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
+    if output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" $command $extra_args . 2>&1); then
         echo "OK"
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
         return 0
@@ -155,13 +157,12 @@ assert_identifiers() {
 run_plan_verify() {
     local work_dir="$1"
     local description="$2"
-    local crn_file="$3"
 
     printf "  %-55s " "$description"
 
     local output
     local rc
-    output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
+    output=$(cd "$work_dir" && with_account_creds "$CARINA_BIN" plan --detailed-exitcode . 2>&1) || rc=$?
     rc=${rc:-0}
 
     if [ $rc -eq 2 ]; then
@@ -182,6 +183,17 @@ run_plan_verify() {
     return 0
 }
 
+# Swap the active .crn into work_dir/main.crn (with provider source injected).
+# Args: source_crn target_work_dir
+swap_crn() {
+    local src="$1"
+    local target="$2"
+    local injected_dir
+    injected_dir=$(inject_provider_source "$src")
+    cp "$injected_dir/main.crn" "$target/main.crn"
+    rm -rf "$injected_dir"
+}
+
 # destroy_work_dir: try to destroy with both step configs, then retry
 # Returns 0 if at least one destroy succeeded, 1 if ALL failed
 # (Named distinctly from `cleanup` so the EXIT trap in _helpers.sh keeps using
@@ -196,17 +208,21 @@ destroy_work_dir() {
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    if cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    swap_crn "$step2" "$work_dir"
+    if (cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1); then
         any_success=true
     fi
-    if cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    swap_crn "$step1" "$work_dir"
+    if (cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1); then
         any_success=true
     fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    if cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    swap_crn "$step2" "$work_dir"
+    if (cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1); then
         any_success=true
     fi
-    if cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    swap_crn "$step1" "$work_dir"
+    if (cd "$work_dir" && with_account_creds "$CARINA_BIN" destroy --auto-approve . 2>&1); then
         any_success=true
     fi
     set -e
@@ -233,9 +249,15 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
-    # Inject provider source into .crn files
-    step1=$(inject_provider_source "$step1")
-    step2=$(inject_provider_source "$step2")
+    # Load step1 and initialize (creates backend lock + installs providers).
+    swap_crn "$step1" "$work_dir"
+    if ! prepare_work_dir "$work_dir"; then
+        echo "  step0: init                                             FAIL"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
 
     # Register for signal cleanup
     ACTIVE_WORK_DIR="$work_dir"
@@ -246,19 +268,17 @@ run_test() {
     echo ""
 
     # Step 1: Apply initial config
-    if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
+    if ! run_step "$work_dir" "step1: apply initial" "apply" "--auto-approve"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 1b: Plan-verify initial state
-    if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
+    if ! run_plan_verify "$work_dir" "step1: plan-verify initial"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -267,11 +287,13 @@ run_test() {
     local ids_after_step1
     ids_after_step1=$(get_identifiers "$work_dir")
 
+    # Swap in step2 config (providers are the same, lock already present).
+    swap_crn "$step2" "$work_dir"
+
     # Step 2: Apply modified config (in-place update)
-    if ! run_step "$work_dir" "step2: apply in-place update" "apply" "$step2" "--auto-approve"; then
+    if ! run_step "$work_dir" "step2: apply in-place update" "apply" "--auto-approve"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -284,16 +306,14 @@ run_test() {
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 3: Plan-verify after update
-    if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
+    if ! run_plan_verify "$work_dir" "step3: plan-verify after update"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -303,14 +323,12 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }
@@ -354,12 +372,6 @@ run_test "s3_bucket" \
     "$SCRIPT_DIR/s3_bucket_step1.crn" \
     "$SCRIPT_DIR/s3_bucket_step2.crn" \
     "Test 6: S3 Bucket (versioning Enabled -> Suspended)"
-
-# Test 7: S3 Bucket ACL - ACL/object_ownership transition
-run_test "s3_bucket_acl" \
-    "$SCRIPT_DIR/s3_bucket_acl_step1.crn" \
-    "$SCRIPT_DIR/s3_bucket_acl_step2.crn" \
-    "Test 7: S3 Bucket ACL (ACL private + BucketOwnerPreferred -> BucketOwnerEnforced)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -84,11 +84,32 @@ inject_provider_source_dir() {
 TEST_PASSED=0
 TEST_FAILED=0
 
-# prepare_work_dir: Inject provider source into all .crn files in a work directory.
+# carina_work_dir_initialized: Return 0 when the work dir already has init artifacts.
+# Args: work_dir
+carina_work_dir_initialized() {
+    local work_dir="$1"
+
+    [ -d "$work_dir/.carina/providers" ] || [ -f "$work_dir/carina-backend.lock" ]
+}
+
+# prepare_work_dir: Inject provider source and ensure the work directory is initialized.
 # Call this after copying .crn files to the work dir but before running carina commands.
 # Args: work_dir
 prepare_work_dir() {
-    inject_provider_source_dir "$1"
+    if [ "$#" -ne 1 ]; then
+        echo "ERROR: prepare_work_dir expects exactly one work directory" >&2
+        return 2
+    fi
+
+    local work_dir="$1"
+
+    inject_provider_source_dir "$work_dir"
+
+    if carina_work_dir_initialized "$work_dir"; then
+        return 0
+    fi
+
+    (cd "$work_dir" && "$CARINA_BIN" init . >/dev/null)
 }
 
 ACTIVE_WORK_DIR=""
@@ -99,7 +120,7 @@ cleanup() {
         cd "$ACTIVE_WORK_DIR"
         "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true
         "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true
-        rm -f carina.state.json carina.state.lock
+        rm -f carina.state.json carina-backend.lock carina-providers.lock
     fi
 }
 trap cleanup EXIT

--- a/acceptance-tests/sts_caller_identity/basic.crn
+++ b/acceptance-tests/sts_caller_identity/basic.crn
@@ -3,3 +3,26 @@ provider aws {
 }
 
 let caller = read aws.sts.CallerIdentity {}
+
+aws.iam.Role {
+  role_name   = 'carina-acc-test-sts-caller-consumer'
+  description = caller.account_id
+
+  assume_role_policy_document = {
+    version = aws.iam.PolicyDocument.Version.2012_10_17
+    statement {
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
+
+      principal = {
+        service = 'lambda.amazonaws.com'
+      }
+
+      action = 'sts:AssumeRole'
+    }
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+    CallerArn   = caller.arn
+  }
+}

--- a/acceptance-tests/sts_caller_identity/tests/basic.sh
+++ b/acceptance-tests/sts_caller_identity/tests/basic.sh
@@ -1,23 +1,28 @@
 #!/bin/bash
-# Test: sts_caller_identity data source (read)
+# Test: sts_caller_identity data source read with a managed consumer role.
 source "$(dirname "$0")/../../shared/_helpers.sh"
 
 echo "Test: sts_caller_identity data source"
 echo ""
+
+CONSUMER_ROLE_NAME="carina-acc-test-sts-caller-consumer"
 
 WORK_DIR=$(mktemp -d)
 ACTIVE_WORK_DIR="$WORK_DIR"
 cp "$SCRIPT_DIR/basic.crn" "$WORK_DIR/main.crn"
 cd "$WORK_DIR"
 
+prepare_work_dir "$WORK_DIR"
+run_step "step0: init (resolve provider)" "$CARINA_BIN" init .
 run_step "step1: apply (read data source)" "$CARINA_BIN" apply --auto-approve .
 
-# Verify state contains the caller identity resource
+# carina#3266 prunes data-source read artifact rows from state.resources;
+# only the managed consumer role is persisted.
 assert_state_resource_count "assert: 1 resource in state" "1" "$WORK_DIR"
 
-# account_id should be a 12-digit number
-printf "  %-50s" "assert: account_id is 12 digits"
-ACCOUNT_ID=$(jq -r '.resources[0].attributes.account_id' "$WORK_DIR/carina.state.json" 2>/dev/null)
+# account_id should be a 12-digit number persisted through the consumer role.
+printf "  %-50s" "assert: consumer.description is 12 digits"
+ACCOUNT_ID=$(jq -r '.resources[] | select(.attributes.role_name == "'"$CONSUMER_ROLE_NAME"'") | .attributes.description' "$WORK_DIR/carina.state.json" 2>/dev/null)
 if echo "$ACCOUNT_ID" | grep -qE '^[0-9]{12}$'; then
     echo "OK ($ACCOUNT_ID)"
     TEST_PASSED=$((TEST_PASSED + 1))
@@ -26,9 +31,9 @@ else
     TEST_FAILED=$((TEST_FAILED + 1))
 fi
 
-# arn should start with arn:aws
-printf "  %-50s" "assert: arn starts with arn:aws"
-ARN=$(jq -r '.resources[0].attributes.arn' "$WORK_DIR/carina.state.json" 2>/dev/null)
+# arn should start with arn:aws and be persisted through the consumer role tag.
+printf "  %-50s" "assert: consumer CallerArn starts with arn:aws"
+ARN=$(jq -r '.resources[] | select(.attributes.role_name == "'"$CONSUMER_ROLE_NAME"'") | .attributes.tags.CallerArn' "$WORK_DIR/carina.state.json" 2>/dev/null)
 if echo "$ARN" | grep -q '^arn:aws'; then
     echo "OK"
     TEST_PASSED=$((TEST_PASSED + 1))
@@ -37,8 +42,8 @@ else
     TEST_FAILED=$((TEST_FAILED + 1))
 fi
 
-# No cleanup needed — read-only data source creates no infrastructure
-rm -rf "$WORK_DIR"
+run_step "step3: destroy (consumer role only)" "$CARINA_BIN" destroy --auto-approve .
 ACTIVE_WORK_DIR=""
+rm -rf "$WORK_DIR"
 
 finish_test


### PR DESCRIPTION
## Summary

The in_place_update and sts_caller_identity multi-step suites never ran `carina init` and failed their first apply with "Provider 'aws' not installed" — carina requires init since carina-rs/carina@f6ef9be4 (2026-04-14).

1. **Shared seam**: `prepare_work_dir` (shared/_helpers.sh) now injects provider sources and runs a guarded `carina init .`, so every suite — current and future — inherits init. Guard checks the real artifacts (`.carina/providers` / `carina-backend.lock`); cleanup() referenced a nonexistent `carina.state.lock` and now removes `carina-backend.lock` + `carina-providers.lock`.
2. **Topology**: in_place_update ran `cd work_dir && carina apply $step_dir`. init/apply/destroy place all artifacts in the *target* dir and `plan` currently reads state from *cwd* (carina-rs/carina#3676), so that topology splits state across step dirs and always fails plan-verify with a phantom `+ add`. Reshaped to the healthy suites' pattern: one work dir, step configs swapped in as `main.crn`, every command `cd work_dir && carina <cmd> .`.
3. **Suite rot fixed while making these green**:
   - Removed the stale `s3_bucket_acl` test entry (bd4fca2 moved that surface to the standalone suite and deleted the fixtures but left the `run_test` invocation → missing-file failure).
   - sts_caller_identity asserted the data-source read persists as a state row, but carina#3266 prunes data-source artifacts from state — a read-only config yields an empty state. Now uses the iam_roles pattern: a managed consumer role persists `caller.account_id` (description) and `caller.arn` (tag), destroyed afterwards.

## Verification (real AWS, carina-test accounts)

| Suite | Result |
|---|---|
| in_place_update (ec2_vpc) | pass (apply → plan-verify → in-place update → plan-verify → destroy) |
| sts_caller_identity | pass (6/6 asserts, consumer role destroyed, no leaks) |
| iam_roles / s3_bucket_data_source | untouched, re-verified green earlier today |

Stub-binary audit: every carina invocation with target `.` and cwd == work dir; init before the first apply per work dir.

Same seam fix in carina-provider-awscc: carina-rs/carina-provider-awscc#392.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vca7585CbZTp7xYdAMu3YN