### PR TITLE
ci: restore main CI (pin wasm toolchain around rust-lld regression, regenerate Smithy schemas)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned to 1.95.0: current stable's rust-lld SIGSEGVs on wasm targets
+      # (rust-lang/rust#150227). Revert to @stable once fixed upstream.
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: wasm32-wasip2
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned to 1.95.0: current stable's rust-lld SIGSEGVs on wasm targets
+      # (rust-lang/rust#150227). Revert to @stable once fixed upstream.
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: wasm32-wasip2
 

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -50,7 +50,7 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsSchemaConfig {
     vec![("disable".to_string(), "disable".to_string()), ("enable".to_string(), "enable".to_string())],
     None,
     None,
-)).with_description("Enable or disable IPv6 support. The default is disable.").with_provider_name("Ipv6Support"),
+)).with_description("Specifies whether IPv6 support is enabled for the attachment. When enabled, the transit gateway network interface receives an IPv6 address. When you e...").with_provider_name("Ipv6Support"),
                     StructField::new("security_group_referencing_support", AttributeType::enum_(
     carina_core::schema::enum_identity("SecurityGroupReferencingSupport", Some("aws.ec2.TransitGatewayAttachment.CreateTransitGatewayVpcAttachmentRequestOptions")),
     Some(vec!["disable".to_string(), "enable".to_string()]),


### PR DESCRIPTION
## 概要

mainのCIが7月2日以降走っておらず、その間の環境driftで**今日どのPRを出しても2ジョブが落ちる**状態になっていた。#492のmergeがこれにブロックされたため復旧する。2つの独立した原因があるが、互いに相手の修正がないとCIが緑にならない相互デッドロックのため、1つのPRに2コミットでまとめた。

### 1. WASM Build: rust-lldのSIGSEGV（toolchain退行）

現行stable（1.98系）のrust-lldがwasm32-wasip2向けの`crc-fast`ビルドでSIGSEGVする既知の未解決バグ（rust-lang/rust#150227）。wasmをビルドする2ジョブ（ci.ymlの`wasm-build`、release.ymlの`build-wasm`）だけtoolchainを1.95.0へ固定して回避する。

- 1.95.0はローカル・registryのDockerfileで実証済みの世代。検証としてローカルの1.95.0で`cargo build -p carina-provider-aws --target wasm32-wasip2 --release`の完走を確認済み
- 他のジョブは現行stableで通っているため`@stable`のまま。upstream修正後に戻す旨をコメントに明記

### 2. Codegen Check: 上流Smithyモデルのdrift

上流AWS SmithyモデルでEC2 TransitGatewayAttachmentの`Ipv6Support`説明文が更新され、生成コードとの差分でCodegen Checkが落ちる。`scripts/generate-schemas-smithy.sh`+`scripts/generate-provider.sh`で再生成（差分は説明文1行のみ）。`cargo test -p carina-provider-aws`通過。

## 補足

- どちらも#492の差分とは無関係（mainでCIを走らせても同様に落ちる）
- CIが月単位で走らない期間があるとこの種のdriftが溜まる。定期実行（scheduleトリガ）の追加は別途検討の余地あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WM98K9HpLgwkM52arRb9AC
