### PR TITLE
ci: sign the WASM artifact with Sigstore keyless and publish the bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,13 @@ jobs:
           mv carina-provider-aws.wasm "carina-provider-aws-${version}.wasm"
           printf 'VERSION=%s\n' "$version" >> "$GITHUB_ENV"
 
+      # Pin v2.6.5: the registry requires Rekor v1's SET; Rekor v2 issues no SET,
+      # and cosign v3 defaults to signing-config, which routes to Rekor v2.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.6.5'
+
       - name: Upload to Rolling Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -179,26 +186,58 @@ jobs:
           fi
           gh release upload "$ROLLING_RELEASE_TAG" "carina-provider-aws-${VERSION}.wasm"
 
+      - name: Sign WASM Artifact (keyless)
+        run: |
+          set -euo pipefail
+
+          for attempt in 1 2 3; do
+            if cosign sign-blob "carina-provider-aws-${VERSION}.wasm" \
+              --bundle sigstore-bundle.json \
+              --new-bundle-format=true \
+              --yes; then
+              break
+            fi
+
+            printf 'Signing attempt %s failed\n' "$attempt" >&2
+            if [ "$attempt" -lt 3 ]; then
+              sleep 10
+              continue
+            fi
+            printf 'Signing failed after 3 attempts\n' >&2
+            exit 1
+          done
+
       - name: Publish to Carina Registry
         # For a 403 claim_mismatch, verify that the trusted-publisher policy uses the
         # main-branch-only sentinel and points to .github/workflows/ci.yml.
         run: |
           set -euo pipefail
 
+          if ! jq -e 'type == "object"' sigstore-bundle.json >/dev/null; then
+            echo "sigstore-bundle.json is missing or not a JSON object" >&2
+            exit 1
+          fi
+
           version="$VERSION"
           asset_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${ROLLING_RELEASE_TAG}/carina-provider-aws-${version}.wasm"
           payload=$(jq -n \
             --arg version "$version" \
             --arg asset_url "$asset_url" \
+            --slurpfile bundle sigstore-bundle.json \
             '{
               namespace: "carina-rs",
               name: "aws",
               version: $version,
-              candidate_download_url: $asset_url
+              candidate_download_url: $asset_url,
+              sigstore_bundle: $bundle[0]
             }')
           response_file=$(mktemp)
           trap 'rm -f "$response_file"' EXIT
 
+          # The Fulcio cert from the sign step lives ~10 minutes and must still be valid
+          # when the registry verifies a new version's bundle; this loop's worst case
+          # (3 x (60s token + 120s POST) + 2 x 10s sleep) nearly exhausts it, so do not
+          # add attempts, sleeps, or timeout headroom here.
           for attempt in 1 2 3; do
             if ! token=$(curl -sS \
               --connect-timeout 10 \


### PR DESCRIPTION
## 概要

registry increment 5（carina-rs/registry#12）のprovider側の実装です。`publish-dev`ジョブで、ビルドしたwasmをcosignのkeyless署名で署名し、生成されたSigstoreバンドルをpublish APIへ`sigstore_bundle`として送ります。registry側の受け口（registry PR#44）はデプロイ済みで、現在のdev policyは`artifact_signing = unsigned-allowed`なので、このPRは先行してマージできます。

## 変更内容

- cosignの導入。installerはコミットSHAで固定（このジョブはid-token:writeとcontents:writeを持つ唯一のジョブで、初のサードパーティ製actionになるため、タグ移動による改竄を防ぐ）
- cosignはv2.6.5に固定。registryはRekor v1のSET（inclusionPromise）を必須とするが、cosign v3はTUFのSigningConfigを既定で使い、SETを発行しないRekor v2シャードへ署名してしまうため、v2系が必要（理由はYAMLコメントに明記）
- 署名ステップを「Upload to Rolling Release」と「Publish to Carina Registry」の間に追加。`cosign sign-blob --new-bundle-format=true`でprotobuf JSONバンドル（messageSignature型）を生成。Fulcio証明書は約10分で失効し、registryは証明書のidentity（SAN + Build Signer Digest拡張）をpublishトークンのクレームと突き合わせるため、署名とPOSTは同一ジョブで直後に実行する
- 署名ステップに3回リトライを追加（外部依存が4つあり、一過性の障害でCIラン全体を落とさないため。各リトライで新しい証明書が発行され、POST前なので副作用なし）
- publishステップの冒頭でバンドルがJSONオブジェクトであることを検査（空ファイルが`null`となり未署名publishに化ける経路を遮断）
- payloadの組み立てに`--slurpfile`でバンドルを追加。payloadはリトライループの外で一度だけ構築するので、リトライは同一バイト列を再送し、registry側の冪等再照合と整合する

## レビュー

5ラウンドの独立レビューを実施し、以下を修正済み:

1. registry検証器との整合(バンドル形式v0.3、messageSignature、digest束縛、identity束縛、tlogエントリ材料、サイズ、証明書鮮度をregistryのソースとcosign/fulcio/rekorのソースで裏取り) — 問題なし
2. Actions/シェル機構 — 問題なし(cosign-installerのPATH追加・keyless動作をaction.ymlとcosignソースで確認)
3. セキュリティ — installerのSHA固定を適用
4. 障害・リトライ・ロールアウト — 署名リトライと時間予算コメントを適用
5. 総合・仕様適合 — コメントの数値修正とバンドル検査を適用

## マージ後の手順（重要）

1. mainへのマージで最初の署名付きpublishが走る。確認事項: レスポンスが201、download JSONに`signature`ブロックがあること、`.../{version}/sigstore.json`が取得できること
2. 確認できたら、devのpublish policyの`artifact_signing`を`required`へ切り替える（infra側、`registry-policy/dev/publish-policy/carina-rs.json`）。切り替えまでの間はCIのrevertで未署名publishが再開できてしまうため、間を空けない

## ロールバックについての注意（一方通行）

carina CLIのresolverは既に`signature_present`によるダウングレード保護を実装しています（provider単位でロックに記録）。署名付き版を一度でも解決したユーザーのロックは`signature_present: true`に昇格し、その後このCIをrevertして未署名publishに戻すと、そのユーザーの解決は恒久的に失敗します。問題が出た場合はrevertではなくfix-forwardを基本とします。

## 残り

- carina CLI側のオフライン署名検証（protocol §3、registry#12の残り）
- SET/inclusion proofの暗号検証はsigstore-rs実装待ち（registry#45、R32）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WM98K9HpLgwkM52arRb9AC
