### PR TITLE
docs: require measured AWS behaviour to be recorded in code with date and region

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,37 @@ The `carina-codegen-aws` crate generates resource definitions from AWS Smithy JS
 cargo run -p carina-codegen-aws -- <smithy-model-path>
 ```
 
+## Record measured AWS behaviour in the code, with date and region
+
+Provider work regularly turns on how a specific AWS API actually behaves rather
+than on what its documentation or Smithy model says: which fields a read returns,
+whether an update accepts a change or silently ignores it, how a value is spelled
+back, which changes force replacement. Verify these against real AWS
+(`aws-vault exec <profile> -- ...`) before designing around them.
+
+When an observation produces a code path — an override, a special-case branch, a
+field that must be stripped or synthesised, a value spelling that has to be
+translated — record the observation in a comment at that code path. Note what was
+run, the **region**, the **date**, and which directions were checked.
+
+```rust
+// UpdateFunctionConfiguration accepts removing this block but the read-back is
+// unchanged, so a presence toggle must force replacement rather than an
+// in-place update. Measured us-east-1, 2026-08-12, both directions
+// (add -> ValidationException; remove -> accepted but read-back unchanged).
+```
+
+The reason is re-measurement, not provenance. AWS behaviour changes, and a branch
+whose justification lives only in a PR thread becomes an incantation nobody dares
+touch. With a date and a region, a future reader can decide whether the
+observation is still current and re-run it. Without them, the only safe move is
+to leave the branch alone forever.
+
+Applies equally to the codegen layer: a `resource_type_overrides()` entry or a
+hand-written deviation from the Smithy model that exists because real AWS
+disagrees with the model needs the same comment, since the generated output alone
+cannot explain itself.
+
 ## Git Workflow
 
 ### Worktree-Based Development


### PR DESCRIPTION
## Problem

Provider code paths regularly exist because real AWS behaves differently from its documentation or Smithy model — which fields a read returns, whether an update silently ignores a change, how a value is spelled back, which changes force replacement. This repo already runs those measurements, but nothing says where the result goes, so it ends up in a PR thread and not in the source.

The cost shows up later. A branch whose justification is not re-checkable becomes an incantation: a reader cannot tell whether the observation still holds, so the only safe move is to leave it alone forever. AWS behaviour does change, and there is currently no way to tell a stale workaround from a load-bearing one.

## Change

Docs only. Adds a `Record measured AWS behaviour in the code, with date and region` section to `CLAUDE.md`, requiring that when an observation produces a code path, the observation is recorded at that code path with the region, the date, and which directions were checked.

The date and region are the point — they are what makes the observation re-measurable rather than merely attributed.

Also states the verification obligation itself, which this repo's `CLAUDE.md` did not previously carry (the awscc repo has a version of it tied to winterbaume issue filing). Extends to codegen overrides and hand-written deviations from the Smithy model, whose generated output cannot explain itself.

A companion PR applies the same rule to `carina-provider-awscc`.

## Notes

No code changes, so no verify cycle applies; the pre-commit hook reported no Rust-affecting changes. This is a convention rather than an enforced invariant — worth being honest that its effect depends on authors following it. The intent is that a few worked examples in-tree teach the format better than a rule alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)