### PR TITLE
feat(s3): expose read-only outputs on the managed aws.s3.Bucket

### DIFF
--- a/acceptance-tests/s3_bucket_outputs/basic.crn
+++ b/acceptance-tests/s3_bucket_outputs/basic.crn
@@ -1,0 +1,29 @@
+# S3 Bucket - Basic managed-output test
+#
+# Tests bucket creation and consumes every managed read-only output through
+# tags on a second bucket. Bucket names are templated by the custom runner.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let source = aws.s3.Bucket {
+  bucket = '${SOURCE_BUCKET}'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+aws.s3.Bucket {
+  bucket = '${CONSUMER_BUCKET}'
+
+  tags = {
+    Environment          = 'acceptance-test'
+    SourceArn            = source.arn
+    SourceRegion         = source.region
+    SourceDomain         = source.bucket_domain_name
+    SourceRegionalDomain = source.bucket_regional_domain_name
+    SourceHostedZoneId   = source.hosted_zone_id
+  }
+}

--- a/acceptance-tests/s3_bucket_outputs/run.sh
+++ b/acceptance-tests/s3_bucket_outputs/run.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Runs s3_bucket_outputs acceptance tests.
+#
+# Usage:
+#   eval "$(aws configure export-credentials --profile <profile> --format env)"
+#   ./run.sh [filter]
+#
+# AWS authentication:
+#   Export AWS credentials before invoking this suite; the Carina WASM
+#   provider cannot use AWS_PROFILE/SSO directly.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER="${1:-}"
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+TESTS_RUN=0
+
+echo "s3_bucket_outputs acceptance tests"
+echo "════════════════════════════════════════"
+
+for test_file in "$SCRIPT_DIR"/tests/*.sh; do
+    [ "$(basename "$test_file")" = "_helpers.sh" ] && continue
+    test_name="$(basename "$test_file" .sh)"
+    if [ -n "$FILTER" ] && ! echo "$test_name" | grep -q "$FILTER"; then
+        continue
+    fi
+    echo ""
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if bash "$test_file"; then
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    else
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+    fi
+done
+
+echo ""
+echo "════════════════════════════════════════"
+echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+echo "════════════════════════════════════════"
+
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/acceptance-tests/s3_bucket_outputs/tests/basic.sh
+++ b/acceptance-tests/s3_bucket_outputs/tests/basic.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Test: managed s3.Bucket read-only outputs
+source "$(dirname "$0")/../../shared/_helpers.sh"
+
+echo "Test: s3_bucket_outputs managed read-only outputs"
+echo ""
+
+REGION="ap-northeast-1"
+SUFFIX="$(uuidgen | tr -d - | tr 'A-Z' 'a-z' | head -c 8)"
+SOURCE_BUCKET="carina-acc-test-aws-s3-source-${SUFFIX}"
+CONSUMER_BUCKET="carina-acc-test-aws-s3-consumer-${SUFFIX}"
+export SOURCE_BUCKET CONSUMER_BUCKET
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+trap cleanup EXIT
+
+envsubst < "$SCRIPT_DIR/basic.crn" > "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+prepare_work_dir "$WORK_DIR"
+run_step "step0: init (resolve provider)" "$CARINA_BIN" init .
+run_step "step1: apply (create source + consumer)" "$CARINA_BIN" apply --auto-approve .
+
+assert_state_resource_count "assert: 2 resources in state" "2" "$WORK_DIR"
+
+SOURCE_PATH=".resources[] | select(.attributes.bucket == \"$SOURCE_BUCKET\")"
+CONSUMER_PATH=".resources[] | select(.attributes.bucket == \"$CONSUMER_BUCKET\")"
+
+assert_state_value "assert: source arn" \
+    "$SOURCE_PATH | .attributes.arn" \
+    "arn:aws:s3:::$SOURCE_BUCKET" \
+    "$WORK_DIR"
+assert_state_value "assert: source region" \
+    "$SOURCE_PATH | .attributes.region" \
+    "$REGION" \
+    "$WORK_DIR"
+assert_state_value "assert: source domain name" \
+    "$SOURCE_PATH | .attributes.bucket_domain_name" \
+    "$SOURCE_BUCKET.s3.amazonaws.com" \
+    "$WORK_DIR"
+assert_state_value "assert: source regional domain name" \
+    "$SOURCE_PATH | .attributes.bucket_regional_domain_name" \
+    "$SOURCE_BUCKET.s3.$REGION.amazonaws.com" \
+    "$WORK_DIR"
+assert_state_value "assert: source hosted zone id" \
+    "$SOURCE_PATH | .attributes.hosted_zone_id" \
+    "Z2M4EHUR26P7ZW" \
+    "$WORK_DIR"
+
+assert_state_value "assert: consumer tag SourceArn" \
+    "$CONSUMER_PATH | .attributes.tags.SourceArn" \
+    "arn:aws:s3:::$SOURCE_BUCKET" \
+    "$WORK_DIR"
+assert_state_value "assert: consumer tag SourceRegion" \
+    "$CONSUMER_PATH | .attributes.tags.SourceRegion" \
+    "$REGION" \
+    "$WORK_DIR"
+assert_state_value "assert: consumer tag SourceDomain" \
+    "$CONSUMER_PATH | .attributes.tags.SourceDomain" \
+    "$SOURCE_BUCKET.s3.amazonaws.com" \
+    "$WORK_DIR"
+assert_state_value "assert: consumer tag SourceRegionalDomain" \
+    "$CONSUMER_PATH | .attributes.tags.SourceRegionalDomain" \
+    "$SOURCE_BUCKET.s3.$REGION.amazonaws.com" \
+    "$WORK_DIR"
+assert_state_value "assert: consumer tag SourceHostedZoneId" \
+    "$CONSUMER_PATH | .attributes.tags.SourceHostedZoneId" \
+    "Z2M4EHUR26P7ZW" \
+    "$WORK_DIR"
+
+run_step "step2: destroy" "$CARINA_BIN" destroy --auto-approve .
+ACTIVE_WORK_DIR=""
+rm -rf "$WORK_DIR"
+
+finish_test

--- a/carina-codegen-aws/src/resource_defs.rs
+++ b/carina-codegen-aws/src/resource_defs.rs
@@ -1328,7 +1328,10 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             update_ops: vec![],
             identifier: "Bucket",
             has_tags: true,
-            type_overrides: vec![],
+            // Keep Region plain: aws_region() accepts DSL spellings such as
+            // aws.Region.ap_northeast_1, while GetBucketLocation returns ap-northeast-1.
+            // Refining a provider-populated output risks validation and phantom diffs.
+            type_overrides: vec![("Region", "AttributeType::string()")],
             exclude_fields: vec![
                 "CreateBucketConfiguration",
                 "ContentMD5",
@@ -1351,8 +1354,43 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             to_dsl_overrides: vec![],
             required_overrides: vec![],
             extra_read_only: vec![],
-            read_only_overrides: vec![],
-            extra_attributes: vec![],
+            // Bucket ARN + its location, DNS names, and hosted zone are read-only.
+            read_only_overrides: vec![
+                "Arn",
+                "Region",
+                "BucketDomainName",
+                "BucketRegionalDomainName",
+                "HostedZoneId",
+            ],
+            extra_attributes: vec![
+                ExtraField {
+                    name: "Arn",
+                    read_source: None,
+                    description: Some("ARN of the bucket."),
+                },
+                ExtraField {
+                    name: "Region",
+                    read_source: None,
+                    description: Some("AWS region the bucket is in."),
+                },
+                ExtraField {
+                    name: "BucketDomainName",
+                    read_source: None,
+                    description: Some("Bucket domain name, in the form NAME.s3.amazonaws.com."),
+                },
+                ExtraField {
+                    name: "BucketRegionalDomainName",
+                    read_source: None,
+                    description: Some(
+                        "Region-specific bucket domain name, in the form NAME.s3.REGION.amazonaws.com.",
+                    ),
+                },
+                ExtraField {
+                    name: "HostedZoneId",
+                    read_source: None,
+                    description: Some("Route 53 Hosted Zone ID for the bucket's region."),
+                },
+            ],
             identity_overrides: vec![],
             deferred_populate_overrides: vec![],
             deferred_populate_struct_field_overrides: vec![],

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -11,6 +11,15 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 const VALID_BUCKET_NAMESPACE: &[&str] = &["account-regional", "global"];
 
+pub fn arn() -> AttributeType {
+    AttributeType::refined_string(
+        Some(super::provider_type("s3", "Bucket", "Arn")),
+        Some("^arn:(aws|aws-cn|aws-us-gov):s3:::.+$".to_string()),
+        None,
+        None,
+    )
+}
+
 /// Returns the schema config for s3.Bucket (Smithy: com.amazonaws.s3)
 pub fn s3_bucket_config() -> AwsSchemaConfig {
     AwsSchemaConfig {
@@ -37,6 +46,36 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
                 .create_only()
                 .with_description("Specifies the namespace where you want to create your general purpose bucket. When you create a general purpose bucket, you can choose to create a buc...")
                 .with_provider_name("BucketNamespace"),
+        )
+        .attribute(
+            AttributeSchema::new("arn", self::arn())
+                .read_only()
+                .with_description("ARN of the bucket. (read-only)")
+                .with_provider_name("Arn"),
+        )
+        .attribute(
+            AttributeSchema::new("region", AttributeType::string())
+                .read_only()
+                .with_description("AWS region the bucket is in. (read-only)")
+                .with_provider_name("Region"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_domain_name", AttributeType::string())
+                .read_only()
+                .with_description("Bucket domain name, in the form NAME.s3.amazonaws.com. (read-only)")
+                .with_provider_name("BucketDomainName"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_regional_domain_name", AttributeType::string())
+                .read_only()
+                .with_description("Region-specific bucket domain name, in the form NAME.s3.REGION.amazonaws.com. (read-only)")
+                .with_provider_name("BucketRegionalDomainName"),
+        )
+        .attribute(
+            AttributeSchema::new("hosted_zone_id", AttributeType::string())
+                .read_only()
+                .with_description("Route 53 Hosted Zone ID for the bucket's region. (read-only)")
+                .with_provider_name("HostedZoneId"),
         )
         .attribute(
             AttributeSchema::new("tags", tags_type())

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -10,6 +10,82 @@ use crate::AwsProvider;
 use crate::error_helpers::api_error_with_meta;
 use crate::helpers::{RetryPolicy, retry_aws_operation, sdk_error_message};
 
+/// The complete read-only projection shared by managed and data-source
+/// reads of an S3 bucket.
+struct S3BucketReadOnlyOutputs {
+    arn: String,
+    region: String,
+    bucket_domain_name: String,
+    bucket_regional_domain_name: String,
+    hosted_zone_id: Option<String>,
+}
+
+impl S3BucketReadOnlyOutputs {
+    /// Consume the projection as one unit so neither read path selects a
+    /// different subset of outputs.
+    fn into_attributes(self) -> HashMap<String, Value> {
+        let mut attributes = HashMap::from([
+            (
+                "arn".to_string(),
+                Value::Concrete(ConcreteValue::String(self.arn)),
+            ),
+            (
+                "region".to_string(),
+                Value::Concrete(ConcreteValue::String(self.region)),
+            ),
+            (
+                "bucket_domain_name".to_string(),
+                Value::Concrete(ConcreteValue::String(self.bucket_domain_name)),
+            ),
+            (
+                "bucket_regional_domain_name".to_string(),
+                Value::Concrete(ConcreteValue::String(self.bucket_regional_domain_name)),
+            ),
+        ]);
+
+        // A miss must omit the attribute rather than break resource management. This
+        // remains the safety net for regions AWS adds after the table was fetched;
+        // isolated GovCloud and China partitions remain out of scope.
+        if let Some(hosted_zone_id) = self.hosted_zone_id {
+            attributes.insert(
+                "hosted_zone_id".to_string(),
+                Value::Concrete(ConcreteValue::String(hosted_zone_id)),
+            );
+        }
+
+        attributes
+    }
+}
+
+/// Compute every read-only output exposed by both views of `s3.Bucket`.
+fn s3_bucket_read_only_outputs(bucket: &str, region: &str) -> S3BucketReadOnlyOutputs {
+    // TODO: Partition and DNS-suffix context is not available here yet, so these
+    // derived values currently hard-code the commercial `aws` / `amazonaws.com`
+    // forms.
+    S3BucketReadOnlyOutputs {
+        arn: format!("arn:aws:s3:::{bucket}"),
+        region: region.to_string(),
+        bucket_domain_name: format!("{bucket}.s3.amazonaws.com"),
+        bucket_regional_domain_name: format!("{bucket}.s3.{region}.amazonaws.com"),
+        hosted_zone_id: s3_hosted_zone_id(region).ok().map(str::to_string),
+    }
+}
+
+fn normalize_bucket_location(region: Option<&str>) -> String {
+    // Older HeadBucket responses can omit `x-amz-bucket-region`. Normalize an
+    // absent/empty value to us-east-1 and preserve S3's legacy EU alias.
+    match region {
+        None | Some("") => "us-east-1",
+        Some("EU") => "eu-west-1",
+        Some(region) => region,
+    }
+    .to_string()
+}
+
+fn create_bucket_location_constraint(provider_region: &str) -> Option<&str> {
+    (provider_region != "us-east-1").then_some(provider_region)
+}
+
 impl AwsProvider {
     /// Read an S3 bucket
     pub(crate) async fn read_s3_bucket(
@@ -22,8 +98,13 @@ impl AwsProvider {
         };
 
         match self.s3_client.head_bucket().bucket(name).send().await {
-            Ok(_) => {
-                let mut attributes = HashMap::new();
+            Ok(output) => {
+                // `HeadBucketOutput::bucket_region()` exposes the response's
+                // `x-amz-bucket-region`. AWS's vendored Smithy model deprecates
+                // GetBucketLocation for this purpose, so using this response avoids
+                // another API round trip and another IAM permission.
+                let region = normalize_bucket_location(output.bucket_region());
+                let mut attributes = s3_bucket_read_only_outputs(name, &region).into_attributes();
                 attributes.insert(
                     "bucket".to_string(),
                     Value::Concrete(ConcreteValue::String(name.to_string())),
@@ -76,21 +157,15 @@ impl AwsProvider {
             }
         };
 
-        // Region is not part of the generated s3.Bucket schema today, so this
-        // optional hand-written override only supports plain AWS-format strings.
-        // Otherwise use the provider region.
-        let region = match resource.get_attr("region") {
-            Some(Value::Concrete(ConcreteValue::String(s))) => s.to_string(),
-            _ => self.region.clone(),
-        };
-
         // Create bucket
         let mut req = self.s3_client.create_bucket().bucket(&bucket_name);
 
-        // Specify LocationConstraint for regions other than us-east-1
-        if region != "us-east-1" {
+        // `region` is a read-only output, not a placement input. Derive the
+        // LocationConstraint only from the provider region even if a caller supplies
+        // that attribute while carina-core still permits read-only writes (carina#3766).
+        if let Some(region) = create_bucket_location_constraint(&self.region) {
             use aws_sdk_s3::types::{BucketLocationConstraint, CreateBucketConfiguration};
-            let constraint = BucketLocationConstraint::from(region.as_str());
+            let constraint = BucketLocationConstraint::from(region);
             let config = CreateBucketConfiguration::builder()
                 .location_constraint(constraint)
                 .build();
@@ -361,8 +436,8 @@ impl AwsProvider {
     }
 
     /// Read `s3.Bucket` as a data source. Looks the bucket up by name (the
-    /// required `bucket` input) via `HeadBucket` + `GetBucketLocation`,
-    /// then computes the Terraform-parity attributes (`arn`,
+    /// required `bucket` input) via `HeadBucket`, then computes the
+    /// Terraform-parity attributes (`arn`,
     /// `bucket_domain_name`, `bucket_regional_domain_name`,
     /// `hosted_zone_id`).
     ///
@@ -387,7 +462,8 @@ impl AwsProvider {
             //    is consistent. For a DataSource lookup the user explicitly
             //    asked to read this bucket, so missing bucket is an error
             //    (unlike read_s3_bucket which returns State::not_found).
-            self.s3_client
+            let output = self
+                .s3_client
                 .head_bucket()
                 .bucket(&bucket)
                 .send()
@@ -419,51 +495,13 @@ impl AwsProvider {
                     }
                 })?;
 
-            // 2. GetBucketLocation — region. Empty / missing
-            //    LocationConstraint means us-east-1 per S3's protocol.
-            let region = self
-                .s3_client
-                .get_bucket_location()
-                .bucket(&bucket)
-                .send()
-                .await
-                .map_err(|e| {
-                    api_error_with_meta("Failed to get bucket location", "s3.GetBucketLocation", e)
-                        .for_resource(resource.id.clone())
-                })?
-                .location_constraint()
-                .map(|c| c.as_str().to_string())
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| "us-east-1".to_string());
-
-            // 3. Computed attributes.
-            let arn = format!("arn:aws:s3:::{}", bucket);
-            let bucket_domain_name = format!("{}.s3.amazonaws.com", bucket);
-            let bucket_regional_domain_name = format!("{}.s3.{}.amazonaws.com", bucket, region);
-            let hosted_zone_id = s3_hosted_zone_id(&region)
-                .map_err(|m| ProviderError::internal(m).for_resource(resource.id.clone()))?;
-
-            let mut attrs = HashMap::new();
+            // 2. Derive the region from HeadBucket's `x-amz-bucket-region` and
+            //    use the same complete output projection as the managed read path.
+            let region = normalize_bucket_location(output.bucket_region());
+            let mut attrs = s3_bucket_read_only_outputs(&bucket, &region).into_attributes();
             attrs.insert(
                 "bucket".into(),
                 Value::Concrete(ConcreteValue::String(bucket.clone())),
-            );
-            attrs.insert("arn".into(), Value::Concrete(ConcreteValue::String(arn)));
-            attrs.insert(
-                "region".into(),
-                Value::Concrete(ConcreteValue::String(region)),
-            );
-            attrs.insert(
-                "bucket_domain_name".into(),
-                Value::Concrete(ConcreteValue::String(bucket_domain_name)),
-            );
-            attrs.insert(
-                "bucket_regional_domain_name".into(),
-                Value::Concrete(ConcreteValue::String(bucket_regional_domain_name)),
-            );
-            attrs.insert(
-                "hosted_zone_id".into(),
-                Value::Concrete(ConcreteValue::String(hosted_zone_id.to_string())),
             );
 
             Ok(State::existing(resource.id.clone(), attrs).with_identifier(&bucket))
@@ -473,7 +511,9 @@ impl AwsProvider {
 
 /// Map AWS region → S3 website-endpoint hosted zone ID.
 ///
-/// Source: https://docs.aws.amazon.com/general/latest/gr/s3.html
+/// Source (fetched 2026-08-15):
+/// https://docs.aws.amazon.com/general/latest/gr/s3.html
+/// "Amazon S3 website endpoints and HostedZone IDs" table.
 /// Limited to commercial regions; isolated partitions (GovCloud, China)
 /// are out of scope.
 pub(crate) fn s3_hosted_zone_id(region: &str) -> Result<&'static str, String> {
@@ -482,20 +522,34 @@ pub(crate) fn s3_hosted_zone_id(region: &str) -> Result<&'static str, String> {
         "us-east-2" => "Z2O1EMRO9K5GLX",
         "us-west-1" => "Z2F56UZL2M1ACD",
         "us-west-2" => "Z3BJ6K6RIION7M",
+        "af-south-1" => "Z2OSFR5PIJ8TYW",
         "ap-east-1" => "ZNB98KWMFR0R6",
+        "ap-east-2" => "Z064739330DAH7WJVOO93",
         "ap-south-1" => "Z11RGJOFQNVJUP",
+        "ap-south-2" => "Z02976202B4EZMXIPMXF7",
         "ap-northeast-1" => "Z2M4EHUR26P7ZW",
         "ap-northeast-2" => "Z3W03O7B5YMIYP",
         "ap-northeast-3" => "Z2YQB5RD63NC85",
         "ap-southeast-1" => "Z3O0J2DXBE1FTB",
         "ap-southeast-2" => "Z1WCIGYICN2BYD",
+        "ap-southeast-3" => "Z01846753K324LI26A3VV",
+        "ap-southeast-4" => "Z0312387243XT5FE14WFO",
+        "ap-southeast-5" => "Z08660063OXLMA7F1FJHU",
+        "ap-southeast-6" => "Z05686083R66JX5C163TC",
+        "ap-southeast-7" => "Z0031014GXUMRZG6I14G",
         "ca-central-1" => "Z1QDHH18159H29",
+        "ca-west-1" => "Z03565811Z33SLEZTHOUL",
         "eu-central-1" => "Z21DNDUVLTQW6Q",
+        "eu-central-2" => "Z030506016YDQGETNASS",
         "eu-west-1" => "Z1BKCTXD74EZPE",
         "eu-west-2" => "Z3GKZC51ZF0DB4",
         "eu-west-3" => "Z3R1K369G5AVDG",
         "eu-north-1" => "Z3BAZG2TWCNX0D",
-        "eu-south-1" => "Z30OZKI7KPW7MI",
+        "eu-south-1" => "Z2OPA49AB41N7K",
+        "eu-south-2" => "Z0081959F7139GRJC19J",
+        "il-central-1" => "Z09640613K4A3MN55U7GU",
+        "mx-central-1" => "Z057606446ZNVQJJ8WOP",
+        "me-central-1" => "Z06143092I8HRXZRUZROF",
         "me-south-1" => "Z1MPMWCPA7YB62",
         "sa-east-1" => "Z7KQH4QJS55SO",
         _ => return Err(format!("Unknown S3 region: '{region}'")),
@@ -542,6 +596,196 @@ pub(crate) fn is_s3_not_configured_error<E: aws_sdk_s3::error::ProvideErrorMetad
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
+
+    fn concrete_string<'a>(attributes: &'a HashMap<String, Value>, name: &str) -> &'a str {
+        match attributes.get(name) {
+            Some(Value::Concrete(ConcreteValue::String(value))) => value,
+            other => panic!("expected concrete string attribute `{name}`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn normalize_bucket_location_handles_s3_spellings() {
+        assert_eq!(normalize_bucket_location(None), "us-east-1");
+        assert_eq!(normalize_bucket_location(Some("")), "us-east-1");
+        assert_eq!(normalize_bucket_location(Some("EU")), "eu-west-1");
+        assert_eq!(
+            normalize_bucket_location(Some("ap-northeast-1")),
+            "ap-northeast-1"
+        );
+    }
+
+    #[test]
+    fn create_bucket_location_constraint_uses_only_the_provider_region() {
+        let provider_region = "ap-northeast-1";
+        let supplied_read_only_region = "us-west-2";
+
+        let constraint = create_bucket_location_constraint(provider_region);
+
+        assert_eq!(constraint, Some(provider_region));
+        assert_ne!(constraint, Some(supplied_read_only_region));
+        assert_eq!(create_bucket_location_constraint("us-east-1"), None);
+    }
+
+    #[test]
+    fn legacy_eu_location_produces_eu_west_1_bucket_outputs() {
+        let region = normalize_bucket_location(Some("EU"));
+        let attributes = s3_bucket_read_only_outputs("NAME", &region).into_attributes();
+
+        assert_eq!(
+            concrete_string(&attributes, "bucket_regional_domain_name"),
+            "NAME.s3.eu-west-1.amazonaws.com"
+        );
+        assert_eq!(
+            concrete_string(&attributes, "hosted_zone_id"),
+            "Z1BKCTXD74EZPE"
+        );
+    }
+
+    #[test]
+    fn s3_bucket_read_only_outputs_are_computed_from_bucket_and_region() {
+        let attributes =
+            s3_bucket_read_only_outputs("example-bucket", "ap-northeast-1").into_attributes();
+
+        assert_eq!(
+            concrete_string(&attributes, "arn"),
+            "arn:aws:s3:::example-bucket"
+        );
+        assert_eq!(concrete_string(&attributes, "region"), "ap-northeast-1");
+        assert_eq!(
+            concrete_string(&attributes, "bucket_domain_name"),
+            "example-bucket.s3.amazonaws.com"
+        );
+        assert_eq!(
+            concrete_string(&attributes, "bucket_regional_domain_name"),
+            "example-bucket.s3.ap-northeast-1.amazonaws.com"
+        );
+        assert_eq!(
+            concrete_string(&attributes, "hosted_zone_id"),
+            "Z2M4EHUR26P7ZW"
+        );
+    }
+
+    #[test]
+    fn s3_bucket_read_only_outputs_omit_hosted_zone_id_for_unknown_region() {
+        let attributes =
+            s3_bucket_read_only_outputs("example-bucket", "xx-fake-1").into_attributes();
+
+        assert_eq!(
+            concrete_string(&attributes, "arn"),
+            "arn:aws:s3:::example-bucket"
+        );
+        assert_eq!(concrete_string(&attributes, "region"), "xx-fake-1");
+        assert_eq!(
+            concrete_string(&attributes, "bucket_domain_name"),
+            "example-bucket.s3.amazonaws.com"
+        );
+        assert_eq!(
+            concrete_string(&attributes, "bucket_regional_domain_name"),
+            "example-bucket.s3.xx-fake-1.amazonaws.com"
+        );
+        assert!(!attributes.contains_key("hosted_zone_id"));
+    }
+
+    #[test]
+    fn generated_schema_read_only_names_match_runtime_projection() {
+        const TABLE_REGION: &str = "ap-northeast-1";
+        const NON_TABLE_REGION: &str = "xx-fake-1";
+        const ALWAYS_PRESENT: [&str; 4] = [
+            "arn",
+            "region",
+            "bucket_domain_name",
+            "bucket_regional_domain_name",
+        ];
+
+        assert!(
+            s3_hosted_zone_id(TABLE_REGION).is_ok(),
+            "TABLE_REGION must exercise a hosted-zone table hit"
+        );
+        assert!(
+            s3_hosted_zone_id(NON_TABLE_REGION).is_err(),
+            "NON_TABLE_REGION must exercise a hosted-zone table miss"
+        );
+
+        let managed_config = crate::schemas::generated::s3::bucket::s3_bucket_config();
+        let managed_declared: BTreeSet<_> = managed_config
+            .schema
+            .attributes
+            .iter()
+            .filter(|(_, attribute)| attribute.read_only)
+            .map(|(name, _)| name.as_str())
+            .collect();
+
+        let data_source_config =
+            crate::schemas::generated::s3::bucket_data_source::s3_bucket_data_source_config();
+        assert!(
+            data_source_config.schema.attributes["bucket"].required,
+            "data-source `bucket` must remain its required input"
+        );
+        // Data-source codegen does not mark outputs read-only, and `bucket` is the
+        // required input that is also echoed. Excluding that one input pins every
+        // remaining generated output name to the shared runtime projection.
+        let data_source_declared: BTreeSet<_> = data_source_config
+            .schema
+            .attributes
+            .iter()
+            .filter(|(name, _)| name.as_str() != "bucket")
+            .map(|(name, _)| name.as_str())
+            .collect();
+
+        let table_attributes =
+            s3_bucket_read_only_outputs("example-bucket", TABLE_REGION).into_attributes();
+        let table_populated: BTreeSet<_> = table_attributes.keys().map(String::as_str).collect();
+        let non_table_attributes =
+            s3_bucket_read_only_outputs("example-bucket", NON_TABLE_REGION).into_attributes();
+        let non_table_populated: BTreeSet<_> =
+            non_table_attributes.keys().map(String::as_str).collect();
+
+        for name in ALWAYS_PRESENT {
+            assert!(
+                managed_declared.contains(name),
+                "managed schema omitted `{name}`"
+            );
+            assert!(
+                data_source_declared.contains(name),
+                "data-source schema omitted `{name}`"
+            );
+            assert!(
+                table_populated.contains(name),
+                "table-region projection omitted `{name}`"
+            );
+            assert!(
+                non_table_populated.contains(name),
+                "non-table-region projection omitted `{name}`"
+            );
+        }
+
+        assert!(managed_declared.contains("hosted_zone_id"));
+        assert!(data_source_declared.contains("hosted_zone_id"));
+        assert!(table_populated.contains("hosted_zone_id"));
+        assert!(!non_table_populated.contains("hosted_zone_id"));
+
+        assert_eq!(
+            managed_declared, data_source_declared,
+            "managed and data-source s3.Bucket output names drifted"
+        );
+        assert_eq!(
+            managed_declared, table_populated,
+            "generated s3.Bucket output names drifted from table-region projection keys"
+        );
+
+        // `hosted_zone_id` is declared but conditional at runtime so regions added by
+        // AWS after the static table was fetched do not break resource management.
+        // Remove exactly that key before making the unknown-region comparison so
+        // schema/runtime drift remains an exact invariant rather than a subset check.
+        let mut expected_non_table = managed_declared;
+        assert!(expected_non_table.remove("hosted_zone_id"));
+        assert_eq!(
+            expected_non_table, non_table_populated,
+            "non-table-region projection drifted beyond conditional `hosted_zone_id`"
+        );
+    }
 
     #[test]
     fn s3_hosted_zone_id_known_regions() {
@@ -551,6 +795,20 @@ mod tests {
         );
         assert_eq!(s3_hosted_zone_id("us-east-1").unwrap(), "Z3AQBSTGFYJSTF");
         assert_eq!(s3_hosted_zone_id("eu-west-1").unwrap(), "Z1BKCTXD74EZPE");
+        assert_eq!(s3_hosted_zone_id("af-south-1").unwrap(), "Z2OSFR5PIJ8TYW");
+        assert_eq!(
+            s3_hosted_zone_id("ap-southeast-6").unwrap(),
+            "Z05686083R66JX5C163TC"
+        );
+        assert_eq!(
+            s3_hosted_zone_id("il-central-1").unwrap(),
+            "Z09640613K4A3MN55U7GU"
+        );
+        assert_eq!(
+            s3_hosted_zone_id("mx-central-1").unwrap(),
+            "Z057606446ZNVQJJ8WOP"
+        );
+        assert_eq!(s3_hosted_zone_id("eu-south-1").unwrap(), "Z2OPA49AB41N7K");
     }
 
     #[test]

--- a/carina-provider-aws/tests/s3_bucket_outputs_winterbaume.rs
+++ b/carina-provider-aws/tests/s3_bucket_outputs_winterbaume.rs
@@ -1,0 +1,237 @@
+//! Provider-level coverage for managed S3 bucket outputs against the
+//! in-process winterbaume S3 service. No real AWS account is contacted.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use aws_sdk_acm::Client as AcmClient;
+use aws_sdk_cloudwatchlogs::Client as CloudWatchLogsClient;
+use aws_sdk_ec2::Client as Ec2Client;
+use aws_sdk_iam::Client as IamClient;
+use aws_sdk_identitystore::Client as IdentityStoreClient;
+use aws_sdk_organizations::Client as OrganizationsClient;
+use aws_sdk_route53::Client as Route53Client;
+use aws_sdk_s3::Client as S3Client;
+use aws_sdk_sqs::Client as SqsClient;
+use aws_sdk_sts::Client as StsClient;
+use carina_core::provider::{CreateRequest, Provider, ReadRequest};
+use carina_core::resource::{ConcreteValue, DataSource, ResolvedResource, Resource, State, Value};
+use carina_provider_aws::AwsProvider;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use winterbaume_core::{
+    MockAws, MockRequest, MockResponse, MockService, StatefulService, default_account_id,
+};
+use winterbaume_s3::views::BucketStateView;
+use winterbaume_s3::{S3Service, S3StateView};
+
+const PROVIDER_REGION: &str = "us-east-1";
+const BUCKET_REGION: &str = "ap-northeast-1";
+const RESOURCE_TYPE: &str = "s3.Bucket";
+
+struct RecordingS3Service {
+    inner: Arc<S3Service>,
+    get_bucket_location_calls: AtomicUsize,
+}
+
+impl RecordingS3Service {
+    fn new(inner: Arc<S3Service>) -> Self {
+        Self {
+            inner,
+            get_bucket_location_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn get_bucket_location_calls(&self) -> usize {
+        self.get_bucket_location_calls.load(Ordering::Relaxed)
+    }
+}
+
+impl MockService for RecordingS3Service {
+    fn service_name(&self) -> &str {
+        self.inner.service_name()
+    }
+
+    fn url_patterns(&self) -> Vec<&str> {
+        self.inner.url_patterns()
+    }
+
+    fn handle(
+        &self,
+        request: MockRequest,
+    ) -> Pin<Box<dyn Future<Output = MockResponse> + Send + '_>> {
+        let is_get_bucket_location = request.method == "GET"
+            && request.uri.split_once('?').is_some_and(|(_, query)| {
+                query
+                    .split('&')
+                    .any(|parameter| parameter.split('=').next() == Some("location"))
+            });
+        if is_get_bucket_location {
+            self.get_bucket_location_calls
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.inner.handle(request)
+    }
+}
+
+fn provider_from_config(sdk_config: &aws_types::SdkConfig) -> AwsProvider {
+    AwsProvider::from_clients(
+        PROVIDER_REGION.to_string(),
+        Vec::new(),
+        Vec::new(),
+        S3Client::new(sdk_config),
+        Ec2Client::new(sdk_config),
+        IamClient::new(sdk_config),
+        CloudWatchLogsClient::new(sdk_config),
+        StsClient::new(sdk_config),
+        OrganizationsClient::new(sdk_config),
+        IdentityStoreClient::new(sdk_config),
+        Route53Client::new(sdk_config),
+        AcmClient::new(sdk_config),
+        SqsClient::new(sdk_config),
+    )
+}
+
+async fn provider_with_s3() -> (AwsProvider, S3Client) {
+    let mock = MockAws::builder().with_service(S3Service::new()).build();
+    let sdk_config = mock.sdk_config(PROVIDER_REGION).await;
+    let s3_client = S3Client::new(&sdk_config);
+    (provider_from_config(&sdk_config), s3_client)
+}
+
+async fn provider_with_staged_bucket(bucket: &str) -> (AwsProvider, Arc<RecordingS3Service>) {
+    let s3_service = Arc::new(S3Service::new());
+
+    // Winterbaume normally derives a created bucket's stored region from the
+    // signed request. Its public restore seam lets this test place a bucket with
+    // a distinct region in the provider/signing region's request scope.
+    s3_service
+        .restore(
+            default_account_id(),
+            PROVIDER_REGION,
+            S3StateView {
+                buckets: HashMap::from([(
+                    bucket.to_string(),
+                    BucketStateView {
+                        name: bucket.to_string(),
+                        region: BUCKET_REGION.to_string(),
+                        ..Default::default()
+                    },
+                )]),
+            },
+        )
+        .await
+        .expect("stage S3 bucket with a distinct region");
+
+    let recording_service = Arc::new(RecordingS3Service::new(s3_service));
+    let mock = MockAws::builder()
+        .with_service(Arc::clone(&recording_service))
+        .build();
+    let sdk_config = mock.sdk_config(PROVIDER_REGION).await;
+    (provider_from_config(&sdk_config), recording_service)
+}
+
+fn string(value: &str) -> Value {
+    Value::Concrete(ConcreteValue::String(value.to_string()))
+}
+
+fn assert_bucket_outputs(state: &State, bucket: &str, region: &str, hosted_zone_id: &str) {
+    assert!(state.exists);
+    assert_eq!(state.attributes.get("bucket"), Some(&string(bucket)));
+    assert_eq!(
+        state.attributes.get("arn"),
+        Some(&string(&format!("arn:aws:s3:::{bucket}")))
+    );
+    assert_eq!(state.attributes.get("region"), Some(&string(region)));
+    assert_eq!(
+        state.attributes.get("bucket_domain_name"),
+        Some(&string(&format!("{bucket}.s3.amazonaws.com")))
+    );
+    assert_eq!(
+        state.attributes.get("bucket_regional_domain_name"),
+        Some(&string(&format!("{bucket}.s3.{region}.amazonaws.com")))
+    );
+    assert_eq!(
+        state.attributes.get("hosted_zone_id"),
+        Some(&string(hosted_zone_id))
+    );
+}
+
+#[tokio::test]
+async fn create_bucket_ignores_supplied_read_only_region_for_placement() {
+    let (provider, client) = provider_with_s3().await;
+    let bucket = "carina-bucket-outputs";
+    let supplied_read_only_region = BUCKET_REGION;
+    let mut resource = Resource::with_provider("aws", RESOURCE_TYPE, "outputs", None);
+    resource.set_attr("bucket", string(bucket));
+    // The provider region controls placement. Supplying this read-only value pins
+    // the regression where create previously treated it as a placement override.
+    resource.set_attr("region", string(supplied_read_only_region));
+    let id = resource.id.clone();
+
+    let state = provider
+        .create(
+            &id,
+            CreateRequest {
+                resource: ResolvedResource::new(resource),
+            },
+        )
+        .await
+        .expect("create S3 bucket")
+        .into_state_for_writeback();
+
+    let raw_location = client
+        .get_bucket_location()
+        .bucket(bucket)
+        .send()
+        .await
+        .expect("read raw bucket location");
+    assert_eq!(
+        raw_location
+            .location_constraint()
+            .map(|constraint| constraint.as_str())
+            .unwrap_or_default(),
+        "",
+        "winterbaume should reproduce S3's absent/empty us-east-1 location constraint"
+    );
+
+    assert_bucket_outputs(&state, bucket, PROVIDER_REGION, "Z3AQBSTGFYJSTF");
+    assert_ne!(
+        state.attributes.get("region"),
+        Some(&string(supplied_read_only_region))
+    );
+}
+
+#[tokio::test]
+async fn managed_and_data_source_reads_use_head_bucket_region_without_get_bucket_location() {
+    assert_ne!(
+        PROVIDER_REGION, BUCKET_REGION,
+        "the fixture must distinguish HeadBucket's region from the provider region"
+    );
+
+    let bucket = "carina-bucket-head-region";
+    let (provider, service) = provider_with_staged_bucket(bucket).await;
+
+    let managed_id = Resource::with_provider("aws", RESOURCE_TYPE, "managed", None).id;
+    let managed_state = provider
+        .read(&managed_id, Some(bucket), ReadRequest)
+        .await
+        .expect("read managed S3 bucket");
+    assert_bucket_outputs(&managed_state, bucket, BUCKET_REGION, "Z2M4EHUR26P7ZW");
+
+    let mut data_source = DataSource::with_provider("aws", RESOURCE_TYPE, "lookup", None);
+    data_source.set_attr("bucket", string(bucket));
+    let data_source_state = provider
+        .read_data_source(&data_source)
+        .await
+        .expect("read S3 bucket data source");
+    assert_bucket_outputs(&data_source_state, bucket, BUCKET_REGION, "Z2M4EHUR26P7ZW");
+
+    assert_eq!(
+        service.get_bucket_location_calls(),
+        0,
+        "both read paths must use HeadBucket's x-amz-bucket-region"
+    );
+}


### PR DESCRIPTION
Closes #499

`aws.s3.Bucket` declared only `bucket`, `bucket_namespace` and `tags`, so a bucket created through the `aws` provider could not have its ARN or domain names referenced — which is what blocks migrating `carina-rs/infra`'s registry bucket off `awscc`. #214 specified keeping these outputs; the bundled-attribute removal landed, the "keep" half did not.

## What this adds

`arn`, `region`, `bucket_domain_name`, `bucket_regional_domain_name`, `hosted_zone_id` as read-only attributes on the managed resource, following the `sqs.Queue` precedent (`extra_attributes` + `read_only_overrides` + `type_overrides`, since `s3.Bucket` has no `read_structure`). `arn` gets the same refined ARN type the data source uses, so `bucket.arn` type-checks identically whichever view it came from.

## Why the scope is wider than "add five attributes"

**Declaring them is not enough.** A schema attribute with no consumer in the read path is silently dropped — the class #496 documents. So the schema half and the read-path half have to land together.

**And the two paths must not drift.** After this change, the managed read and the data-source read compute the same five values about the same bucket. Copy-pasting the derivation would let a future edit to one silently disagree with the other. Both now go through a single `S3BucketReadOnlyOutputs` projection, and `into_attributes` takes `self` by value so a caller cannot emit a partial subset. This *removes* duplication rather than adding a second copy — the data source previously derived all five inline; each derivation now appears exactly once.

## Design decisions

**`region` is an output, not an input.** The data source already models it that way, and the provider block determines placement. The `get_attr("region")` branch in `create_s3_bucket` was dead code — the schema never declared `region`, so validation rejected any user value — and it is gone; placement reads the provider region directly.

Note that carina-core does not currently reject writes to read-only attributes, so `region = '...'` on a bucket is now silently ignored rather than erroring as it did before. Filed as carina-rs/carina#3766; the type shape here is the one the data source and the design spec already use.

**The region comes from `HeadBucket`, not `GetBucketLocation`.** An earlier revision of this branch added a `GetBucketLocation` call. That was wrong: `HeadBucketOutput::bucket_region()` already carries the region from the `HeadBucket` call the read path makes anyway, and AWS's own Smithy model (vendored in this repo) records that `GetBucketLocation` "is no longer a best practice" for exactly this. Using it costs no extra API call, no extra `s3:GetBucketLocation` IAM permission, and no TOCTOU window.

**Unmapped regions degrade, they do not fail.** `hosted_zone_id` is omitted when the region is not in the lookup table, so a bucket in an unsupported region stays manageable. To make that path rare, the table is completed from 20 to 34 commercial regions from the [AWS S3 website endpoints table](https://docs.aws.amazon.com/general/latest/gr/s3.html) (fetched 2026-08-15). That also corrects `eu-south-1`, which has carried a wrong value since the data source landed — so `read aws.s3.Bucket` has been returning a bad hosted zone ID for Milan buckets.

**Legacy `EU` is normalized to `eu-west-1`.** Measured 2026-08-15 that a newly created eu-west-1 bucket reports `eu-west-1`, so the alias only affects buckets created through the original API; the code comment marks which half is measured and which comes from the SDK and docs.

## Tests

- Schema-vs-runtime agreement in **both** directions and for **both** views — the generated managed schema names and the data-source non-input names, each against the projection keys. Verified by mutation that removing an `ExtraField` (either list) or a projection field turns it red.
- The five computed values, the `EU` alias, and the unknown-region path (four outputs present and correct, `hosted_zone_id` absent, no error).
- A winterbaume integration test driving the real provider path with a bucket region (`ap-northeast-1`) that differs from the provider and signing region (`us-east-1`), asserting both read paths take the region from `HeadBucket` and that no `GetBucketLocation` call is made. Verified by mutation that substituting `self.region` fails it.
- A new `acceptance-tests/s3_bucket_outputs/` suite asserting the outputs on the source bucket *and* the values chained through a second bucket's tags — the cross-resource reference that motivated the issue. `acceptance-tests/s3_bucket/` is left in its original single-file form so it stays in `run-tests.sh`'s sweep.

## Follow-ups filed

- #500 — `strip_html_tags` mangles descriptions containing angle brackets, and managed docs drop read-only descriptions entirely. This is why the managed descriptions here read `NAME.s3.amazonaws.com` while the data source keeps `` `<bucket>.s3.amazonaws.com` ``; they should converge once fixed.
- #501 — the committed generated tree is out of sync with the generator (a no-op regen changes 46 files). Only `s3/bucket.rs` is regenerated here; unrelated churn was reverted.
- #502 — S3 outputs hardcode the `aws` partition and `amazonaws.com` suffix, wrong for China/GovCloud. Pre-existing on the data-source path, newly extended to the managed path by this change; marked with a comment at the derivation site.
- carina-rs/carina#3766 — assigning to a read-only attribute is silently accepted.
- carina-rs/carina#3767 — refinement/enum/custom-type validation is skipped for any value arriving via a resource reference, so the refined ARN regex is not actually enforced on `bucket.arn`.

## Verification

421 tests pass, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `check-examples.sh` / `check-string-enum-aliases.sh` / `check-carina-pin.sh` pass. The acceptance suite was authored but not run against AWS.
